### PR TITLE
Read log files should return unicode lines.

### DIFF
--- a/medusa/logger.py
+++ b/medusa/logger.py
@@ -183,7 +183,7 @@ def reverse_readlines(filename, buf_size=2097152, encoding=default_encoding):
     :return:
     :rtype: collections.Iterable of str
     """
-    new_line = b'\n'
+    new_line = '\n'
     with io.open(filename, 'rb') as fh:
         segment = None
         offset = 0
@@ -193,6 +193,7 @@ def reverse_readlines(filename, buf_size=2097152, encoding=default_encoding):
             offset = min(file_size, offset + buf_size)
             fh.seek(file_size - offset)
             buf = fh.read(min(remaining_size, buf_size))
+            buf = text_type(buf.decode(sys.getfilesystemencoding()) if os.name == 'nt' else buf)
             remaining_size -= buf_size
             lines = buf.split(new_line)
             # the first line of the buffer is probably not a complete line so
@@ -371,7 +372,7 @@ class LogLine(object):
         :return:
         :rtype: LogLine or None
         """
-        lines = line.split(b'\n')
+        lines = line.split('\n')
         match = LogLine.log_re.match(lines[0])
         if not match:
             return

--- a/medusa/logger.py
+++ b/medusa/logger.py
@@ -193,7 +193,7 @@ def reverse_readlines(filename, buf_size=2097152, encoding=default_encoding):
             offset = min(file_size, offset + buf_size)
             fh.seek(file_size - offset)
             buf = fh.read(min(remaining_size, buf_size))
-            buf = text_type(buf.decode(sys.getfilesystemencoding()) if os.name == 'nt' else buf)
+            buf = text_type(buf.decode(sys.getfilesystemencoding()) if os.name == 'nt' else buf, errors='replace')
             remaining_size -= buf_size
             lines = buf.split(new_line)
             # the first line of the buffer is probably not a complete line so

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -6,6 +6,8 @@ import medusa.logger as sut
 from medusa.logger import DEBUG, INFO, LogLine, WARNING
 import pytest
 
+from six import text_type
+
 
 class TestStandardLoggingApi(object):
     @pytest.mark.parametrize('p', [
@@ -86,6 +88,9 @@ def test_reverse_readlines(create_file, line_pattern):
     no_lines = 10000
     filename = create_file(filename='samplefile.log', lines=[line_pattern.format(n=i) for i in range(0, no_lines)])
     expected = [line_pattern.format(n=no_lines - i - 1) for i in range(0, no_lines)]
+    for i, v in enumerate(expected):
+        if not isinstance(v, text_type):
+            expected[i] = text_type(v, errors='replace')
 
     # When
     actual = list(sut.reverse_readlines(filename, buf_size=1024))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)
- [x] Fixes #1261. Log reader should always return unicode
