### PR TITLE
Revert quality method should_replace in PP

### DIFF
--- a/medusa/common.py
+++ b/medusa/common.py
@@ -657,10 +657,6 @@ class Quality(object):
             if new_quality in preferred_qualities:
                 return True, 'New quality is preferred. Accepting new quality'
 
-            # Commented for now as Labrys requests
-            # if new_quality > old_quality:
-            #    return True, 'New quality is higher quality (but not preferred). Accepting new quality'
-
             return False, 'New quality is same/lower quality (and not preferred). Ignoring new quality'
 
         else:

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
-
+"""Post processor module."""
 import fnmatch
 import os
 import re
@@ -114,10 +114,11 @@ class PostProcessor(object):
 
         return self.file_path
 
-    def _checkForExistingFile(self, existing_file):
+    def _check_for_existing_file(self, existing_file):
         """
-        Check if a file exists already and if it does whether it's bigger or smaller than
-        the file we are post processing.
+        Check if a file exists already.
+
+        If it does whether it's bigger or smaller than the file we are post processing.
 
         :param existing_file: The file to compare to
         :return:
@@ -452,7 +453,7 @@ class PostProcessor(object):
         self._combined_file_operation(file_path, new_path, new_base_name, associated_files,
                                       action=_int_hard_link, subtitles=subtitles)
 
-    def _moveAndSymlink(self, file_path, new_path, new_base_name, associated_files=False, subtitles=False):
+    def _move_and_symlink(self, file_path, new_path, new_base_name, associated_files=False, subtitles=False):
         """
         Move file, symlink source location back to destination, and set proper permissions.
 
@@ -995,7 +996,7 @@ class PostProcessor(object):
         new_ep_version = version
 
         # check for an existing file
-        existing_file_status = self._checkForExistingFile(ep_obj.location)
+        existing_file_status = self._check_for_existing_file(ep_obj.location)
 
         if not priority_download:
             if existing_file_status == PostProcessor.EXISTS_SAME:
@@ -1168,8 +1169,8 @@ class PostProcessor(object):
             elif self.process_method == "symlink":
                 if helpers.is_file_locked(self.file_path, True):
                     raise EpisodePostProcessingFailedException('File is locked for reading/writing')
-                self._moveAndSymlink(self.file_path, dest_path, new_base_name, app.MOVE_ASSOCIATED_FILES,
-                                     app.USE_SUBTITLES and ep_obj.show.subtitles)
+                self._move_and_symlink(self.file_path, dest_path, new_base_name, app.MOVE_ASSOCIATED_FILES,
+                                       app.USE_SUBTITLES and ep_obj.show.subtitles)
             else:
                 logger.log(u' "{0}" is an unknown file processing method. '
                            u'Please correct your app\'s usage of the api.'.format(self.process_method), logger.WARNING)

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -1007,15 +1007,12 @@ class PostProcessor(object):
                     self._log(u'New file is a PROPER, marking it safe to replace')
                     self.flag_kodi_clean_library()
                 else:
-                    allowed_qualities, preferred_qualities = show.current_qualities
-                    should_replace, replace_msg = common.Quality.should_replace(old_ep_status, old_ep_quality,
-                                                                                new_ep_quality, allowed_qualities,
-                                                                                preferred_qualities)
-                    if not should_replace:
+                    _, preferred_qualities = show.current_qualities
+                    if new_ep_quality not in preferred_qualities:
                         raise EpisodePostProcessingFailedException(
-                            u'File exists. Marking it unsafe to replace. Reason: {0}'.format(replace_msg))
+                            u'File exists. Marking it unsafe to replace because this quality is not preferred')
                     else:
-                        self._log(u'File exists. Marking it safe to replace. Reason: {0}'.format(replace_msg))
+                        self._log(u'File exists. Marking it safe to replace because this quality is preferred')
                         self.flag_kodi_clean_library()
 
             # Check if the processed file season is already in our indexer. If not,

--- a/pytest.ini
+++ b/pytest.ini
@@ -89,7 +89,6 @@ flake8-ignore =
     medusa/numdict.py D102 D105 D205 D400 D401
     medusa/nzb_splitter.py D100 D202 D400
     medusa/nzbget.py D100 D400 D401 N802 N806
-    medusa/post_processor.py D100 D205 D400 N802
     medusa/process_tv.py D100 D101 D102 D103 D202 D400 E265 N802 N803 N806
     medusa/providers/__init__.py D104 F401
     medusa/providers/nzb/__init__.py D104

--- a/tests/test_quality_replace.py
+++ b/tests/test_quality_replace.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for medusa/test_quality_replace.py."""
-from medusa.common import ARCHIVED, DOWNLOADED, Quality, SKIPPED, SNATCHED, SNATCHED_PROPER, WANTED
+from medusa.common import ARCHIVED, DOWNLOADED, Quality, SKIPPED, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER, WANTED
 
 import pytest
 
@@ -401,6 +401,17 @@ import pytest
         'force': True,
         'manually_searched': True,
         'expected': True
+    },
+    {  # p36: SNATCHED BEST and found HDBLURAY: no
+        'ep_status': SNATCHED_BEST,
+        'cur_quality': Quality.HDTV,
+        'new_quality': Quality.HDBLURAY,
+        'allowed_qualities': [Quality.SDTV],
+        'preferred_qualities': [Quality.HDTV],
+        'download_current_quality': False,
+        'force': False,
+        'manually_searched': False,
+        'expected': False
     }
 ])
 def test_should_replace(p):


### PR DESCRIPTION
Here the check can be simple as before. Don't need to do all `should_replace_ checks

This code is when user manually adds a file in PP folder
So it will only run this code when not priority_download (if is it snatched, in history, PROPER, or BEST)

This won't fix issue 1856 neither omg issue