### PR TITLE
Fixed unicodeDecode error, when opening shows with a unicode name.

### DIFF
--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -54,7 +54,7 @@ import medusa as app
 import requests
 from requests.compat import urlparse
 import shutil_custom
-from six import string_types, text_type
+from six import string_types, text_type, binary_type
 from six.moves import http_client
 from . import classes, db
 from .common import USER_AGENT
@@ -861,7 +861,7 @@ def check_url(url):
 def anon_url(*url):
     """Return a URL string consisting of the Anonymous redirect URL and an arbitrary number of values appended."""
     # normalize to byte
-    url = [u.encode('utf-8') if isinstance(u, unicode) else str(u) for u in url]
+    url = [u.encode('utf-8') if isinstance(u, text_type) else binary_type(u) for u in url]
     return '' if None in url else '{0}{1}'.format(app.ANON_REDIRECT, ''.join(url)).decode('utf-8')
 
 # Encryption

--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -860,7 +860,9 @@ def check_url(url):
 
 def anon_url(*url):
     """Return a URL string consisting of the Anonymous redirect URL and an arbitrary number of values appended."""
-    return '' if None in url else '%s%s' % (app.ANON_REDIRECT, ''.join(str(s) for s in url))
+    # normalize to byte
+    url = [u.encode('utf-8') if isinstance(u, unicode) else str(u) for u in url]
+    return '' if None in url else '{0}{1}'.format(app.ANON_REDIRECT, ''.join(url)).decode('utf-8')
 
 # Encryption
 # ==========

--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -54,7 +54,7 @@ import medusa as app
 import requests
 from requests.compat import urlparse
 import shutil_custom
-from six import string_types, text_type, binary_type
+from six import binary_type, string_types, text_type
 from six.moves import http_client
 from . import classes, db
 from .common import USER_AGENT


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/PyMedusa/SickRage/blob/master/.github/CONTRIBUTING.md)

Like swithing anime show to language japanese.
Don't know if this is the way though.

At least the error occurs because it tries to do a ''.join(unicode). As it's mixing str and unicode in the anon_url function.

The problem goes a little bit further then this.
The root cause why the anon_url is called with unicode chars, is because of the xem url.
But that url is invalid.
![image](https://cloud.githubusercontent.com/assets/1331394/20191617/91de766c-a786-11e6-9393-038eb3e0de5e.png)

Meaning, the url for xem is created from the shows title. But the shows title changes with the language you select on it. How should this work? Because if we should use the english language by default, this could be another challenge. As when changing your language for the show, you loose the english title.