### PR TITLE
Improved pushbullet.py to return the error message

### DIFF
--- a/medusa/notifiers/pushbullet.py
+++ b/medusa/notifiers/pushbullet.py
@@ -126,6 +126,7 @@ class Notifier(object):
         except ValueError:
             logger.log('Pushbullet notification failed. Could not parse pushbullet response.', logger.WARNING)
             push_result['error'] = 'Pushbullet notification failed. Could not parse pushbullet response.'
+            return push_result
 
         failed = response.pop('error', {})
         if failed:

--- a/medusa/notifiers/pushbullet.py
+++ b/medusa/notifiers/pushbullet.py
@@ -20,7 +20,6 @@
 from __future__ import unicode_literals
 
 import re
-
 from requests.compat import urljoin
 from .. import app, common, helpers, logger
 
@@ -42,8 +41,13 @@ class Notifier(object):
 
     def get_devices(self, pushbullet_api):
         logger.log('Testing Pushbullet authentication and retrieving the device list.', logger.DEBUG)
-        headers = {'Access-Token': pushbullet_api}
-        return helpers.getURL(urljoin(self.url, 'devices'), session=self.session, headers=headers, returns='text') or {}
+        headers = {'Access-Token': pushbullet_api,
+                   'Content-Type': 'application/json'}
+        try:
+            r = self.session.get(urljoin(self.url, 'devices'), headers=headers)
+            return r.text
+        except ValueError:
+            return {}
 
     def notify_snatch(self, ep_name, is_proper):
         if app.PUSHBULLET_NOTIFY_ONSNATCH:
@@ -90,6 +94,7 @@ class Notifier(object):
 
     def _sendPushbullet(  # pylint: disable=too-many-arguments
             self, pushbullet_api=None, pushbullet_device=None, event=None, message=None, link=None, force=False):
+        push_result = {'success': False, 'error': ''}
 
         if not (app.USE_PUSHBULLET or force):
             return False
@@ -111,16 +116,23 @@ class Notifier(object):
         if link:
             post_data['url'] = link
 
-        headers = {'Access-Token': pushbullet_api}
+        headers = {'Access-Token': pushbullet_api,
+                   'Content-Type': 'application/json'}
 
-        response = helpers.getURL(urljoin(self.url, 'pushes'), session=self.session, post_data=post_data, headers=headers, returns='json') or {}
-        if not response:
-            return False
+        r = self.session.post(urljoin(self.url, 'pushes'), json=post_data, headers=headers)
+
+        try:
+            response = r.json()
+        except ValueError:
+            logger.log('Pushbullet notification failed. Could not parse pushbullet response.', logger.WARNING)
+            push_result['error'] = 'Pushbullet notification failed. Could not parse pushbullet response.'
 
         failed = response.pop('error', {})
         if failed:
-            logger.log('Pushbullet notification failed: {}'.format(failed.pop('message')), logger.WARNING)
+            logger.log('Pushbullet notification failed: {0}'.format(failed.get('message')), logger.WARNING)
+            push_result['error'] = 'Pushbullet notification failed: {0}'.format(failed.get('message'))
         else:
             logger.log('Pushbullet notification sent.', logger.DEBUG)
+            push_result['success'] = True
 
-        return False if failed else True
+        return push_result

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -546,10 +546,10 @@ class Home(WebRoot):
     @staticmethod
     def testPushbullet(api=None):
         result = notifiers.pushbullet_notifier.test_notify(api)
-        if result:
+        if result.get('success'):
             return 'Pushbullet notification succeeded. Check your device to make sure it worked'
         else:
-            return 'Error sending Pushbullet notification'
+            return 'Error sending Pushbullet notification: {0}'.format(result.get('error'))
 
     @staticmethod
     def getPushbulletDevices(api=None):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

which is returned instead of a generic error message.

Replaced getURL with default session object. As there is no reason IMO to use getURL here. getURL isn't really usefull for json requests anyway, as it will return None when a 4xx response is returned.