### PR TITLE
Removed the cleanup function to use on tvshow information. As I don't…

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -453,9 +453,6 @@ class TVDBv2(BaseIndexer):
             if v is not None:
                 if k in ['banner', 'fanart', 'poster']:
                     v = self.config['artwork_prefix'] % v
-                else:
-                    v = self._clean_data(v)
-
             self._set_show_data(sid, k, v)
 
         # get episode data


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

… think it's needed anymore with the new api. Left it as is for episode information.
The cleanup method was mostly used for episode summaries which had html in it.