### PR TITLE
Feature/indexer sanitizing

### DIFF
--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -113,7 +113,7 @@ class Tmdb(BaseIndexer):
                         continue
 
                     # Do some value sanitizing
-                    if isinstance(value, list):
+                    if isinstance(value, list) and key not in ['episode_run_time']:
                         if all(isinstance(x, (str, unicode, int)) for x in value):
                             value = list_separator.join(str(v) for v in value)
 

--- a/medusa/indexers/tvmaze/tvmaze_api.py
+++ b/medusa/indexers/tvmaze/tvmaze_api.py
@@ -113,7 +113,7 @@ class TVmaze(BaseIndexer):
                         continue
 
                     # These keys have more complex dictionaries, let's map these manually
-                    if key in ['schedule', 'network', 'image', 'externals' , 'rating']:
+                    if key in ['schedule', 'network', 'image', 'externals', 'rating']:
                         if key == 'schedule':
                             return_dict['airs_time'] = value.get('time') or '0:00AM'
                             return_dict['airs_dayofweek'] = value.get('days')[0] if value.get('days') else None

--- a/medusa/indexers/tvmaze/tvmaze_api.py
+++ b/medusa/indexers/tvmaze/tvmaze_api.py
@@ -113,7 +113,7 @@ class TVmaze(BaseIndexer):
                         continue
 
                     # These keys have more complex dictionaries, let's map these manually
-                    if key in ['schedule', 'network', 'image', 'externals']:
+                    if key in ['schedule', 'network', 'image', 'externals' , 'rating']:
                         if key == 'schedule':
                             return_dict['airs_time'] = value.get('time') or '0:00AM'
                             return_dict['airs_dayofweek'] = value.get('days')[0] if value.get('days') else None
@@ -130,33 +130,31 @@ class TVmaze(BaseIndexer):
                             return_dict['tvrage_id'] = value.get('tvrage')
                             return_dict['tvdb_id'] = value.get('thetvdb')
                             return_dict['imdb_id'] = value.get('imdb')
-
+                        if key == 'rating':
+                            return_dict['contentrating'] = str(value.get('average'))\
+                                if isinstance(value, dict) else str(value)
                     else:
                         # Do some value sanitizing
                         if isinstance(value, list):
                             if all(isinstance(x, (str, unicode, int)) for x in value):
                                 value = list_separator.join(str(v) for v in value)
 
-                        # Process webChannel['name']
-                        if key == 'webChannel':
-                            value = value.get('name')
-
-                        # Process rating
-                        if key == 'rating':
-                            value = str(value.get('average')) if isinstance(value, dict) else str(value)
-
                         # Try to map the key
                         if key in key_mappings:
                             key = key_mappings[key]
 
                         # Set value to key
-                        return_dict[key] = value
+                        return_dict[key] = str(value) if isinstance(value, (float, int)) else value
 
                 # For episodes
                 if hasattr(item, 'season_number') and getattr(item, 'episode_number') is None:
-                    return_dict['episodenumber'] = index_special_episodes
+                    return_dict['episodenumber'] = str(index_special_episodes)
                     return_dict['seasonnumber'] = 0
                     index_special_episodes += 1
+
+                # Use webChannel if available
+                if getattr(item, 'webChannel', None):
+                    return_dict['network'] = getattr(item, 'webChannel')
 
             except Exception as e:
                 log().warning('Exception trying to parse attribute: %s, with exception: %r', key, e)

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -138,8 +138,8 @@ class GenericProvider(object):
         for proper_candidate in proper_candidates:
             show_obj = Show.find(app.showList,
                                  int(proper_candidate[b'showid'])) if proper_candidate[b'showid'] else None
-
             if show_obj:
+                self.show = show_obj
                 episode_obj = show_obj.get_episode(proper_candidate[b'season'], proper_candidate[b'episode'])
 
                 for term in self.proper_strings:

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -21,7 +21,7 @@ import traceback
 
 from imdb import _exceptions as imdb_exceptions
 from six import binary_type, text_type
