### PR TITLE
Fix RARBG regex when check if is media file

### DIFF
--- a/medusa/helpers.py
+++ b/medusa/helpers.py
@@ -108,7 +108,7 @@ def isMediaFile(filename):
             return False
 
         # ignore RARBG release intro
-        if re.search(r'^RARBG\.\w+\.(mp4|avi|txt)$', filename, re.I):
+        if re.search(r'^RARBG(\.(com|to))?\.(txt|avi|mp4)$', filename, re.I):
             return False
 
         # ignore MAC OS's retarded "resource fork" files


### PR DESCRIPTION
It was detecting RARBG.mp4 as valid media info file.
hey, @rarbg are there any other file formats other than `RARBG.mp4` ?