### PR TITLE
Don't verify TLS certs for public trackers downloads. Fixes #1425

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -111,8 +111,10 @@ class GenericProvider(object):  # pylint: disable=too-many-instance-attributes
             if url.endswith(GenericProvider.TORRENT) and filename.endswith(GenericProvider.NZB):
                 filename = replace_extension(filename, GenericProvider.TORRENT)
 
+            verify = False if self.public else None
+
             if download_file(url, filename, session=self.session, headers=self.headers,
-                             hooks={'response': self.get_url_hook}):
+                             hooks={'response': self.get_url_hook}, verify=verify):
                 if self._verify_download(filename):
                     logger.log('Saved result to %s' % filename, logger.INFO)
                     return True


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

There is no good reason to verify the certs of a download URL for public trackers, as they use an external provider anyway or no auth at all (no sensitive data).