### PR TITLE
Fix status check happening too early

### DIFF
--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -286,11 +286,11 @@ class Manage(Home, WebRoot):
 
                 tv_episode = TVEpisode.from_filepath(video_path)
 
-                if tv_episode.status not in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
-                    continue
-
                 if not tv_episode:
                     logger.log(u"Filename '{0}' cannot be parsed to an episode".format(filename), logger.DEBUG)
+                    continue
+
+                if tv_episode.status not in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
                     continue
 
                 if not tv_episode.show.subtitles:

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -1,6 +1,5 @@
 # coding=utf-8
-# Author: medariox <dariox@gmx.com>,
-# based on Antoine Bertin's <diaoulael@gmail.com> work
+# Based on Antoine Bertin's <diaoulael@gmail.com> work
 # and originally written by Nyaran <nyayukko@gmail.com>
 #
 # This file is part of Medusa.
@@ -837,12 +836,12 @@ class SubtitlesFinder(object):
                     logger.debug(u'%s cannot be parsed to an episode', filename)
                     continue
 
+                if tv_episode.status not in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
+                    continue
+
                 if not tv_episode.show.subtitles:
                     logger.debug(u'Subtitle disabled for show: %s. Running post-process to PP it', filename)
                     run_post_process = True
-                    continue
-
-                if tv_episode.status not in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST:
                     continue
 
                 # Should not consider existing subtitles from db if it's a replacement


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

TVEpisode.from_filepath may return None and cause tv_episode.status to raise an exception.