### PR TITLE
Do not return None, for non 2xx response, when the request type is 'response'.

### DIFF
--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -1198,7 +1198,9 @@ def getURL(url, post_data=None, params=None, headers=None, timeout=30, session=N
 
             logger.debug(u'Requested url {url} returned status code {status}: {desc}'.format
                          (url=resp.url, status=resp.status_code, desc=http_code_description(resp.status_code)))
-            return None
+
+            if response_type and response_type != u'response':
+                return None
 
     except requests.exceptions.RequestException as e:
         logger.debug(u'Error requesting url {url}. Error: {err_msg}', url=url, err_msg=e)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

There is still the issue where some exceptions are swallowed and returned as None. But don't want to change too much in one go.