### PR TITLE
Remove torrent from client when replace|proper|manual search snatch

### DIFF
--- a/medusa/__init__.py
+++ b/medusa/__init__.py
@@ -275,6 +275,7 @@ TORRENT_METHOD = None
 TORRENT_DIR = None
 DOWNLOAD_PROPERS = False
 CHECK_PROPERS_INTERVAL = None
+REMOVE_FROM_CLIENT = False
 ALLOW_HIGH_PRIORITY = False
 SAB_FORCED = False
 RANDOMIZE_PROVIDERS = False
@@ -645,7 +646,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
     with INIT_LOCK:
         # pylint: disable=global-statement
         global BRANCH, GIT_RESET, GIT_RESET_BRANCHES, GIT_REMOTE, GIT_REMOTE_URL, CUR_COMMIT_HASH, CUR_COMMIT_BRANCH, ACTUAL_LOG_DIR, LOG_DIR, LOG_NR, LOG_SIZE, WEB_PORT, WEB_LOG, ENCRYPTION_VERSION, ENCRYPTION_SECRET, WEB_ROOT, WEB_USERNAME, WEB_PASSWORD, WEB_HOST, WEB_IPV6, WEB_COOKIE_SECRET, WEB_USE_GZIP, API_KEY, ENABLE_HTTPS, HTTPS_CERT, HTTPS_KEY, \
-            HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, RANDOMIZE_PROVIDERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, SAB_FORCED, TORRENT_METHOD, NOTIFY_ON_LOGIN, SUBLIMINAL_LOG, PRIVACY_LEVEL, \
+            HANDLE_REVERSE_PROXY, USE_NZBS, USE_TORRENTS, NZB_METHOD, NZB_DIR, DOWNLOAD_PROPERS, REMOVE_FROM_CLIENT, RANDOMIZE_PROVIDERS, CHECK_PROPERS_INTERVAL, ALLOW_HIGH_PRIORITY, SAB_FORCED, TORRENT_METHOD, NOTIFY_ON_LOGIN, SUBLIMINAL_LOG, PRIVACY_LEVEL, \
             SAB_USERNAME, SAB_PASSWORD, SAB_APIKEY, SAB_CATEGORY, SAB_CATEGORY_BACKLOG, SAB_CATEGORY_ANIME, SAB_CATEGORY_ANIME_BACKLOG, SAB_HOST, \
             NZBGET_USERNAME, NZBGET_PASSWORD, NZBGET_CATEGORY, NZBGET_CATEGORY_BACKLOG, NZBGET_CATEGORY_ANIME, NZBGET_CATEGORY_ANIME_BACKLOG, NZBGET_PRIORITY, NZBGET_HOST, NZBGET_USE_HTTPS, backlogSearchScheduler, \
             TORRENT_USERNAME, TORRENT_PASSWORD, TORRENT_HOST, TORRENT_PATH, TORRENT_SEED_TIME, TORRENT_PAUSED, TORRENT_HIGH_BANDWIDTH, TORRENT_LABEL, TORRENT_LABEL_ANIME, TORRENT_VERIFY_CERT, TORRENT_RPCURL, TORRENT_AUTH_TYPE, \
@@ -896,6 +897,7 @@ def initialize(consoleLogging=True):  # pylint: disable=too-many-locals, too-man
             TORRENT_METHOD = 'blackhole'
 
         DOWNLOAD_PROPERS = bool(check_setting_int(CFG, 'General', 'download_propers', 1))
+        REMOVE_FROM_CLIENT = bool(check_setting_int(CFG, 'General', 'remove_from_client', 0))
         CHECK_PROPERS_INTERVAL = check_setting_str(CFG, 'General', 'check_propers_interval', '')
         if CHECK_PROPERS_INTERVAL not in ('15m', '45m', '90m', '4h', 'daily'):
             CHECK_PROPERS_INTERVAL = 'daily'
@@ -1697,6 +1699,7 @@ def save_config():  # pylint: disable=too-many-statements, too-many-branches
     new_config['General']['update_frequency'] = int(UPDATE_FREQUENCY)
     new_config['General']['showupdate_hour'] = int(SHOWUPDATE_HOUR)
     new_config['General']['download_propers'] = int(DOWNLOAD_PROPERS)
