### PR TITLE
Show a "x" icon for failed download in compact view

### DIFF
--- a/views/history.mako
+++ b/views/history.mako
@@ -136,7 +136,7 @@
                 <td align="center" provider="${str(sorted(hItem.actions)[0].provider)}">
                     % for cur_action in sorted(hItem.actions):
                         <% composite = Quality.splitCompositeStatus(int(cur_action.action)) %>
-                        % if composite.status in [SNATCHED, FAILED]:
+                        % if composite.status == SNATCHED:
                             <% provider = providers.get_provider_class(GenericProvider.make_id(cur_action.provider)) %>
                             % if provider is not None:
                                 <img src="images/providers/${provider.image_name()}" width="16" height="16" style="vertical-align:middle;" alt="${provider.name}" style="cursor: help;" title="${provider.name}: ${os.path.basename(cur_action.resource)}"/>
@@ -146,6 +146,9 @@
                             % else:
                                 <img src="images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/>
                             % endif
+                        % endif
+                        % if composite.status == FAILED:
+                                <img src="images/no16.png" width="16" height="16" style="vertical-align:middle;" title="Failed!"/>
                         % endif
                     % endfor
                 </td>


### PR DESCRIPTION
Without this PR it shows again the provider icon

![image](https://cloud.githubusercontent.com/assets/2620870/19875507/5b3b1c52-9fb4-11e6-85d5-e7f0db8fe65d.png)


@duramato @medariox 
