### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'name'

### DIFF
--- a/views/history.mako
+++ b/views/history.mako
@@ -148,7 +148,7 @@
                             % endif
                         % endif
                         % if composite.status == FAILED:
-                                <img src="images/no16.png" width="16" height="16" style="vertical-align:middle;" title="${provider.name} download failed: ${cur_action.resource}"/>
+                                <img src="images/no16.png" width="16" height="16" style="vertical-align:middle;" title="${provider.name if provider else 'Unknown provider'} download failed: ${cur_action.resource}"/>
                         % endif
                     % endfor
                 </td>

--- a/views/history.mako
+++ b/views/history.mako
@@ -148,7 +148,7 @@
                             % endif
                         % endif
                         % if composite.status == FAILED:
-                                <img src="images/no16.png" width="16" height="16" style="vertical-align:middle;" title="${provider.name if provider else 'Unknown provider'} download failed: ${cur_action.resource}"/>
+                                <img src="images/no16.png" width="16" height="16" style="vertical-align:middle;" title="${provider.name if provider else cur_action.provider} download failed: ${cur_action.resource}"/>
                         % endif
                     % endfor
                 </td>

--- a/views/history.mako
+++ b/views/history.mako
@@ -144,7 +144,7 @@
                                     <img src="images/info32.png" width="16" height="16" style="vertical-align:middle;" title="${cur_action.proper_tags.replace('|', ', ')}"/>
                                 % endif
                             % else:
-                                <img src="images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="missing provider"/>
+                                <img src="images/providers/missing.png" width="16" height="16" style="vertical-align:middle;" alt="missing provider" title="${Missing provider: cur_action.provider}"/>
                             % endif
                         % endif
                         % if composite.status == FAILED:


### PR DESCRIPTION
Fix after @duramato added the provider to the title in faled

This happens when provider is no longer in providers (like a RSS provider that got deleted) or provider we removed in the past like Torrentz and have a failed download