+    new_config['General']['remove_from_client'] = int(REMOVE_FROM_CLIENT)
     new_config['General']['randomize_providers'] = int(RANDOMIZE_PROVIDERS)
     new_config['General']['check_propers_interval'] = CHECK_PROPERS_INTERVAL
     new_config['General']['allow_high_priority'] = int(ALLOW_HIGH_PRIORITY)

--- a/medusa/clients/deluge_client.py
+++ b/medusa/clients/deluge_client.py
@@ -164,6 +164,20 @@ class DelugeAPI(GenericClient):
 
         return self.response.json()['result']
 
+    def _remove_torrent(self, torrent_hash):
+
+        post_data = json.dumps({
+            'method': 'core.remove_torrent',
+            'params': [
+                torrent_hash,
+                True,
+            ],
+            'id': 5,
+        })
+
+        self._request(method='post', data=post_data)
+        return not self.response.json()['error']
+
     def _set_torrent_label(self, result):
 
         label = app.TORRENT_LABEL.lower()

--- a/medusa/clients/deluged_client.py
+++ b/medusa/clients/deluged_client.py
@@ -83,6 +83,9 @@ class DelugeDAPI(GenericClient):
 
         return remote_torrent or None
 
+    def _remove_torrent(self, torrent_hash):
+        return self.drpc.remove_torrent_ratio(torrent_hash, True)
+
     def _set_torrent_label(self, result):
 
         label = app.TORRENT_LABEL.lower()

--- a/medusa/clients/qbittorrent_client.py
+++ b/medusa/clients/qbittorrent_client.py
@@ -130,4 +130,12 @@ class QBittorrentAPI(GenericClient):
         }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 
+    def _remove_torrent(self, torrent_hash):
+        self.url = '{host}command/deletePerm'.format(host=self.host)
+        data = {
+            'hashes': torrent_hash.lower(),
+        }
+
+        return self._request(method='post', data=data, cookies=self.session.cookies)
+
 api = QBittorrentAPI

--- a/medusa/clients/transmission_client.py
+++ b/medusa/clients/transmission_client.py
@@ -186,5 +186,26 @@ class TransmissionAPI(GenericClient):
 
         return self.response.json()['result'] == 'success'
 
+    def remove_torrent(self, torrent_hash):
+        """Remove torrent from client using given torrent_hash.
+
+        :param torrent_hash:
+        :type torrent_hash: string
+        :return
+        :rtype: bool
+        """
+        arguments = {
+            'ids': [torrent_hash],
+            'delete-local-data': 1,
+        }
+
+        post_data = json.dumps({
+            'arguments': arguments,
+            'method': 'torrent-remove',
+        })
+
+        self._request(method='post', data=post_data)
+
+        return self.response.json()['result'] == 'success'
 
 api = TransmissionAPI

--- a/medusa/clients/utorrent_client.py
+++ b/medusa/clients/utorrent_client.py
@@ -164,5 +164,10 @@ class UTorrentAPI(GenericClient):
             'hash': result.hash,
         })
 
+    def _remove_torrent(self, torrent_hash):
+        return self._request(params={
+            'action': 'removedatatorrent',
+            'hash': torrent_hash,
+        })
 
 api = UTorrentAPI

--- a/medusa/databases/main_db.py
+++ b/medusa/databases/main_db.py
@@ -31,7 +31,7 @@ MIN_DB_VERSION = 40  # oldest db version we support migrating from
 MAX_DB_VERSION = 44
 
 # Used to check when checking for updates
-CURRENT_MINOR_DB_VERSION = 2
+CURRENT_MINOR_DB_VERSION = 3
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -508,3 +508,21 @@ class AddProperTags(TestIncreaseMajorVersion):
         self.inc_minor_version()
 
         logger.log(u'Updated to: %d.%d' % self.connection.version)
+
+
+class AddTorrentHash(AddProperTags):
+    """Adds column torrent_hash to history table."""
+
+    def test(self):
+        """
+        Test if the version is at least 44.3
+        """
+        return self.connection.version >= (44, 3)
+
+    def execute(self):
+        backupDatabase(self.connection.version)
+
+        logger.log(u"Adding column torrent_hash in history")
+        if not self.hasColumn("history", "torrent_hash"):
+            self.addColumn("history", "torrent_hash", 'TEXT', None)
+        self.inc_minor_version()

--- a/medusa/history.py
+++ b/medusa/history.py
@@ -25,7 +25,7 @@ from .helper.encoding import ss
 from .show.History import History
 
 
