### PR TITLE
fix api auth when using no user/pass, add new field to api config

### DIFF
--- a/medusa/server/api/v2/auth.py
+++ b/medusa/server/api/v2/auth.py
@@ -22,6 +22,7 @@ class LoginHandler(BaseRequestHandler):
 
     def post(self, *args, **kwargs):
         """Submit login."""
+        self.set_header('X-Medusa-Server', app.APP_VERSION)
         username = app.WEB_USERNAME
         password = app.WEB_PASSWORD
         submitted_username = ''

--- a/medusa/server/api/v2/config.py
+++ b/medusa/server/api/v2/config.py
@@ -74,7 +74,7 @@ class ConfigHandler(BaseRequestHandler):
                     'enabled': bool(app.USE_PLEX_SERVER and app.PLEX_UPDATE_LIBRARY)
                 },
                 'client': {
-                    'enabled': False # Replace this with plex client code
+                    'enabled': False  # Replace this with plex client code
                 }
             },
             'emby': {

--- a/medusa/server/api/v2/config.py
+++ b/medusa/server/api/v2/config.py
@@ -60,15 +60,22 @@ class ConfigHandler(BaseRequestHandler):
             'sourceUrl': app.APPLICATION_URL,
             'displayAllSeasons': app.DISPLAY_ALL_SEASONS,
             'displayShowSpecials': app.DISPLAY_SHOW_SPECIALS,
-            'useSubtitles': app.USE_SUBTITLES,
             'downloadUrl': app.DOWNLOAD_URL,
             'subtitlesMulti': app.SUBTITLES_MULTI,
             'namingForceFolders': app.NAMING_FORCE_FOLDERS,
+            'subtitles': {
+                'enabled': bool(app.USE_SUBTITLES)
+            },
             'kodi': {
                 'enabled': bool(app.USE_KODI and app.KODI_UPDATE_LIBRARY)
             },
             'plex': {
-                'enabled': bool(app.USE_PLEX_SERVER and app.PLEX_UPDATE_LIBRARY)
+                'server': {
+                    'enabled': bool(app.USE_PLEX_SERVER and app.PLEX_UPDATE_LIBRARY)
+                },
+                'client': {
+                    'enabled': False # Replace this with plex client code
+                }
             },
             'emby': {
                 'enabled': bool(app.USE_EMBY)

--- a/tests/apiv2/test_config.py
+++ b/tests/apiv2/test_config.py
@@ -59,15 +59,22 @@ def config(monkeypatch, app_config):
         'sourceUrl': app.APPLICATION_URL,
         'displayAllSeasons': app.DISPLAY_ALL_SEASONS,
         'displayShowSpecials': app.DISPLAY_SHOW_SPECIALS,
-        'useSubtitles': app.USE_SUBTITLES,
         'downloadUrl': app.DOWNLOAD_URL,
         'subtitlesMulti': app.SUBTITLES_MULTI,
         'namingForceFolders': app.NAMING_FORCE_FOLDERS,
+        'subtitles': {
+            'enabled': bool(app.USE_SUBTITLES)
+        },
         'kodi': {
             'enabled': bool(app.USE_KODI and app.KODI_UPDATE_LIBRARY)
         },
         'plex': {
-            'enabled': bool(app.USE_PLEX_SERVER and app.PLEX_UPDATE_LIBRARY)
+            'server': {
+                'enabled': bool(app.USE_PLEX_SERVER and app.PLEX_UPDATE_LIBRARY)
+            },
+            'client': {
+                'enabled': False  # Replace this with plex client code
+            }
         },
         'emby': {
             'enabled': bool(app.USE_EMBY)


### PR DESCRIPTION
This allows the use of a form when posting to `/api/auth/login` instead of just basic auth. It also allows users to authenticate and get an API key when there's no username/password set. This is mainly used when Medusa is first installed.