### PR TITLE
Fixed: For some shows there isn't an 'en' language available. But a result is provide, without the showname.

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -167,11 +167,7 @@ class TVDBv2(BaseIndexer):
 
         # Remove results with an empty series_name.
         # Skip shows when they do not have a series_name in the searched language. example: '24 h berlin' in 'en'
-        cleaned_results = []
-        for show in mapped_results:
-            if not show.get('seriesname'):
-                continue
-            cleaned_results.append(show)
+        cleaned_results = [show for show in mapped_results if show.get('seriesname')]
 
         return OrderedDict({'series': cleaned_results})['series']
 

--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -163,8 +163,20 @@ class TVDBv2(BaseIndexer):
             return
 
         mapped_results = self._object_to_dict(results, self.series_map, '|')
+        mapped_results = [mapped_results] if not isinstance(mapped_results, list) else mapped_results
 
-        return OrderedDict({'series': mapped_results})['series']
+        # Remove results with an empty series_name.
+        # Skip shows without configured series_name. example: '24 h berlin'
+        cleaned_results = []
+        for show in mapped_results:
+            if not show.get('seriesname', None):
+                if show.get('aliases', '') and len(show.get('aliases').split('|')):
+                    show['seriesname'] = show.get('aliases').split('|')[0]
+                else:
+                    continue
+            cleaned_results.append(show)
+
+        return OrderedDict({'series': cleaned_results})['series']
 
     def _get_show_by_id(self, tvdbv2_id, request_language='en'):  # pylint: disable=unused-argument
         """Retrieve tvdbv2 show information by tvdbv2 id, or if no tvdbv2 id provided by passed external id.

--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -166,14 +166,11 @@ class TVDBv2(BaseIndexer):
         mapped_results = [mapped_results] if not isinstance(mapped_results, list) else mapped_results
 
         # Remove results with an empty series_name.
-        # Skip shows without configured series_name. example: '24 h berlin'
+        # Skip shows when they do not have a series_name in the searched language. example: '24 h berlin' in 'en'
         cleaned_results = []
         for show in mapped_results:
-            if not show.get('seriesname', None):
-                if show.get('aliases', '') and len(show.get('aliases').split('|')):
-                    show['seriesname'] = show.get('aliases').split('|')[0]
-                else:
-                    continue
+            if not show.get('seriesname'):
+                continue
             cleaned_results.append(show)
 
         return OrderedDict({'series': cleaned_results})['series']


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Skipping the show when it doesn't have a result in the requested language.
your can reproduce the issue by searching for: '24 h berlin' in english.