### PR TITLE
Don't run RSS search before backlog search

### DIFF
--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -519,14 +519,9 @@ def searchProviders(show, episodes, forced_search=False, downCurQuality=False,
         providers = [x for x in app.providers.sorted_provider_list(app.RANDOMIZE_PROVIDERS)
                      if x.is_active() and x.enable_manualsearch]
     else:
+        logger.log("Using backlog search providers")
         providers = [x for x in app.providers.sorted_provider_list(app.RANDOMIZE_PROVIDERS)
                      if x.is_active() and x.enable_backlog]
-
-    if not forced_search:
-        for cur_provider in providers:
-            threading.currentThread().name = '{thread} :: [{provider}]'.format(thread=original_thread_name,
-                                                                               provider=cur_provider.name)
-            cur_provider.cache.updateCache()
 
     threading.currentThread().name = original_thread_name
 

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -440,6 +440,7 @@ def searchForNeededEpisodes():
     original_thread_name = threading.currentThread().name
 
     providers = enabled_providers('daily')
+    logger.log("Using daily search providers")
     for cur_provider in providers:
         threading.currentThread().name = '{thread} :: [{provider}]'.format(thread=original_thread_name,
                                                                            provider=cur_provider.name)

--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -450,7 +450,7 @@ class BacklogQueueItem(generic_queue.QueueItem):
         if not self.show.paused:
             try:
                 logger.log(u"Beginning backlog search for: [" + self.show.name + "]")
-                search_result = searchProviders(self.show, self.segment, False, False)
+                search_result = searchProviders(self.show, self.segment)
 
                 if search_result:
                     for result in search_result:

--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -515,7 +515,7 @@ class FailedQueueItem(generic_queue.QueueItem):
 
             # If it is wanted, self.downCurQuality doesnt matter
             # if it isnt wanted, we need to make sure to not overwrite the existing ep that we reverted to!
-            search_result = searchProviders(self.show, self.segment, True, False, False)
+            search_result = searchProviders(self.show, self.segment, True)
 
             if search_result:
                 for result in search_result:

--- a/medusa/tv_cache.py
+++ b/medusa/tv_cache.py
@@ -345,6 +345,7 @@ class TVCache(object):
             logger.log('Last update was too soon, using old cache: {0}. '
                        'Updated less then {1} minutes ago'.format(self.lastUpdate, self.minTime), logger.DEBUG)
             return False
+        logger.log("Updating providers cache", logger.DEBUG)
 
         return True
 


### PR DESCRIPTION
Backlog = specific search. Doesn't need to run daily. 
Daily runs a lot more frequent than backlog.

@pymedusa/developers 

![image](https://cloud.githubusercontent.com/assets/2620870/20451142/6b0ebab2-addd-11e6-91d0-bcd1d259428d.png)

Daily uses another function:
![image](https://cloud.githubusercontent.com/assets/2620870/20451166/93ebd258-addd-11e6-8091-f92892b6d872.png)

