### PR TITLE
Remove torrent hash from providers parsing

### DIFF
--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -210,7 +210,7 @@ class ShowListUI(object):  # pylint: disable=too-few-public-methods
 
 
 class Proper(object):
-    def __init__(self, name, url, date, show, seeders, leechers, size, pubdate, torrent_hash, proper_tags):
+    def __init__(self, name, url, date, show, seeders, leechers, size, pubdate, proper_tags):
         self.name = name
         self.url = url
         self.date = date
@@ -223,7 +223,7 @@ class Proper(object):
         self.size = size
         self.pubdate = pubdate
         self.proper_tags = proper_tags
-        self.hash = torrent_hash
+        self.hash = None
         self.show = show
         self.indexer = None
         self.indexerid = -1

--- a/medusa/clients/deluged_client.py
+++ b/medusa/clients/deluged_client.py
@@ -164,15 +164,15 @@ class DelugeRPC(object):
         else:
             return True
 
-    def add_torrent_magnet(self, torrent, options, torrent_hash):
+    def add_torrent_magnet(self, torrent, options, info_hash):
         """Add Torrent magnet and return torrent id/hash.
 
         :param torrent:
         :type torrent: str
         :param options:
         :type options: dict
-        :param torrent_hash:
-        :type torrent_hash: str
+        :param info_hash:
+        :type info_hash: str
         :return:
         :rtype: str or bool
         """
@@ -180,7 +180,7 @@ class DelugeRPC(object):
             self.connect()
             torrent_id = self.client.core.add_torrent_magnet(torrent, options).get()
             if not torrent_id:
-                torrent_id = self._check_torrent(torrent_hash)
+                torrent_id = self._check_torrent(info_hash)
         except Exception:
             return False
         else:
@@ -189,7 +189,7 @@ class DelugeRPC(object):
             if self.client:
                 self.disconnect()
 
-    def add_torrent_file(self, filename, torrent, options, torrent_hash):
+    def add_torrent_file(self, filename, torrent, options, info_hash):
         """Add Torrent file and return torrent id/hash.
 
         :param filename:
@@ -198,8 +198,8 @@ class DelugeRPC(object):
         :type torrent: str
         :param options:
         :type options: dict
-        :param torrent_hash:
-        :type torrent_hash: str
+        :param info_hash:
+        :type info_hash: str
         :return:
         :rtype: str or bool
         """
@@ -207,7 +207,7 @@ class DelugeRPC(object):
             self.connect()
             torrent_id = self.client.core.add_torrent_file(filename, b64encode(torrent), options).get()
             if not torrent_id:
-                torrent_id = self._check_torrent(torrent_hash)
+                torrent_id = self._check_torrent(info_hash)
         except Exception:
             return False
         else:
@@ -326,11 +326,11 @@ class DelugeRPC(object):
         """Disconnect RPC client."""
         self.client.disconnect()
 
-    def _check_torrent(self, torrent_hash):
-        torrent_id = self.client.core.get_torrent_status(torrent_hash, {}).get()
+    def _check_torrent(self, info_hash):
+        torrent_id = self.client.core.get_torrent_status(info_hash, {}).get()
         if torrent_id['hash']:
             logger.debug('DelugeD: Torrent already exists in Deluge')
-            return torrent_hash
+            return info_hash
         return False
 
 api = DelugeDAPI

--- a/medusa/clients/generic.py
+++ b/medusa/clients/generic.py
@@ -179,7 +179,7 @@ class GenericClient(object):
         return True
 
     @staticmethod
-    def _get_torrent_hash(result):
+    def _get_info_hash(result):
 
         if result.url.startswith('magnet'):
             result.hash = re.findall(r'urn:btih:([\w]{32,40})', result.url)[0]
@@ -227,7 +227,7 @@ class GenericClient(object):
             result.ratio = result.provider.seed_ratio()
 
             # lazy fix for now, I'm sure we already do this somewhere else too
