### PR TITLE
Fix showing show object in show updater

### DIFF
--- a/medusa/show_updater.py
+++ b/medusa/show_updater.py
@@ -100,7 +100,7 @@ class ShowUpdater(object):
             for show in season_updates:
                 # If the cur_show is not 'paused' then add to the showQueueSchedular
                 if not show[0].paused:
-                    logger.info(u'Updating season {season} for show: {show}.', season=show[0], show=show[0].name)
+                    logger.info(u'Updating season {season} for show: {show}.', season=show[1], show=show[0].name)
                     pi_list.append(app.showQueueScheduler.action.updateShow(show[0], season=show[1]))
                 else:
                     logger.info(u'Show update skipped, show: {show} is paused.', show=show[0].name)


### PR DESCRIPTION
I think as we are showing the full object while calling the showupdater, it raises that warning about:
"in process of being updated by Post-processor or manually started, can't update again until it's done."


Traceback:
```
2016-11-02 03:00:10 WARNING  SHOWUPDATER :: [cb32c93] Automatic update failed. Error: Once Upon a Time (2011) is in process of being updated by Post-processor or manually started, can't update again until it's done.
2016-11-02 03:00:10 INFO     SHOWUPDATER :: [cb32c93] Updating season indexerid: 248835
indexer: 1
name: Once Upon a Time (2011)
location: /media/SAMSUNG/media/series/Once Upon a Time (2011)
network: ABC (US)
airs: Sunday 8:00 PM
status: Continuing
startyear: 2011
genre: Adventure|Drama|Fantasy|Romance
classification: Scripted
runtime: 45
quality: 80
scene: True
sports: False
anime: False
 for show: Once Upon a Time (2011
```