### PR TITLE
Standard logging call should be used in rules.py 

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1934,8 +1934,8 @@ class AvoidMultipleValuesRule(Rule):
             values = matches.named(name)
             unique_values = {v.value for v in values}
             if len(unique_values) > 1:
-                logger.error(u"Guessed more than one '{name}' for '{input}': {values}",
-                             name=name, input=matches.input_string, values=u' '.join(unique_values))
+                logger.error(u"Guessed more than one '%s' for '%s': %s",
+                             name, matches.input_string, u','.join(unique_values), exc_info=False)
                 to_remove.extend(values)
 
         return to_remove


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
- [x] Standard logging call should be used in rules.py since guessit rules are loaded before wrapped logger instance is initialized.

This fixes latest bug in logger call reported in #1093 