-            result = self._get_torrent_hash(result)
+            result = self._get_info_hash(result)
 
             if not result.hash:
                 return False

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -144,13 +144,12 @@ class GenericProvider(object):
                         seeders, leechers = self._get_result_info(item)
                         size = self._get_size(item)
                         pubdate = self._get_pubdate(item)
-                        torrent_hash = self._get_torrent_hash(item)
 
                         # This will be retrived from the parser
                         proper_tags = ''
 
                         results.append(Proper(title, url, datetime.today(), show_obj, seeders, leechers, size, pubdate,
-                                              torrent_hash, proper_tags))
+                                              proper_tags))
 
         return results
 
@@ -213,7 +212,6 @@ class GenericProvider(object):
             (seeders, leechers) = self._get_result_info(item)
             size = self._get_size(item)
             pubdate = self._get_pubdate(item)
-            torrent_hash = self._get_torrent_hash(item)
 
             try:
                 parse_result = NameParser(parse_method=('normal', 'anime')[show.is_anime]).parse(title)
@@ -304,7 +302,7 @@ class GenericProvider(object):
                 logger.log('Adding item from search to cache: %s' % title, logger.DEBUG)
 
                 # Access to a protected member of a client class
-                ci = self.cache.add_cache_entry(title, url, seeders, leechers, size, pubdate, torrent_hash)
+                ci = self.cache.add_cache_entry(title, url, seeders, leechers, size, pubdate, torrent_hash=None)
 
                 if ci is not None:
                     cl.append(ci)
@@ -342,7 +340,6 @@ class GenericProvider(object):
             result.content = None
             result.size = self._get_size(item)
             result.pubdate = self._get_pubdate(item)
-            result.hash = self._get_torrent_hash(item)
 
             if not episode_object:
                 episode_number = SEASON_RESULT
@@ -516,13 +513,6 @@ class GenericProvider(object):
         """Return publish date of the item.
 
         If provider doesnt have _get_pubdate function this will be used
-        """
-        return None
-
-    def _get_torrent_hash(self, item):
-        """Return hash of the item.
-
-        If provider doesnt have _get_torrent_hash function this will be used
         """
         return None
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -55,13 +55,13 @@ class GenericProvider(object):
 
         self.anime_only = False
         self.bt_cache_urls = [
-            'http://itorrents.org/torrent/{torrent_hash}.torrent',
-            'https://torrentproject.se/torrent/{torrent_hash}.torrent',
-            'http://torrasave.top/torrent/{torrent_hash}.torrent',
-            'http://torra.pro/torrent/{torrent_hash}.torrent',
-            'http://torra.click/torrent/{torrent_hash}.torrent',
-            'http://reflektor.karmorra.info/torrent/{torrent_hash}.torrent',
-            'http://torrasave.site/torrent/{torrent_hash}.torrent',
+            'http://itorrents.org/torrent/{info_hash}.torrent',
+            'https://torrentproject.se/torrent/{info_hash}.torrent',
+            'http://torrasave.top/torrent/{info_hash}.torrent',
+            'http://torra.pro/torrent/{info_hash}.torrent',
+            'http://torra.click/torrent/{info_hash}.torrent',
+            'http://reflektor.karmorra.info/torrent/{info_hash}.torrent',
+            'http://torrasave.site/torrent/{info_hash}.torrent',
         ]
         self.cache = TVCache(self)
         self.enable_backlog = False
@@ -302,7 +302,7 @@ class GenericProvider(object):
                 logger.log('Adding item from search to cache: %s' % title, logger.DEBUG)
 
                 # Access to a protected member of a client class
-                ci = self.cache.add_cache_entry(title, url, seeders, leechers, size, pubdate, torrent_hash=None)
+                ci = self.cache.add_cache_entry(title, url, seeders, leechers, size, pubdate)
 
                 if ci is not None:
                     cl.append(ci)
@@ -546,21 +546,21 @@ class GenericProvider(object):
 
         if result.url.startswith('magnet'):
             try:
