### PR TITLE
remove "Close" from fileBrowser dialog since we use x

### DIFF
--- a/static/js/browser.js
+++ b/static/js/browser.js
@@ -27,6 +27,7 @@
         }
 
         fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog busy');
+        fileBrowserDialog.dialog('option', 'closeText', ''); // This removes the "Close" text
 
         currentRequest = $.getJSON(endpoint, {
             path: path,


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch

Fixes https://github.com/pymedusa/Medusa/issues/1353#issuecomment-257041472