### PR TITLE
Fix proper being redownloaded.

### DIFF
--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -382,7 +382,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _canonical_name(name, clear_extension=False):
-        ignore_list = {'website', 'mimetype'} | {'container'} if clear_extension else {}
+        ignore_list = {'website', 'mimetype', 'parsing_time'} | {'container'} if clear_extension else {}
         return helpers.canonical_name(name, ignore_list=ignore_list).lower()
 
     @staticmethod


### PR DESCRIPTION
@ratoaq2 @duramato 

To check if is already in history we do:

if any(clean_proper_name == self._canonical_name(cur_result[b'resource'], clear_extension=True)

with `parsing_time` added to parse, it was comparing it with history, and history doesn't have this info, so proper was snatched again.

clean_proper_name = u'title:show|season:1|episode:1|other:proper|proper_count:1|proper_tag:repack|screen_size:1080p|format:hdtv|video_codec:h264|video_encoder:x264|release_group:dimension|type:episode|parsing_time:0.553999900818'