### PR TITLE
Fix pymedusa/Medusa/issues/1675

### DIFF
--- a/medusa/providers/torrent/html/bithdtv.py
+++ b/medusa/providers/torrent/html/bithdtv.py
@@ -126,6 +126,10 @@ class BithdtvProvider(TorrentProvider):
             # Skip column headers
             for row in torrent_rows[1:]:
                 cells = row('td')
+                if len(cells) < 3:
+                    # We must have cells[2] because it containts the title
+                    continue
+
                 if self.freeleech and not row.get('bgcolor'):
                     continue
 


### PR DESCRIPTION
Fixes pymedusa/Medusa/issues/1675

  File "/home/pi/Medusa/medusa/providers/torrent/html/bithdtv.py", line 133, in parse
    title = cells[2].find('a')['title']
IndexError: list index out of range