-                torrent_hash = re.findall(r'urn:btih:([\w]{32,40})', result.url)[0].upper()
+                info_hash = re.findall(r'urn:btih:([\w]{32,40})', result.url)[0].upper()
 
                 try:
                     torrent_name = re.findall('dn=([^&]+)', result.url)[0]
                 except Exception:
                     torrent_name = 'NO_DOWNLOAD_NAME'
 
-                if len(torrent_hash) == 32:
-                    torrent_hash = b16encode(b32decode(torrent_hash)).upper()
+                if len(info_hash) == 32:
+                    info_hash = b16encode(b32decode(info_hash)).upper()
 
-                if not torrent_hash:
+                if not info_hash:
                     logger.log('Unable to extract torrent hash from magnet: %s' % ex(result.url), logger.ERROR)
                     return urls, filename
 
-                urls = [x.format(torrent_hash=torrent_hash, torrent_name=torrent_name) for x in self.bt_cache_urls]
+                urls = [x.format(info_hash=info_hash, torrent_name=torrent_name) for x in self.bt_cache_urls]
                 shuffle(urls)
             except Exception:
                 logger.log('Unable to extract torrent hash or name from magnet: %s' % ex(result.url), logger.ERROR)

--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -208,7 +208,6 @@ class NewznabProvider(NZBProvider):
                                 'seeders': seeders,
                                 'leechers': leechers,
                                 'pubdate': pubdate,
-                                'torrent_hash': None,
                             }
                             if mode != 'RSS':
                                 if seeders == -1:

--- a/medusa/providers/torrent/html/abnormal.py
+++ b/medusa/providers/torrent/html/abnormal.py
@@ -170,7 +170,6 @@ class ABNormalProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/alpharatio.py
+++ b/medusa/providers/torrent/html/alpharatio.py
@@ -175,7 +175,6 @@ class AlphaRatioProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/animebytes.py
+++ b/medusa/providers/torrent/html/animebytes.py
@@ -262,7 +262,6 @@ class AnimeBytes(TorrentProvider):
                                     'seeders': seeders,
                                     'leechers': leechers,
                                     'pubdate': None,
-                                    'torrent_hash': None
                                 }
                                 if mode != 'RSS':
                                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/animetorrents.py
+++ b/medusa/providers/torrent/html/animetorrents.py
@@ -185,7 +185,6 @@ class AnimeTorrentsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/bithdtv.py
+++ b/medusa/providers/torrent/html/bithdtv.py
@@ -161,7 +161,6 @@ class BithdtvProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/cpasbien.py
+++ b/medusa/providers/torrent/html/cpasbien.py
@@ -131,7 +131,6 @@ class CpasbienProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/danishbits.py
+++ b/medusa/providers/torrent/html/danishbits.py
@@ -174,7 +174,6 @@ class DanishbitsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/elitetorrent.py
+++ b/medusa/providers/torrent/html/elitetorrent.py
@@ -152,7 +152,6 @@ class EliteTorrentProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/extratorrent.py
+++ b/medusa/providers/torrent/html/extratorrent.py
@@ -175,7 +175,6 @@ class ExtraTorrentProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/freshontv.py
+++ b/medusa/providers/torrent/html/freshontv.py
@@ -206,7 +206,6 @@ class FreshOnTVProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/gftracker.py
+++ b/medusa/providers/torrent/html/gftracker.py
@@ -183,7 +183,6 @@ class GFTrackerProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/hdspace.py
+++ b/medusa/providers/torrent/html/hdspace.py
@@ -168,7 +168,6 @@ class HDSpaceProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/hdtorrents.py
+++ b/medusa/providers/torrent/html/hdtorrents.py
@@ -179,7 +179,6 @@ class HDTorrentsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/hounddawgs.py
+++ b/medusa/providers/torrent/html/hounddawgs.py
@@ -183,7 +183,6 @@ class HoundDawgsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/iptorrents.py
+++ b/medusa/providers/torrent/html/iptorrents.py
@@ -153,7 +153,6 @@ class IPTorrentsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -181,7 +181,6 @@ class LimeTorrentsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': torrent_hash,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/limetorrents.py
+++ b/medusa/providers/torrent/html/limetorrents.py
@@ -150,14 +150,14 @@ class LimeTorrentsProvider(TorrentProvider):
                         title = alt_title.replace('-', ' ')
 
                     torrent_id = regex_result.group(2)
