### PR TITLE
Fix failed history not saving to DB when reverting episode

### DIFF
--- a/medusa/failed_history.py
+++ b/medusa/failed_history.py
@@ -22,7 +22,7 @@ import re
 from datetime import datetime, timedelta
 
 from . import db, logger
-from .common import FAILED, Quality, WANTED
+from .common import FAILED, Quality, WANTED, statusStrings
 from .helper.exceptions import EpisodeNotFoundException
 from .show.history import History
 
@@ -156,14 +156,15 @@ def revert_episode(ep_obj):
                    u'{show.episode}): {show.name}'.format(show=ep_obj))
         with ep_obj.lock:
             if ep_obj.episode in history_eps:
-                logger.log(u'Found in history')
                 ep_obj.status = history_eps[ep_obj.episode]['old_status']
+                logger.log(u'Episode have a previous status to revert. Setting it back to {0}'.format
+                           (statusStrings[ep_obj.status]), logger.DEBUG)
             else:
                 logger.log(u'Episode does not have a previous snatched status '
                            u'to revert. Setting it back to WANTED',
                            logger.DEBUG)
                 ep_obj.status = WANTED
-                ep_obj.save_to_db()
+            ep_obj.save_to_db()
 
     except EpisodeNotFoundException as error:
         logger.log(u'Unable to create episode, please set its status '


### PR DESCRIPTION
@labrys as i said in chat

i think @duramato had this issue before about composite FAILED status.

FAILED is temporary status.  After set to failed medusa set to WANTED so medusa starts a new search OR revert old episode status (as user already have the file in the library)


To reproduce:

1) Snatch & PP an episodes in allowed
2) Preferred quality is released
3) Snatch the preferred
4) Download of preferred failed

Without this PR:
5) Status is set to compound FAILED (preferred quality)
6) Revert of episode not saved to database
7) Medusa starts a search with episode status FAILED (which is wrong)

With this PR:
5) Episode is reverted to allowed quality and library file is untouched
6) Medusa starts a search with old episode status DOWNLOADED (allowed) , so it will still look for preferred.