### PR TITLE
Remove proper strings from providers which return "propers" without them

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -69,7 +69,7 @@ class GenericProvider(object):
         self.enable_daily = False
         self.enabled = False
         self.headers = {'User-Agent': UA_POOL.random}
-        self.proper_strings = ['PROPER|REPACK|REAL']
+        self.proper_strings = ['PROPER|REPACK|REAL|RERIP']
         self.provider_type = None
         self.public = False
         self.search_fallback = False

--- a/medusa/providers/torrent/html/bithdtv.py
+++ b/medusa/providers/torrent/html/bithdtv.py
@@ -53,6 +53,7 @@ class BithdtvProvider(TorrentProvider):
         }
 
         # Proper Strings
+        self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
         # Miscellaneous Options
 

--- a/medusa/providers/torrent/html/freshontv.py
+++ b/medusa/providers/torrent/html/freshontv.py
@@ -58,7 +58,7 @@ class FreshOnTVProvider(TorrentProvider):
         }
 
         # Proper Strings
-        self.proper_strings = [' ']
+        self.proper_strings = ['']
 
         # Miscellaneous Options
         self.freeleech = False

--- a/medusa/providers/torrent/html/freshontv.py
+++ b/medusa/providers/torrent/html/freshontv.py
@@ -58,7 +58,7 @@ class FreshOnTVProvider(TorrentProvider):
         }
 
         # Proper Strings
-        self.proper_strings = ['PROPER', 'REPACK', 'REAL']
+        self.proper_strings = [' ']
 
         # Miscellaneous Options
         self.freeleech = False

--- a/medusa/providers/torrent/html/freshontv.py
+++ b/medusa/providers/torrent/html/freshontv.py
@@ -58,6 +58,7 @@ class FreshOnTVProvider(TorrentProvider):
         }
 
         # Proper Strings
+        # Provider always returns propers and non-propers in a show search
         self.proper_strings = ['']
 
         # Miscellaneous Options

--- a/medusa/providers/torrent/html/scenetime.py
+++ b/medusa/providers/torrent/html/scenetime.py
@@ -50,6 +50,8 @@ class SceneTimeProvider(TorrentProvider):
         }
 
         # Proper Strings
+        # Provider always returns propers and non-propers in a show search
+        self.proper_strings = ['']
 
         # Miscellaneous Options
         self.enable_cookies = True

--- a/medusa/providers/torrent/html/speedcd.py
+++ b/medusa/providers/torrent/html/speedcd.py
@@ -49,7 +49,7 @@ class SpeedCDProvider(TorrentProvider):
         }
 
         # Proper Strings
-        self.proper_strings = ['PROPER', 'REPACK']
+        self.proper_strings = ['PROPER', 'REPACK', 'REAL']
 
         # Miscellaneous Options
         self.freeleech = False

--- a/medusa/providers/torrent/html/tvchaosuk.py
+++ b/medusa/providers/torrent/html/tvchaosuk.py
@@ -50,6 +50,7 @@ class TVChaosUKProvider(TorrentProvider):
         }
 
         # Proper Strings
+        self.proper_strings = [' ']
 
         # Miscellaneous Options
         self.freeleech = None

--- a/medusa/providers/torrent/html/tvchaosuk.py
+++ b/medusa/providers/torrent/html/tvchaosuk.py
@@ -50,7 +50,7 @@ class TVChaosUKProvider(TorrentProvider):
         }
 
         # Proper Strings
-        self.proper_strings = [' ']
+        self.proper_strings = ['']
 
         # Miscellaneous Options
         self.freeleech = None

--- a/medusa/providers/torrent/html/tvchaosuk.py
+++ b/medusa/providers/torrent/html/tvchaosuk.py
@@ -50,6 +50,7 @@ class TVChaosUKProvider(TorrentProvider):
         }
 
         # Proper Strings
+        # Provider always returns propers and non-propers in a show search
         self.proper_strings = ['']
 
         # Miscellaneous Options


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Some providers return the same results with `Show S01E01` or `Show S01E01 PROPER`, so this makes them just use `Show S01E01` propers, as they will still return "proper" results