-                    torrent_hash = hash_regex.search(title_url).group(2)
-                    if not all([title, torrent_id, torrent_hash]):
+                    info_hash = hash_regex.search(title_url).group(2)
+                    if not all([title, torrent_id, info_hash]):
                         continue
 
                     with suppress(RequestsConnectionError, Timeout):
                         # Suppress the timeout since we are not interested in actually getting the results
                         self.session.get(self.urls['update'], timeout=0.1, params={'torrent_id': torrent_id,
-                                                                                   'infohash': torrent_hash})
+                                                                                   'infohash': info_hash})
 
                     # Remove comma as thousands separator from larger number like 2,000 seeders = 2000
                     seeders = try_int(cells[labels.index('Seed')].get_text(strip=True).replace(',', ''), 1)
@@ -172,7 +172,7 @@ class LimeTorrentsProvider(TorrentProvider):
 
                     size = convert_size(cells[labels.index('Size')].get_text(strip=True)) or -1
                     download_url = 'magnet:?xt=urn:btih:{hash}&dn={title}{trackers}'.format(
-                        hash=torrent_hash, title=title, trackers=self._custom_trackers)
+                        hash=info_hash, title=title, trackers=self._custom_trackers)
 
                     item = {
                         'title': title,

--- a/medusa/providers/torrent/html/morethantv.py
+++ b/medusa/providers/torrent/html/morethantv.py
@@ -190,7 +190,6 @@ class MoreThanTVProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/newpct.py
+++ b/medusa/providers/torrent/html/newpct.py
@@ -152,7 +152,6 @@ class NewpctProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/pretome.py
+++ b/medusa/providers/torrent/html/pretome.py
@@ -150,7 +150,6 @@ class PretomeProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/scc.py
+++ b/medusa/providers/torrent/html/scc.py
@@ -152,7 +152,6 @@ class SCCProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/scenetime.py
+++ b/medusa/providers/torrent/html/scenetime.py
@@ -170,7 +170,6 @@ class SceneTimeProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/sdbits.py
+++ b/medusa/providers/torrent/html/sdbits.py
@@ -173,7 +173,6 @@ class SDBitsProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/speedcd.py
+++ b/medusa/providers/torrent/html/speedcd.py
@@ -164,7 +164,6 @@ class SpeedCDProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/thepiratebay.py
+++ b/medusa/providers/torrent/html/thepiratebay.py
@@ -183,7 +183,6 @@ class ThePirateBayProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/tntvillage.py
+++ b/medusa/providers/torrent/html/tntvillage.py
@@ -175,7 +175,6 @@ class TNTVillageProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/tokyotoshokan.py
+++ b/medusa/providers/torrent/html/tokyotoshokan.py
@@ -150,7 +150,6 @@ class TokyoToshokanProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/torrentbytes.py
+++ b/medusa/providers/torrent/html/torrentbytes.py
@@ -176,7 +176,6 @@ class TorrentBytesProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/torrentleech.py
+++ b/medusa/providers/torrent/html/torrentleech.py
@@ -167,7 +167,6 @@ class TorrentLeechProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/torrentproject.py
+++ b/medusa/providers/torrent/html/torrentproject.py
@@ -131,9 +131,9 @@ class TorrentProjectProvider(TorrentProvider):
                     if not all([title, download_url]):
                         continue
 
-                    torrent_hash = download_url.split('/')[1]
+                    info_hash = download_url.split('/')[1]
                     download_url = 'magnet:?xt=urn:btih:{hash}&dn={title}{trackers}'.format(
-                        hash=torrent_hash, title=title, trackers=self._custom_trackers)
+                        hash=info_hash, title=title, trackers=self._custom_trackers)
 
                     seeders = try_int(row.find('span', class_='bc seeders').find('span').get_text(), 1)
                     leechers = try_int(row.find('span', class_='bc leechers').find('span').get_text())

