### PR TITLE
fix tooltips

### DIFF
--- a/static/js/config/post-processing.js
+++ b/static/js/config/post-processing.js
@@ -476,7 +476,6 @@ MEDUSA.config.postProcessing = function() { // eslint-disable-line max-lines
     $(this).refreshMetadataConfig(true);
     $('img[title]').qtip({
         position: {
-            viewport: $(window),
             at: 'bottom center',
             my: 'top right'
         },
@@ -490,7 +489,6 @@ MEDUSA.config.postProcessing = function() { // eslint-disable-line max-lines
     });
     $('i[title]').qtip({
         position: {
-            viewport: $(window),
             at: 'top center',
             my: 'bottom center'
         },
@@ -510,7 +508,6 @@ MEDUSA.config.postProcessing = function() { // eslint-disable-line max-lines
         },
         hide: false,
         position: {
-            viewport: $(window),
             at: 'center left',
             my: 'center right'
         },

--- a/static/js/home/display-show.js
+++ b/static/js/home/display-show.js
@@ -299,9 +299,23 @@ MEDUSA.home.displayShow = function() { // eslint-disable-line max-lines
             'text-shadow': '0px 0px 0.5px #666'
         });
         $(this).qtip({
-            show: {solo: true},
-            position: {viewport: $(window), my: 'left center', adjust: {y: -10, x: 2}},
-            style: {tip: {corner: true, method: 'polygon'}, classes: 'qtip-rounded qtip-shadow ui-tooltip-sb'}
+            show: {
+                solo: true
+            },
+            position: {
+                my: 'left center',
+                adjust: {
+                    y: -10,
+                    x: 2
+                }
+            },
+            style: {
+                tip: {
+                    corner: true,
+                    method: 'polygon'
+                },
+                classes: 'qtip-rounded qtip-shadow ui-tooltip-sb'
+            }
         });
     });
 

--- a/static/js/plot-tooltip.js
+++ b/static/js/plot-tooltip.js
@@ -21,7 +21,6 @@ $(function() {
                 solo: true
             },
             position: {
-                viewport: $(window),
                 my: 'left center',
                 adjust: {
                     y: -10,

--- a/static/js/rating-tooltip.js
+++ b/static/js/rating-tooltip.js
@@ -10,7 +10,6 @@ $(function() {
             solo: true
         },
         position: {
-            viewport: $(window),
             my: 'right center',
             at: 'center left',
             adjust: {

--- a/static/js/scene-exceptions-tooltip.js
+++ b/static/js/scene-exceptions-tooltip.js
@@ -19,7 +19,6 @@ $(function() {
                 solo: true
             },
             position: {
-                viewport: $(window),
                 my: 'bottom center',
                 at: 'top center',
                 adjust: {


### PR DESCRIPTION
Fixes tooltips not loading as `viewport: $(window)` breaks on jQuery 3.x.x