### PR TITLE
Fix for the massEdit table selecting allot of shows.

### DIFF
--- a/gui/slick/js/mass-update.js
+++ b/gui/slick/js/mass-update.js
@@ -14,8 +14,8 @@ $(document).ready(function() {
         }
 
         $.ajax({
-            type: "POST",
-            url: srRoot + '/massEdit',
+            type: 'POST',
+            url: 'massEdit',
             data: JSON.stringify(data),
           }).done(function(response) {
               $('#container').html(response);

--- a/gui/slick/js/mass-update.js
+++ b/gui/slick/js/mass-update.js
@@ -2,17 +2,24 @@ $(document).ready(function() {
     $('.submitMassEdit').on('click', function() {
         var editArr = [];
 
+        var data = {"editListOfShows" : []};
         $('.editCheck').each(function() {
             if (this.checked === true) {
-                editArr.push($(this).attr('id').split('-')[1]);
+                data.editListOfShows.push($(this).attr('id').split('-')[1]);
             }
         });
 
-        if (editArr.length === 0) {
+        if(data.editListOfShows.length === 0) {
             return;
         }
 
-        window.location.href = 'manage/massEdit?toEdit=' + editArr.join('|');
+        $.ajax({
+            type: "POST",
+            url: srRoot + '/massEdit',
+            data: JSON.stringify(data),
+          }).done(function(response) {
+              $('#container').html(response);
+          });
     });
 
     $('.submitMassUpdate').on('click', function() {

--- a/gui/slick/views/addShows_addExistingShow.mako
+++ b/gui/slick/views/addShows_addExistingShow.mako
@@ -5,6 +5,7 @@
 <%block name="scripts">
 <script type="text/javascript" src="js/quality-chooser.js?${sbPID}"></script>
 <script type="text/javascript" src="js/add-show-options.js?${sbPID}"></script>
+<script type="text/javascript" src="js/lib/jquery.redirect.js?${sbPID}"></script>
 </%block>
 <%block name="content">
 % if not header is UNDEFINED:
@@ -12,6 +13,8 @@
 % else:
     <h1 class="title">${title}</h1>
 % endif
+
+<div id="container">
 <div id="newShowPortal">
     <div id="config-components">
         ## @TODO: Fix this stupid hack
@@ -46,4 +49,5 @@
         </div>
     </div>
 </div>
+</div> <!-- end of container -->
 </%block>

--- a/gui/slick/views/addShows_newShow.mako
+++ b/gui/slick/views/addShows_newShow.mako
@@ -1,5 +1,6 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
+    from urllib import urlencode, quote_plus
     import medusa as app
     from medusa.helpers import anon_url
 %>
@@ -74,7 +75,7 @@
                     </div>
                 </fieldset>
                 % for curNextDir in other_shows:
-                <input type="hidden" name="other_shows" value="${curNextDir}" />
+                <input type="hidden" name="other_shows" value="${quote_plus(str(curNextDir))}" />
                 % endfor
                 <input type="hidden" name="skipShow" id="skipShow" value="" />
             </form>

--- a/gui/slick/views/home_massAddTable.mako
+++ b/gui/slick/views/home_massAddTable.mako
@@ -17,20 +17,22 @@
         if curDir['added_already']:
             continue
         show_id = curDir['dir']
-        if curDir['existing_info'][0]:
-            show_id = show_id + '|' + str(curDir['existing_info'][0]) + '|' + str(curDir['existing_info'][1])
-            indexer = curDir['existing_info'][2]
+        if curDir['existing_info']['indexer_id']:
+            show_id = show_id + '|' + str(curDir['existing_info']['indexer_id']) + '|' + str(curDir['existing_info']['show_name'])
+            indexer = curDir['existing_info']['indexer']
         indexer = 0
-        if curDir['existing_info'][0]:
-            indexer = curDir['existing_info'][2]
+        if curDir['existing_info']['indexer_id']:
+            indexer = curDir['existing_info']['indexer']
         elif app.INDEXER_DEFAULT > 0:
             indexer = app.INDEXER_DEFAULT
     %>
     <tr>
-        <td class="col-checkbox"><input type="checkbox" id="${show_id}" class="dirCheck" checked=checked></td>
+        <td class="col-checkbox"><input type="checkbox" id="${show_id}" class="dirCheck" checked=checked
+        data-existing-indexer-id="${curDir['existing_info']['indexer_id']}" data-show-name="${curDir['existing_info']['show_name']}" 
+        data-existing-indexer="${curDir['existing_info']['indexer']}" data-show-dir="${curDir['dir']}" data-allready-added="${curDir['added_already']}"></td>
         <td><label for="${show_id}">${curDir['display_dir']}</label></td>
-        % if curDir['existing_info'][1] and indexer > 0:
-            <td><a href="${anon_url(app.indexerApi(indexer).config['show_url'], curDir['existing_info'][0])}">${curDir['existing_info'][1]}</a></td>
+        % if curDir['existing_info']['show_name'] and indexer > 0:
+            <td><a href="${anon_url(app.indexerApi(indexer).config['show_url'], curDir['existing_info']['indexer_id'])}">${curDir['existing_info']['show_name']}</a></td>
         % else:
             <td>?</td>
         % endif

--- a/gui/slick/views/home_massAddTable.mako
+++ b/gui/slick/views/home_massAddTable.mako
@@ -2,6 +2,7 @@
     import medusa as app
     from medusa.helpers import anon_url
 %>
+<div id="container">
 <table id="addRootDirTable" class="defaultTable tablesorter">
     <thead>
         <tr>
@@ -47,3 +48,4 @@
 % endfor
     </tbody>
 </table>
+</div>

--- a/gui/slick/views/manage.mako
+++ b/gui/slick/views/manage.mako
@@ -9,6 +9,7 @@
 </%block>
 <%block name="content">
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
+<div id="container">
 <form name="massUpdateForm" method="post" action="manage/massUpdate">
 <table style="width: 100%;" class="home-header">
     <tr>
@@ -110,4 +111,5 @@
 </tbody>
 </table>
 </form>
+</div> <!-- end of container -->
 </%block>

--- a/gui/slick/views/manage_massEdit.mako
+++ b/gui/slick/views/manage_massEdit.mako
@@ -18,6 +18,8 @@
 <script type="text/javascript" src="js/mass-edit.js?${sbPID}"></script>
 </%block>
 <%block name="content">
+
+<div id="container">
 <div id="config">
     <div id="config-content">
         <form action="manage/massEditSubmit" method="post">
@@ -227,4 +229,6 @@
         </form>
     </div>
 </div>
+</div> <!-- end of container -->
+
 </%block>

--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -34,6 +34,7 @@ from ....show.recommendations.trakt import TraktPopular
 class HomeAddShows(Home):
     def __init__(self, *args, **kwargs):
         super(HomeAddShows, self).__init__(*args, **kwargs)
+        self.shows_to_add = None
 
     def index(self):
         t = PageTemplate(rh=self, filename='addShows.mako')
@@ -171,20 +172,48 @@ class HomeAddShows(Home):
                             if not indexer_id and i:
                                 indexer_id = i
 
-                cur_dir['existing_info'] = (indexer_id, show_name, indexer)
+                cur_dir['existing_info'] = {"indexer_id": indexer_id or '', "show_name": show_name or '',
+                                            "indexer": indexer or ''}
 
                 if indexer_id and Show.find(app.showList, indexer_id):
                     cur_dir['added_already'] = True
         return t.render(dirList=dir_list)
 
-    def newShow(self, show_to_add=None, other_shows=None, search_string=None):
+    def newShow(self, show_to_add=None, other_shows=None, search_string=None, **shows_to_add):
         """
         Display the new show page which collects a tvdb id, folder, and extra options and
         posts them to addNewShow
         """
         t = PageTemplate(rh=self, filename='addShows_newShow.mako')
 
-        indexer, show_dir, indexer_id, show_name = self.split_extra_show(show_to_add)
+        if shows_to_add:
+            if isinstance(shows_to_add.items()[0][1], list):
+                shows_from_json = [{} for x in range(len(shows_to_add.items()[0][1]))]
+                for attribute in shows_to_add:
+                    for i, x in enumerate(shows_to_add[attribute]):
+                        try:
+                            shows_from_json[i][attribute] = x
+                        except:
+                            pass
+
+                # Get the first show from the list, and process this one
+                show_to_add = shows_from_json.pop(0)
+                other_shows = shows_from_json
+            else:
+                # This should be the last show to be added
+                show_to_add = shows_to_add
+        elif show_to_add:
+            # Sanitize unquote and eval to dict
+            show_to_add = ast.literal_eval(unquote_plus(show_to_add).strip())
+            other_shows = [ast.literal_eval(unquote_plus(x).strip()) for x in other_shows]
+        else:
+            return
+
+        indexer = show_to_add.get('selectedIndexer')
+        indexer_id = show_to_add.get('existingIndexerId')
+        show_name = show_to_add.get('showName')
+        show_dir = show_to_add.get('showDir')
+
         use_provided_info = bool(indexer_id and indexer and show_name)
 
         # use the given show_dir for the indexer search if available
@@ -604,12 +633,18 @@ class HomeAddShows(Home):
 
         return indexer, show_dir, indexer_id, show_name
 
-    def addExistingShows(self, shows_to_add=None, promptForSettings=None):
+    def addExistingShows(self, **data):
         """
         Receives a dir list and add them. Adds the ones with given TVDB IDs first, then forwards
         along to the newShow page.
         """
-        prompt_for_settings = promptForSettings
+
+        # We need to do this, because somewhere Tornado wraps the json in another json object.
+        json_param = json.loads(data.iteritems().next()[0])
+
+        # Get the passed attributes
+        shows_to_add = json_param.get('submitListOfShows')
+        prompt_for_settings = config.checkbox_to_value(json_param.get('promptForSettings'))
 
         # grab a list of other shows to add, if provided
         if not shows_to_add:
@@ -617,27 +652,32 @@ class HomeAddShows(Home):
         elif not isinstance(shows_to_add, list):
             shows_to_add = [shows_to_add]
 
-        shows_to_add = [unquote_plus(x) for x in shows_to_add]
-
-        prompt_for_settings = config.checkbox_to_value(prompt_for_settings)
+        # shows_to_add = [unquote_plus(x) for x in shows_to_add]
 
         indexer_id_given = []
         dirs_only = []
         # separate all the ones with Indexer IDs
         for cur_dir in shows_to_add:
-            if '|' in cur_dir:
-                split_vals = cur_dir.split('|')
-                if len(split_vals) < 3:
-                    dirs_only.append(cur_dir)
-            if '|' not in cur_dir:
+            selected_indexer = cur_dir.get('selectedIndexer')
+            existing_indexer = cur_dir.get('existingIndexer')
+            existing_indexer_id = cur_dir.get('existingIndexerId')
+            show_name = cur_dir.get('showName')
+            show_dir = cur_dir.get('showDir')
+
+            if existing_indexer_id and existing_indexer:
+                indexer = existing_indexer
+            elif app.INDEXER_DEFAULT > 0:
+                indexer = app.INDEXER_DEFAULT
+
+            if not existing_indexer:
                 dirs_only.append(cur_dir)
             else:
                 indexer, show_dir, indexer_id, show_name = self.split_extra_show(cur_dir)
 
-                if not show_dir or not indexer_id or not show_name:
+                if not show_dir or not existing_indexer_id or not show_name:
                     continue
 
-                indexer_id_given.append((int(indexer), show_dir, int(indexer_id), show_name))
+                indexer_id_given.append((int(indexer), show_dir, int(existing_indexer_id), show_name))
 
         # if they want me to prompt for settings then I will just carry on to the newShow page
         if prompt_for_settings and shows_to_add:
@@ -670,5 +710,9 @@ class HomeAddShows(Home):
         if not dirs_only:
             return self.redirect('/home/')
 
+        # Keep track of the dirs, for shows that we want to add
+        self.shows_to_add = dirs_only
         # for the remaining shows we need to prompt for each one, so forward this on to the newShow page
-        return self.newShow(dirs_only[0], dirs_only[1:])
+        ## We're going to return a json with info, that will be used to redirect
+        # return self.newShow(dirs_only[0], dirs_only[1:])
+        return json.dumps(dirs_only)

--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -2,6 +2,7 @@
 
 from __future__ import unicode_literals
 
+import ast
 import datetime
 import json
 import os
@@ -638,7 +639,6 @@ class HomeAddShows(Home):
         Receives a dir list and add them. Adds the ones with given TVDB IDs first, then forwards
         along to the newShow page.
         """
-
         # We need to do this, because somewhere Tornado wraps the json in another json object.
         json_param = json.loads(data.iteritems().next()[0])
 
@@ -658,16 +658,19 @@ class HomeAddShows(Home):
         dirs_only = []
         # separate all the ones with Indexer IDs
         for cur_dir in shows_to_add:
-            selected_indexer = cur_dir.get('selectedIndexer')
+            # TODO: work in progress #434
+            # selected_indexer = cur_dir.get('selectedIndexer')
             existing_indexer = cur_dir.get('existingIndexer')
             existing_indexer_id = cur_dir.get('existingIndexerId')
-            show_name = cur_dir.get('showName')
-            show_dir = cur_dir.get('showDir')
+            # show_name = cur_dir.get('showName')
+            # show_dir = cur_dir.get('showDir')
 
             if existing_indexer_id and existing_indexer:
-                indexer = existing_indexer
+                # indexer = existing_indexer
+                pass
             elif app.INDEXER_DEFAULT > 0:
-                indexer = app.INDEXER_DEFAULT
+                # indexer = app.INDEXER_DEFAULT
+                pass
 
             if not existing_indexer:
                 dirs_only.append(cur_dir)
@@ -713,6 +716,6 @@ class HomeAddShows(Home):
         # Keep track of the dirs, for shows that we want to add
         self.shows_to_add = dirs_only
         # for the remaining shows we need to prompt for each one, so forward this on to the newShow page
-        ## We're going to return a json with info, that will be used to redirect
+        # We're going to return a json with info, that will be used to redirect
         # return self.newShow(dirs_only[0], dirs_only[1:])
         return json.dumps(dirs_only)

--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -333,13 +333,17 @@ class Manage(Home, WebRoot):
             action='backlogOverview', title='Backlog Overview',
             header='Backlog Overview', topmenu='manage')
 
-    def massEdit(self, toEdit=None):
+    def massEdit(self, **shows):
         t = PageTemplate(rh=self, filename='manage_massEdit.mako')
 
-        if not toEdit:
-            return self.redirect('/manage/')
+        # I need to do this, because somewhere Tornado wraps the json in another json object.
+        showIDs = json.loads(shows.iteritems().next()[0]).get('editListOfShows')
 
-        show_ids = toEdit.split('|')
+        # This doesn't do anything, at least not that I can think of. Because of no checkboxes selected
+        # massEdit is never called.
+        if not showIDs:
+            return json.dumps({"redirect": "/manage/"})
+
         show_list = []
         show_names = []
         for cur_id in show_ids:
@@ -452,7 +456,7 @@ class Manage(Home, WebRoot):
         air_by_date_value = last_air_by_date if air_by_date_all_same else None
         root_dir_list = root_dir_list
 
-        return t.render(showList=toEdit, showNames=show_names, default_ep_status_value=default_ep_status_value,
+        return t.render(showList='|'.join(showIDs), showNames=showNames, default_ep_status_value=default_ep_status_value,
                         paused_value=paused_value, anime_value=anime_value, flatten_folders_value=flatten_folders_value,
                         quality_value=quality_value, subtitles_value=subtitles_value, scene_value=scene_value, sports_value=sports_value,
                         air_by_date_value=air_by_date_value, root_dir_list=root_dir_list, title='Mass Edit', header='Mass Edit', topmenu='manage')

--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -337,11 +337,11 @@ class Manage(Home, WebRoot):
         t = PageTemplate(rh=self, filename='manage_massEdit.mako')
 
         # I need to do this, because somewhere Tornado wraps the json in another json object.
-        showIDs = json.loads(shows.iteritems().next()[0]).get('editListOfShows')
+        show_ids = json.loads(shows.iteritems().next()[0]).get('editListOfShows')
 
         # This doesn't do anything, at least not that I can think of. Because of no checkboxes selected
         # massEdit is never called.
-        if not showIDs:
+        if not show_ids:
             return json.dumps({"redirect": "/manage/"})
 
         show_list = []
@@ -456,7 +456,7 @@ class Manage(Home, WebRoot):
         air_by_date_value = last_air_by_date if air_by_date_all_same else None
         root_dir_list = root_dir_list
 
-        return t.render(showList='|'.join(showIDs), showNames=showNames, default_ep_status_value=default_ep_status_value,
+        return t.render(showList='|'.join(show_ids), showNames=show_names, default_ep_status_value=default_ep_status_value,
                         paused_value=paused_value, anime_value=anime_value, flatten_folders_value=flatten_folders_value,
                         quality_value=quality_value, subtitles_value=subtitles_value, scene_value=scene_value, sports_value=sports_value,
                         air_by_date_value=air_by_date_value, root_dir_list=root_dir_list, title='Mass Edit', header='Mass Edit', topmenu='manage')


### PR DESCRIPTION
The shows where provided through a get request with the showId's separated by "|".

Changed the get to post, and provided the showId's in a json.
The result is parsed as html.

### TODO:
- [ ] Also change the massUpdate button. Make sure it also uses the post.
- [ ] Implement the same vor  /addShows/addExistingShows