--- a/medusa/providers/torrent/html/torrentproject.py
+++ b/medusa/providers/torrent/html/torrentproject.py
@@ -156,7 +156,6 @@ class TorrentProjectProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': torrent_hash,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/torrentshack.py
+++ b/medusa/providers/torrent/html/torrentshack.py
@@ -167,7 +167,6 @@ class TorrentShackProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/transmitthenet.py
+++ b/medusa/providers/torrent/html/transmitthenet.py
@@ -175,7 +175,6 @@ class TransmitTheNetProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/tvchaosuk.py
+++ b/medusa/providers/torrent/html/tvchaosuk.py
@@ -188,7 +188,6 @@ class TVChaosUKProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/xthor.py
+++ b/medusa/providers/torrent/html/xthor.py
@@ -181,7 +181,6 @@ class XthorProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/html/zooqle.py
+++ b/medusa/providers/torrent/html/zooqle.py
@@ -155,7 +155,6 @@ class ZooqleProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': None,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/bitcannon.py
+++ b/medusa/providers/torrent/json/bitcannon.py
@@ -149,7 +149,6 @@ class BitCannonProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': None,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -142,7 +142,6 @@ class BTNProvider(TorrentProvider):
                 'seeders': seeders,
                 'leechers': leechers,
                 'pubdate': None,
-                'torrent_hash': None,
             }
             logger.log('Found result: {0} with {1} seeders and {2} leechers'.format
                        (title, seeders, leechers), logger.DEBUG)

--- a/medusa/providers/torrent/json/hd4free.py
+++ b/medusa/providers/torrent/json/hd4free.py
@@ -161,7 +161,6 @@ class HD4FreeProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': pubdate,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/norbits.py
+++ b/medusa/providers/torrent/json/norbits.py
@@ -138,7 +138,6 @@ class NorbitsProvider(TorrentProvider):
                                    (title, seeders), logger.DEBUG)
                     continue
 
-                info_hash = row.pop('info_hash', '')
                 size = convert_size(row.pop('size', -1), -1)
 
                 item = {
@@ -148,7 +147,6 @@ class NorbitsProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': None,
-                    'torrent_hash': info_hash,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/rarbg.py
+++ b/medusa/providers/torrent/json/rarbg.py
@@ -198,7 +198,6 @@ class RarbgProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': pubdate,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/t411.py
+++ b/medusa/providers/torrent/json/t411.py
@@ -170,7 +170,6 @@ class T411Provider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': None,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/json/torrentday.py
+++ b/medusa/providers/torrent/json/torrentday.py
@@ -166,7 +166,6 @@ class TorrentDayProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': pubdate,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/rss/nyaatorrents.py
+++ b/medusa/providers/torrent/rss/nyaatorrents.py
@@ -151,7 +151,6 @@ class NyaaProvider(TorrentProvider):
                     'seeders': seeders,
                     'leechers': leechers,
                     'pubdate': None,
-                    'torrent_hash': None,
                 }
                 if mode != 'RSS':
                     logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/torrent_provider.py
+++ b/medusa/providers/torrent/torrent_provider.py
@@ -146,18 +146,3 @@ class TorrentProvider(GenericProvider):
             pubdate = None
 
         return pubdate
-
-    def _get_torrent_hash(self, item):
-        """
-        Return torrent_hash of the item.
-
-        If provider doesnt have _get_torrent_hash function this will be used
-        """
-        if isinstance(item, dict):
-            torrent_hash = item.get('torrent_hash')
-        elif isinstance(item, (list, tuple)) and len(item) > 2:
-            torrent_hash = item[6]
-        else:
-            torrent_hash = None
-
-        return torrent_hash

