### PR TITLE
Fix xem keyerror

### DIFF
--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -492,6 +492,8 @@ def xem_refresh(indexer_id, indexer, force=False):
         )
 
         try:
+            if not indexerApi(indexer).config.get('xem_origin'):
+                return
             # XEM MAP URL
             url = "http://thexem.de/map/havemap?origin=%s" % indexerApi(indexer).config['xem_origin']
             parsedJSON = helpers.getURL(url, session=xem_session, returns='json')


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

@p0psicles 

Fix:

```
2016-11-28 22:26:02 DEBUG    SHOWQUEUE-ADD :: [b88941f] Looking up XEM scene mapping for show 21756 on TVmaze
2016-11-28 22:26:02 WARNING  SHOWQUEUE-ADD :: [b88941f] Exception while refreshing XEM data for show 21756 on TVmaze: xem_origin
2016-11-28 22:26:02 DEBUG    SHOWQUEUE-ADD :: [b88941f] Traceback (most recent call last):
  File "/home/home/SickRage/**********/scene_numbering.py", line 496, in xem_refresh
    url = "http://thexem.de/map/havemap?origin=%s" % indexerApi(indexer).config['xem_origin']
KeyError: 'xem_origin'
```
