### PR TITLE
Avoids logging results when they are null

### DIFF
--- a/medusa/providers/nzb/omgwtfnzbs.py
+++ b/medusa/providers/nzb/omgwtfnzbs.py
@@ -88,8 +88,8 @@ class OmgwtfnzbsProvider(NZBProvider):
                     try:
                         if not self._get_title_and_url(item):
                             continue
-
-                        logger.log('Found result: {0}'.format(item.get('title')), logger.DEBUG)
+                        if title:
+                            logger.log('Found result: {0}'.format(item.get('title')), logger.DEBUG)
                         items.append(item)
                     except (AttributeError, TypeError, KeyError, ValueError, IndexError):
                             logger.log('Failed parsing provider. Traceback: {0!r}'.format

--- a/medusa/providers/nzb/omgwtfnzbs.py
+++ b/medusa/providers/nzb/omgwtfnzbs.py
@@ -88,8 +88,9 @@ class OmgwtfnzbsProvider(NZBProvider):
                     try:
                         if not self._get_title_and_url(item):
                             continue
+                        title = item.get('title')
                         if title:
-                            logger.log('Found result: {0}'.format(item.get('title')), logger.DEBUG)
+                            logger.log('Found result: {0}'.format(title), logger.DEBUG)
                         items.append(item)
                     except (AttributeError, TypeError, KeyError, ValueError, IndexError):
                             logger.log('Failed parsing provider. Traceback: {0!r}'.format

--- a/medusa/providers/nzb/omgwtfnzbs.py
+++ b/medusa/providers/nzb/omgwtfnzbs.py
@@ -86,11 +86,10 @@ class OmgwtfnzbsProvider(NZBProvider):
 
                 for item in response:
                     try:
-                        if not self._get_title_and_url(item):
+                        if not all(self._get_title_and_url(item)):
                             continue
-                        title = item.get('title')
-                        if title:
-                            logger.log('Found result: {0}'.format(title), logger.DEBUG)
+
+                        logger.log('Found result: {0}'.format(item.get('title')), logger.DEBUG)
                         items.append(item)
                     except (AttributeError, TypeError, KeyError, ValueError, IndexError):
                             logger.log('Failed parsing provider. Traceback: {0!r}'.format


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Fixes: 
```2016-10-26 22:01:47 DEBUG    SEARCHQUEUE-MANUAL-282401 :: [OMGWTFNZBs] :: [683951e] Found result: None```