### PR TITLE
Fixed creation of tvdb season posters and banners (seasonwide) metadata

### DIFF
--- a/medusa/metadata/generic.py
+++ b/medusa/metadata/generic.py
@@ -36,6 +36,7 @@ try:
 except ImportError:
     import xml.etree.ElementTree as etree
 
+
 # todo: Implement Fanart.tv v3 API
 
 
@@ -331,7 +332,8 @@ class GenericMetadata(object):
     def create_season_banners(self, show_obj):
         if self.season_banners and show_obj:
             result = []
-            logger.log(u"Metadata provider " + self.name + " creating season banners for " + show_obj.name, logger.DEBUG)
+            logger.log(u"Metadata provider " + self.name + " creating season banners for " + show_obj.name,
+                       logger.DEBUG)
             for season in iterkeys(show_obj.episodes):  # @UnusedVariable
                 if not self._has_season_banner(show_obj, season):
                     result = result + [self.save_season_banners(show_obj, season)]
@@ -739,7 +741,8 @@ class GenericMetadata(object):
         except (IndexerError, IOError) as e:
             logger.log(u"Unable to look up show on " + indexerApi(
                 show_obj.indexer).name + ", not downloading images: " + ex(e), logger.WARNING)
-            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name, logger.DEBUG)
+            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name,
+                       logger.DEBUG)
             return None
 
         if image_type not in ('fanart', 'poster', 'banner', 'poster_thumb', 'banner_thumb'):
@@ -802,16 +805,17 @@ class GenericMetadata(object):
         except (IndexerError, IOError) as e:
             logger.log(u"Unable to look up show on " + indexerApi(
                 show_obj.indexer).name + ", not downloading images: " + ex(e), logger.WARNING)
-            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name, logger.DEBUG)
+            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name,
+                       logger.DEBUG)
             return result
 
         # if we have no season banners then just finish
         if not getattr(indexer_show_obj, '_banners', None):
             return result
 
-        if any(['seasonwide' not in indexer_show_obj['_banners'],
-                'original' not in indexer_show_obj['_banners']['seasonwide'],
-                season not in indexer_show_obj['_banners']['seasonwide']['original']]):
+        if ('season' not in indexer_show_obj['_banners'] or
+                'original' not in indexer_show_obj['_banners']['season'] or
+                season not in indexer_show_obj['_banners']['season']['original']):
             return result
 
         # Give us just the normal poster-style season graphics
@@ -864,12 +868,13 @@ class GenericMetadata(object):
         except (IndexerError, IOError) as e:
             logger.log(u"Unable to look up show on " + indexerApi(
                 show_obj.indexer).name + ", not downloading images: " + ex(e), logger.WARNING)
-            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name, logger.DEBUG)
+            logger.log(u"%s may be experiencing some problems. Try again later." % indexerApi(show_obj.indexer).name,
+                       logger.DEBUG)
             return result
 
-        if any(['seasonwide' not in indexer_show_obj['_banners'],
-                'original' not in indexer_show_obj['_banners']['seasonwide'],
-                season not in indexer_show_obj['_banners']['seasonwide']['original']]):
+        if ('seasonwide' not in indexer_show_obj['_banners'] or
+                'original' not in indexer_show_obj['_banners']['season'] or
+                season not in indexer_show_obj['_banners']['seasonwide']['original']):
             return result
 
         # Give us just the normal poster-style season graphics
@@ -906,8 +911,10 @@ class GenericMetadata(object):
             with io.open(metadata_path, 'rb') as xmlFileObj:
                 showXML = etree.ElementTree(file=xmlFileObj)
 
