### PR TITLE
Fix season update

### DIFF
--- a/medusa/network_timezones.py
+++ b/medusa/network_timezones.py
@@ -41,6 +41,7 @@ missing_network_timezones = set()
 def update_network_dict():
     """Update timezone information from Medusa repositories"""
 
+    logger.log(u'Started updating network timezones', logger.DEBUG)
     url = 'https://cdn.pymedusa.com/sb_network_timezones/network_timezones.txt'
     response = helpers.getURL(url, session=helpers.make_session(), returns='response')
     if not response or not response.text:

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -700,7 +700,7 @@ class QueueItemUpdate(ShowQueueItem):
             logger.log(traceback.format_exc(), logger.ERROR)
 
         # get episode list from DB
-        DBEpList = self.show.load_episodes_from_db()
+        DBEpList = self.show.load_episodes_from_db(self.seasons)
 
         # get episode list from the indexer
         try:

--- a/medusa/show_updater.py
+++ b/medusa/show_updater.py
@@ -52,11 +52,7 @@ class ShowUpdater(object):
         expired_seasons = self.last_update.expired_seasons()
 
         for indexer in expired_seasons:
-
-            # Set refresh to True, to force refreshing of the entire show. Making sure per-season
-            # updating is disabled.
-            # TODO: Change to False, when per season updating has been fixed.
-            refresh = True
+            refresh = False
 
             # Query the indexer for changed shows, since last update
             # refresh network timezones

--- a/medusa/show_updater.py
+++ b/medusa/show_updater.py
@@ -45,6 +45,8 @@ class ShowUpdater(object):
 
         network_timezones.update_network_dict()
 
+        logger.info(u'Started full updating on all shows')
+
         # Initialize the indexer_update table. Add seasons with next_update, if they don't already exist.
         self.last_update.initialize_indexer_update(app.showList)
 

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -666,8 +666,10 @@ class TVShow(TVObject):
             main_db_con = db.DBConnection()
             main_db_con.mass_action(sql_l)
 
-    def load_episodes_from_db(self):
+    def load_episodes_from_db(self, seasons=None):
         """Load episodes from database.
+
+        @param: seasons: list of seasons and their episodes to load from db
 
         :return:
         :rtype: dict(int -> dict(int -> bool))
@@ -684,8 +686,12 @@ class TVShow(TVObject):
                    b'JOIN '
                    b'  tv_shows '
                    b'WHERE '
-                   b'  showid = indexer_id and showid = ?')
-            sql_results = main_db_con.select(sql, [self.indexerid])
+                   b'  showid = indexer_id AND showid = ?')
+            if seasons:
+                sql += b' AND season in ?'
+                sql_results = main_db_con.select(sql, [self.indexerid, ','.join(seasons)])
+            else:
+                sql_results = main_db_con.select(sql, [self.indexerid])
         except Exception as error:
             logger.log(u'{id}: Could not load episodes from the DB. Error: {error_msg}'.format
                        (id=self.indexerid, error_msg=error), logger.ERROR)


### PR DESCRIPTION
We are loading all eps from db:
```python
         # get episode list from DB
        DBEpList = self.show.load_episodes_from_db()
```
and for indexer we are loading only outdated season(s): 
```python
IndexerEpList = self.show.load_episodes_from_indexer(self.seasons)
```

@p0psicles @medariox 
My idea is to pass "season" to `self.show.load_episodes_from_db()` and only load episodes from that season(s)

Feel free to commit to this PR