### PR TITLE
Use scene number in history and schedule pages

### DIFF
--- a/medusa/show/ComingEpisodes.py
+++ b/medusa/show/ComingEpisodes.py
@@ -64,8 +64,12 @@ class ComingEpisodes(object):
 
         db = DBConnection()
         fields_to_select = ', '.join(
-            ['airdate', 'airs', 'e.description as description', 'episode', 'imdb_id', 'e.indexer', 'indexer_id', 'name', 'network',
-             'paused', 'quality', 'runtime', 'season', 'show_name', 'showid', 's.status']
+            ['airdate', 'airs', 'e.description as description',
+             "CASE WHEN scene_episode is not null and s.scene = 1 THEN scene_episode else episode END as 'episode'",
+             'imdb_id', 'e.indexer', 'indexer_id', 'name', 'network',
+             'paused', 'quality', 'runtime',
+             "CASE WHEN scene_season is not null and s.scene = 1 THEN scene_season else season END as 'season'",
+             'show_name', 'showid', 's.status']
         )
         results = db.select(
             'SELECT %s ' % fields_to_select +

--- a/medusa/show/History.py
+++ b/medusa/show/History.py
@@ -22,6 +22,7 @@ from six import text_type
 from ..common import Quality
 from ..db import DBConnection
 from ..helper.common import try_int
+from ..scene_numbering import get_scene_numbering
 
 
 class History(object):
@@ -56,7 +57,7 @@ class History(object):
         actions = History._get_actions(action)
         limit = max(try_int(limit), 0)
 
-        common_sql = 'SELECT show_name, showid, season, episode, h.quality, ' \
+        common_sql = 'SELECT show_name, showid, s.indexer, s.scene, season, episode, h.quality, ' \
                      'action, provider, resource, date, h.proper_tags ' \
                      'FROM history h, tv_shows s ' \
                      'WHERE h.showid = s.indexer_id '
@@ -117,7 +118,7 @@ class History(object):
     Action = namedtuple('Action', action_fields)
     Action.width = len(action_fields)
 
-    index_fields = ('show_id', 'season', 'episode', 'quality')
+    index_fields = ('show_id', 'indexer', 'scene', 'season', 'episode', 'quality')
     # An index for an item or compact item from history
     Index = namedtuple('Index', index_fields)
     Index.width = len(index_fields)
@@ -144,10 +145,18 @@ class History(object):
             """
             Create a look-up index for the item
             """
+            if self.scene:
+                season, episode = get_scene_numbering(self.show_id, self.indexer, self.season, self.episode)
+            else:
+                season = self.season
+                episode = self.episode
+
             return History.Index(
                 self.show_id,
-                self.season,
-                self.episode,
+                self.indexer,
+                self.scene,
+                season,
+                episode,
                 self.quality,
             )
 

--- a/medusa/show/History.py
+++ b/medusa/show/History.py
@@ -145,16 +145,19 @@ class History(object):
             """
             Create a look-up index for the item
             """
+            scene_numbering = False
             if self.scene:
                 season, episode = get_scene_numbering(self.show_id, self.indexer, self.season, self.episode)
             else:
                 season = self.season
                 episode = self.episode
+            if season != self.season or episode != self.episode:
+                scene_numbering = True
 
             return History.Index(
                 self.show_id,
                 self.indexer,
-                self.scene,
+                scene_numbering,
                 season,
                 episode,
                 self.quality,

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -2484,7 +2484,15 @@ class TVEpisode(TVObject):
         elif self.show.air_by_date:
             return self._format_pattern('%SN - %AD - %EN')
 
-        return self._format_pattern('%SN - S%0SE%0E - %EN')
+        default_pattern = '%SN - S%0SE%0E - %EN'
+        if self.show.scene:
+            # Change pattern to use scene number if xem map exists
+            if self.scene_season:
+                default_pattern = default_pattern.replace('S%0S','S%0XS')
+            if self.scene_episode:
+                default_pattern = default_pattern.replace('%0E','%0XE')
+
+        return self._format_pattern(default_pattern)
 
     def __ep_name(self):
         """Return the name of the episode to use during renaming.

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -2486,11 +2486,11 @@ class TVEpisode(TVObject):
 
         default_pattern = '%SN - S%0SE%0E - %EN'
         if self.show.scene:
-            # Change pattern to use scene number if xem map exists
+            # Change pattern to use scene number if there is one set
             if self.scene_season:
-                default_pattern = default_pattern.replace('S%0S','S%0XS')
+                default_pattern = default_pattern.replace('S%0S', 'S%0XS')
             if self.scene_episode:
-                default_pattern = default_pattern.replace('%0E','%0XE')
+                default_pattern = default_pattern.replace('%0E', '%0XE')
 
         return self._format_pattern(default_pattern)
 

--- a/views/history.mako
+++ b/views/history.mako
@@ -131,7 +131,7 @@
                 </td>
                 <td class="tvShow">
                     <% proper_tags = [action.proper_tags for action in hItem.actions if action.proper_tags] %>
-                    <span><a href="home/displayShow?show=${hItem.index.show_id}#season-${hItem.index.season}">${hItem.show_name} - ${"S%02i" % int(hItem.index.season)}${"E%02i" % int(hItem.index.episode)} ${'<span class="quality Proper">Proper</span>' if proper_tags else ''}</a></span>
+                    <span><a href="home/displayShow?show=${hItem.index.show_id}#season-${hItem.index.season}">${hItem.show_name} - ${"S%02i" % int(hItem.index.season)}${"E%02i" % int(hItem.index.episode)} ${'<img alt="[xem]" height="16" width="16" src="images/xem.png" style="margin-top: -1px; vertical-align:middle;"/>' if hItem.index.scene else ''} ${'<span class="quality Proper">Proper</span>' if proper_tags else ''}</a></span>
                 </td>
                 <td align="center" provider="${str(sorted(hItem.actions)[0].provider)}">
                     % for cur_action in sorted(hItem.actions):


### PR DESCRIPTION
### THIS MAKES HISTORY PAGE LOADING SLOW. 
Need to figure it out why is slow. maybe the function to get scene numbering

@duramato 
Known issue in Schedule:
we have two "coming episodes" S11E10 because mapping its not complete.

### DisplayShow:

there is no scene season/episodem mapping for "The Battles, Part 4"
![scene](https://cloud.githubusercontent.com/assets/2620870/19363409/bc87a744-9160-11e6-8df1-a0ee1909c3f9.png)

### Schedule:

![scene2](https://cloud.githubusercontent.com/assets/2620870/19363490/176e4988-9161-11e6-992e-05784a39055a.png)