--- a/medusa/providers/torrent/xml/bitsnoop.py
+++ b/medusa/providers/torrent/xml/bitsnoop.py
@@ -135,7 +135,6 @@ class BitSnoopProvider(TorrentProvider):
 
                     torrent_size = row.find('size').text
                     size = convert_size(torrent_size) or -1
-                    torrent_hash = row.find('infohash').text
 
                     item = {
                         'title': title,
@@ -144,7 +143,6 @@ class BitSnoopProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': torrent_hash,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/xml/torrentz2.py
+++ b/medusa/providers/torrent/xml/torrentz2.py
@@ -143,7 +143,6 @@ class Torrentz2Provider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': None,
-                        'torrent_hash': torrent_hash,
                     }
                     if mode != 'RSS':
                         logger.log('Found result: {0} with {1} seeders and {2} leechers'.format

--- a/medusa/providers/torrent/xml/torrentz2.py
+++ b/medusa/providers/torrent/xml/torrentz2.py
@@ -120,8 +120,8 @@ class Torrentz2Provider(TorrentProvider):
                     title_raw = row.title.text
                     # Add "-" after codec and add missing "."
                     title = re.sub(r'([xh][ .]?264|xvid)( )', r'\1-', title_raw).replace(' ', '.') if title_raw else ''
-                    torrent_hash = row.guid.text.rsplit('/', 1)[-1]
-                    download_url = "magnet:?xt=urn:btih:" + torrent_hash + "&dn=" + title + self._custom_trackers
+                    info_hash = row.guid.text.rsplit('/', 1)[-1]
+                    download_url = "magnet:?xt=urn:btih:" + info_hash + "&dn=" + title + self._custom_trackers
                     if not all([title, download_url]):
                         continue
 

--- a/medusa/tv_cache.py
+++ b/medusa/tv_cache.py
@@ -168,10 +168,6 @@ class TVCache(object):
         """Return publish date of the item."""
         return self.provider._get_pubdate(item)
 
-    def _get_torrent_hash(self, item):
-        """Return hash of the item."""
-        return self.provider._get_torrent_hash(item)
-
     def _get_rss_data(self):
         """Return rss data."""
         return {'entries': self.provider.search(self.search_params)} if self.search_params else None
@@ -241,7 +237,7 @@ class TVCache(object):
             cl = []
             for item in manual_data:
                 logger.log('Adding to cache item found in manual search: {0}'.format(item.name), logger.DEBUG)
-                ci = self.add_cache_entry(item.name, item.url, item.seeders, item.leechers, item.size, item.pubdate, item.hash)
+                ci = self.add_cache_entry(item.name, item.url, item.seeders, item.leechers, item.size, item.pubdate, torrent_hash=None)
                 if ci is not None:
                     cl.append(ci)
         except Exception as e:
@@ -279,7 +275,6 @@ class TVCache(object):
         seeders, leechers = self._get_result_info(item)
         size = self._get_size(item)
         pubdate = self._get_pubdate(item)
-        torrent_hash = self._get_torrent_hash(item)
 
         self._check_item_auth(title, url)
 
@@ -288,7 +283,7 @@ class TVCache(object):
             url = self._translate_link_url(url)
 
             # logger.log('Attempting to add item to cache: ' + title, logger.DEBUG)
-            return self.add_cache_entry(title, url, seeders, leechers, size, pubdate, torrent_hash)
+            return self.add_cache_entry(title, url, seeders, leechers, size, pubdate, torrent_hash=None)
 
         else:
             logger.log(


### PR DESCRIPTION
We get the torrent hash in `send_torrent` method right before update history table
No need to parse from providers

My history table has hashes even providers doesn't parse it:

![image](https://cloud.githubusercontent.com/assets/2620870/21189437/d8e94afc-c205-11e6-8572-f1f6e29ef57f.png)