-def _logHistoryItem(action, showid, season, episode, quality, resource, provider, version=-1, proper_tags=''):
+def _logHistoryItem(action, showid, season, episode, quality, resource, provider, version=-1, proper_tags='', torrent_hash=None):
     """
     Insert a history item in DB
 
@@ -43,8 +43,8 @@ def _logHistoryItem(action, showid, season, episode, quality, resource, provider
 
     main_db_con = db.DBConnection()
     main_db_con.action(
-        "INSERT INTO history (action, date, showid, season, episode, quality, resource, provider, version, proper_tags) VALUES (?,?,?,?,?,?,?,?,?,?)",
-        [action, logDate, showid, season, episode, quality, resource, provider, version, proper_tags])
+        "INSERT INTO history (action, date, showid, season, episode, quality, resource, provider, version, proper_tags, torrent_hash) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+        [action, logDate, showid, season, episode, quality, resource, provider, version, proper_tags, torrent_hash])
 
 
 def logSnatch(searchResult):
@@ -61,6 +61,7 @@ def logSnatch(searchResult):
         quality = searchResult.quality
         version = searchResult.version
         proper_tags = '|'.join(searchResult.proper_tags)
+        torrent_hash = searchResult.hash if searchResult.hash else None
 
         providerClass = searchResult.provider
         if providerClass is not None:
@@ -72,7 +73,7 @@ def logSnatch(searchResult):
 
         resource = searchResult.name
 
-        _logHistoryItem(action, showid, season, episode, quality, resource, provider, version, proper_tags)
+        _logHistoryItem(action, showid, season, episode, quality, resource, provider, version, proper_tags, torrent_hash)
 
 
 def logDownload(episode, filename, new_ep_quality, release_group=None, version=-1):

--- a/medusa/server/web/config/search.py
+++ b/medusa/server/web/config/search.py
@@ -43,7 +43,7 @@ class ConfigSearch(Config):
                    nzbget_category_anime_backlog=None, nzbget_priority=None, nzbget_host=None,
                    nzbget_use_https=None, backlog_days=None, backlog_frequency=None, dailysearch_frequency=None,
                    nzb_method=None, torrent_method=None, usenet_retention=None, download_propers=None,
-                   check_propers_interval=None, allow_high_priority=None, sab_forced=None,
+                   check_propers_interval=None, allow_high_priority=None, sab_forced=None, remove_from_client=None,
                    randomize_providers=None, use_failed_downloads=None, delete_failed=None,
                    torrent_dir=None, torrent_username=None, torrent_password=None, torrent_host=None,
                    torrent_label=None, torrent_label_anime=None, torrent_path=None, torrent_verify_cert=None,
@@ -89,7 +89,7 @@ class ConfigSearch(Config):
         app.RANDOMIZE_PROVIDERS = config.checkbox_to_value(randomize_providers)
 
         config.change_DOWNLOAD_PROPERS(download_propers)
-
+        app.REMOVE_FROM_CLIENT = config.checkbox_to_value(remove_from_client)
         app.CHECK_PROPERS_INTERVAL = check_propers_interval
 
         app.ALLOW_HIGH_PRIORITY = config.checkbox_to_value(allow_high_priority)

--- a/views/config_search.mako
+++ b/views/config_search.mako
@@ -87,6 +87,16 @@
                                 </label>
                             </div><!-- daily search frequency -->
                             <div class="field-pair">
+                                <label for="remove_from_client">
+                                    <span class="component-title">Remove from client</span>
+                                    <span class="component-desc">
+                                        <input type="checkbox" name="remove_from_client" id="remove_from_client" class="enabler" ${'checked="checked"' if app.REMOVE_FROM_CLIENT else ''}/>
+                                        <p>Remove old snatch from client and delete old snatched releases from post-processor folder when snatches a new release</p>
+                                        <p><b>Note:</b> For now only Transmission is supported</p>
+                                    </span>
+                                </label>
+                            </div>
+                            <div class="field-pair">
                                 <label>
                                     <span class="component-title">Usenet retention</span>
                                     <span class="component-desc">


### PR DESCRIPTION
and also remove file from PP folder if exists

Must enable the option `remove from client`

IMPORTANT: It adds `torrent_hash` to history table. Value already exists in `searchResult` object. Im only storing in the DB