### PR TITLE
Return full file path instead of parent in get_rel_path

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -114,9 +114,7 @@ class PostProcessor(object):
             except ValueError:
                 pass
 
-        parent_name = os.path.basename(os.path.dirname(self.file_path))
-        # return self.file_path once this bug is fixed: goo.gl/U4XNoP
-        return os.path.join(parent_name, self.file_name)
+        return self.file_path
 
     def _checkForExistingFile(self, existing_file):
         """

--- a/tests/legacy/pp_tests.py
+++ b/tests/legacy/pp_tests.py
@@ -39,7 +39,7 @@ class PPInitTests(unittest.TestCase):
         self.assertEqual(self.post_processor.file_name, test.FILENAME)
 
     def test_init_folder_name(self):
-        self.assertEqual(self.post_processor.rel_path, test.REL_PATH)
+        self.assertEqual(self.post_processor.rel_path, test.FILE_PATH)
 
 
 class PPBasicTests(test.AppTestDBCase):

--- a/tests/legacy/test_lib.py
+++ b/tests/legacy/test_lib.py
@@ -50,7 +50,6 @@ EPISODE = 2
 FILENAME = u"show name - s0" + str(SEASON) + "e0" + str(EPISODE) + ".mkv"
 FILE_DIR = os.path.join(TEST_DIR, SHOW_NAME)
 FILE_PATH = os.path.join(FILE_DIR, FILENAME)
-REL_PATH = os.path.join(os.path.basename(os.path.dirname(FILE_PATH)), FILENAME)
 SHOW_DIR = os.path.join(TEST_DIR, SHOW_NAME + " final")
 
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