-from traktor import TraktApi, TraktException
+from traktor import TraktException
 from . import app, generic_queue, logger, name_cache, notifiers, scene_numbering, ui
 from .black_and_white_list import BlackAndWhiteList
 from .common import WANTED

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -387,7 +387,7 @@ class QueueItemAdd(ShowQueueItem):
         # TODO: Add more specific indexer exceptions, that should provide the user with some accurate feedback.
         except IndexerShowIncomplete as e:
             logger.log(u"%s Error while loading information from indexer %s. "
-                       u"Error: %r" % (self.indexer_id, indexerApi(self.indexer).name, ex(e)), logger.ERROR)
+                       u"Error: %s" % (self.indexer_id, indexerApi(self.indexer).name, e.message), logger.WARNING)
             ui.notifications.error(
                 "Unable to add show",
                 "Unable to look up the show in %s on %s using ID %s "

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -386,6 +386,8 @@ class QueueItemAdd(ShowQueueItem):
                 return
         # TODO: Add more specific indexer exceptions, that should provide the user with some accurate feedback.
         except IndexerShowIncomplete as e:
+            logger.log(u"%s Error while loading information from indexer %s. "
+                       u"Error: %r" % (self.indexer_id, indexerApi(self.indexer).name, ex(e)), logger.ERROR)
             ui.notifications.error(
                 "Unable to add show",
                 "Unable to look up the show in %s on %s using ID %s "
@@ -397,44 +399,12 @@ class QueueItemAdd(ShowQueueItem):
         except Exception as e:
             logger.log(u"%s Error while loading information from indexer %s. "
                        u"Error: %r" % (self.indexer_id, indexerApi(self.indexer).name, ex(e)), logger.ERROR)
-            # logger.log(u"Show name with ID %s doesn't exist on %s anymore. If you are using trakt, it will be "
-            #            "removed from your TRAKT watchlist. If you are adding manually, try removing the nfo "
-            #            "and adding again" % (self.indexer_id, api.indexerApi(self.indexer).name), logger.WARNING)
-
             ui.notifications.error(
                 "Unable to add show",
                 "Unable to look up the show in %s on %s using ID %s, not using the NFO. "
                 "Delete .nfo and try adding manually again." %
                 (self.showDir, indexerApi(self.indexer).name, self.indexer_id)
             )
-
-            # FIXME: This shouldn't be here. I've commented it. If nobody can provide me with reasons to keep it.
-            # It should be removed completely.
-            # if app.USE_TRAKT:
-            #
-            #     trakt_id = indexerApi(self.indexer).config['trakt_id']
-            #     trakt_api = TraktApi(app.SSL_VERIFY, app.TRAKT_TIMEOUT)
-            #
-            #     title = self.showDir.split("/")[-1]
-            #     data = {
-            #         'shows': [
-            #             {
-            #                 'title': title,
-            #                 'ids': {}
-            #             }
-            #         ]
-            #     }
-            #     if trakt_id == 'tvdb_id':
-            #         data['shows'][0]['ids']['tvdb'] = self.indexer_id
-            #     # else:
-            #     #     data['shows'][0]['ids']['tvrage'] = self.indexer_id
-            #
-            #     try:
-            #         trakt_api.traktRequest("sync/watchlist/remove", data, method='POST')
-            #     except TraktException as e:
-            #         logger.log(u"Could not remove show '{0}' from watchlist. Error: {1}".format
-            #                    (title, e), logger.WARNING)
-
             self._finishEarly()
             return
 

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -1283,28 +1283,28 @@ class TVShow(TVObject):
         try:
             if not self.imdbid:
                 # Somewhere title2imdbID started to return without 'tt'
-                imdb_search = imdb_api.title2imdbID(self.name, kind='tv series')
+                self.imdbid = imdb_api.title2imdbID(self.name, kind='tv series')
 
-            if not imdb_search:
+            if not self.imdbid:
                 logger.log(u'{0}: Not loading show info from IMDb, '
                            u"because we don't know its ID".format(self.indexerid))
                 return
 
             # Make sure we only use one ID, and sanitize the imdb to include the tt.
-            imdb_id = imdb_search.split(',')[0]
-            if 'tt' not in imdb_id:
-                imdb_id = 'tt{imdb_id}'.format(imdb_id=imdb_id)
+            self.imdbid = self.imdbid.split(',')[0]
+            if 'tt' not in self.imdbid:
+                self.imdbid = 'tt{imdb_id}'.format(imdb_id=self.imdbid)
 
             logger.log(u'{0}: Loading show info from IMDb with ID: {1}'.format(
-                self.indexerid, imdb_id), logger.DEBUG)
+                self.indexerid, self.imdbid), logger.DEBUG)
 
             # Remove first two chars from ID
-            imdb_obj = imdb_api.get_movie(imdb_id[2:])
+            imdb_obj = imdb_api.get_movie(self.imdbid[2:])
 
             # IMDb returned something we don't want
             if not imdb_obj.get('year'):
                 logger.log(u'{0}: IMDb returned invalid info for {1}, skipping update.'.format(
-                    self.indexerid, imdb_id), logger.DEBUG)
+                    self.indexerid, self.imdbid), logger.DEBUG)
                 return
 
         except IMDbDataAccessError:
@@ -1318,7 +1318,7 @@ class TVShow(TVObject):
             return
 
         self.imdb_info = {
-            'imdb_id': imdb_id,
+            'imdb_id': self.imdbid,
             'title': imdb_obj.get('title', ''),
             'year': imdb_obj.get('year', ''),
             'akas': '|'.join(imdb_obj.get('akas', '')),
@@ -1330,7 +1330,6 @@ class TVShow(TVObject):
             'last_update': datetime.date.today().toordinal()
         }
 
-        self.imdbid = imdb_id
         self.externals['imdb_id'] = self.imdbid
 
         if imdb_obj.get('runtimes'):

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -1292,7 +1292,7 @@ class TVShow(TVObject):
 
             # Make sure we only use one ID, and sanitize the imdb to include the tt.
             imdb_id = imdb_search.split(',')[0]
-            if not 'tt' in imdb_id:
+            if 'tt' not in imdb_id:
                 imdb_id = 'tt{imdb_id}'.format(imdb_id=imdb_id)
 
             logger.log(u'{0}: Loading show info from IMDb with ID: {1}'.format(


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Sanitized indexer inputs. Int and Floats are now cast to str by default. I'd like to use it by default like this, as the metadata doesn't handle integer fields very well.
* Sanitize tvmaze input.
* Use WebChannel as network, when available.
* Sanitize tmdb input.
* Use highest value runtime from tmdb.
* Removed some piece of old trakt code. It apparently removes a show from trakt watchlist, when that show can't be added because of "any" reason (is located in an catch Exception block. The main reason I removed it, is because it also still has references to tvrage. Leaving this can cause unexpected situations.