-            if showXML.findtext('title') is None or (showXML.findtext('tvdbid') is None and showXML.findtext('id') is None):
-                logger.log(u"Invalid info in tvshow.nfo (missing name or id): %s %s %s" % (showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')))
+            if showXML.findtext('title') is None or (
+                    showXML.findtext('tvdbid') is None and showXML.findtext('id') is None):
+                logger.log(u"Invalid info in tvshow.nfo (missing name or id): %s %s %s" % (
+                showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')))
                 return empty_return
 
             name = showXML.findtext('title')
@@ -935,7 +942,8 @@ class GenericMetadata(object):
                     elif 'themoviedb.org' in epg_url:
                         indexer = 4
                     elif 'tvrage' in epg_url:
-                        logger.log(u"Invalid Indexer ID (" + str(indexer_id) + "), not using metadata file because it has TVRage info", logger.WARNING)
+                        logger.log(u"Invalid Indexer ID (" + str(
+                            indexer_id) + "), not using metadata file because it has TVRage info", logger.WARNING)
                         return empty_return
 
         except Exception as e:

--- a/medusa/metadata/generic.py
+++ b/medusa/metadata/generic.py
@@ -911,10 +911,11 @@ class GenericMetadata(object):
             with io.open(metadata_path, 'rb') as xmlFileObj:
                 showXML = etree.ElementTree(file=xmlFileObj)
 
-            if showXML.findtext('title') is None or (
-                        showXML.findtext('tvdbid') is None and showXML.findtext('id') is None):
-                logger.log(u"Invalid info in tvshow.nfo (missing name or id): %s %s %s" % (
-                    showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')))
+            if (showXML.findtext('title') is None or
+                    (showXML.findtext('tvdbid') is None and showXML.findtext('id') is None)):
+                logger.log(u"Invalid info in tvshow.nfo (missing name or id): %s %s %s"
+                           % (showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')),
+                           logger.DEBUG)
                 return empty_return
 
             name = showXML.findtext('title')

--- a/medusa/metadata/generic.py
+++ b/medusa/metadata/generic.py
@@ -814,8 +814,8 @@ class GenericMetadata(object):
             return result
 
         if ('season' not in indexer_show_obj['_banners'] or
-                'original' not in indexer_show_obj['_banners']['season'] or
-                season not in indexer_show_obj['_banners']['season']['original']):
+                    'original' not in indexer_show_obj['_banners']['season'] or
+                    season not in indexer_show_obj['_banners']['season']['original']):
             return result
 
         # Give us just the normal poster-style season graphics
@@ -873,8 +873,8 @@ class GenericMetadata(object):
             return result
 
         if ('seasonwide' not in indexer_show_obj['_banners'] or
-                'original' not in indexer_show_obj['_banners']['season'] or
-                season not in indexer_show_obj['_banners']['seasonwide']['original']):
+                    'original' not in indexer_show_obj['_banners']['season'] or
+                    season not in indexer_show_obj['_banners']['seasonwide']['original']):
             return result
 
         # Give us just the normal poster-style season graphics
@@ -912,9 +912,9 @@ class GenericMetadata(object):
                 showXML = etree.ElementTree(file=xmlFileObj)
 
             if showXML.findtext('title') is None or (
-                    showXML.findtext('tvdbid') is None and showXML.findtext('id') is None):
+                        showXML.findtext('tvdbid') is None and showXML.findtext('id') is None):
                 logger.log(u"Invalid info in tvshow.nfo (missing name or id): %s %s %s" % (
-                showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')))
+                    showXML.findtext('title'), showXML.findtext('tvdbid'), showXML.findtext('id')))
                 return empty_return
 
             name = showXML.findtext('title')

--- a/medusa/metadata/generic.py
+++ b/medusa/metadata/generic.py
@@ -814,8 +814,8 @@ class GenericMetadata(object):
             return result
 
         if ('season' not in indexer_show_obj['_banners'] or
-                    'original' not in indexer_show_obj['_banners']['season'] or
-                    season not in indexer_show_obj['_banners']['season']['original']):
+                'original' not in indexer_show_obj['_banners']['season'] or
+                season not in indexer_show_obj['_banners']['season']['original']):
             return result
 
         # Give us just the normal poster-style season graphics
@@ -873,8 +873,8 @@ class GenericMetadata(object):
             return result
 
         if ('seasonwide' not in indexer_show_obj['_banners'] or
-                    'original' not in indexer_show_obj['_banners']['season'] or
-                    season not in indexer_show_obj['_banners']['seasonwide']['original']):
+                'original' not in indexer_show_obj['_banners']['season'] or
+                season not in indexer_show_obj['_banners']['seasonwide']['original']):
             return result
 
         # Give us just the normal poster-style season graphics

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -569,9 +569,9 @@ class QueueItemRefresh(ShowQueueItem):
 
         try:
             self.show.refresh_dir()
-            self.show.write_metadata()
             if self.force:
                 self.show.update_metadata()
+            self.show.write_metadata()
             self.show.populate_cache()
 
             # Load XEM data to DB for show

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -999,6 +999,7 @@ class TVShow(TVObject):
             season_banners_result = cur_provider.create_season_banners(self) or season_banners_result
             season_all_poster_result = cur_provider.create_season_all_poster(self) or season_all_poster_result
             season_all_banner_result = cur_provider.create_season_all_banner(self) or season_all_banner_result
+            cur_provider.indexer_api = None  # Let's cleanup the stored indexerApi objects.
 
         return (fanart_result or poster_result or banner_result or season_posters_result or
                 season_banners_result or season_all_poster_result or season_all_banner_result)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

* Improved speed, as i'm caching the indexer api, for every season that it's getting images.
Previously we did one call to the indexer for every season poster and banner. For a show with 24 seasons, that means 48 calls. I've reduced this to one.

I've changed the structure a little. So i'll need to further investigate if this as any other side effects. For example if the indexers images are used by anything other then the metadata generators.

### TODOs
- [x] Test with a wide range of shows
- [x] Currently no language support available. Need to look at how to implement this.
There is language support. As it will try to get the images in your language. Unfortunately also here again tvdb api is coming short. As for example with the show House of anubis (NL), the show has a poster, banner and fanart in language 'en', but no season or seasonwide. In in the language 'nl' it has season (no seasonwide) but also no poster, banner or fanart. So in this example, if you choose the set original shows language, you will miss out on the default poster.
- [x] parse_image method became somewhat of a mess. Maybe this can be done cleaner.

### Note:
Default structure indexer image path will be:
t['scrubs']['_banners']['poster']['680x1000']['35308']['_bannerpath']

For season images:
t['scrubs']['_banners']['season'][1]['680x1000']['35308']['_bannerpath']
or
t['scrubs']['_banners']['seasonwide'][1]['758x140']['35308']['_bannerpath']

This should be implemented for the other indexers (or external sources) in the same format.
