### PR TITLE
Catch possible Trakt exception while adding a show.

### DIFF
--- a/medusa/helper/externals.py
+++ b/medusa/helper/externals.py
@@ -42,10 +42,11 @@ def get_trakt_externals(externals):
                 app.TRAKT_ACCESS_TOKEN = api.access_token
                 app.TRAKT_REFRESH_TOKEN = api.refresh_token
                 app.instance.save_config()
-        except (TokenExpiredException, TraktException):
-            app.TRAKT_ACCESS_TOKEN = ''
-            raise
-        return result
+        except (TokenExpiredException, TraktException) as e:
+            logger.info(u"Could not use Trakt to enrich with externals. Cause: {cause}", cause=e)
+            return []
+        else:
+            return result
 
     trakt_settings = {'trakt_api_key': app.TRAKT_API_KEY,
                       'trakt_api_secret': app.TRAKT_API_SECRET,

--- a/medusa/helper/externals.py
+++ b/medusa/helper/externals.py
@@ -43,7 +43,7 @@ def get_trakt_externals(externals):
                 app.TRAKT_REFRESH_TOKEN = api.refresh_token
                 app.instance.save_config()
         except (TokenExpiredException, TraktException) as e:
-            logger.info(u"Could not use Trakt to enrich with externals. Cause: {cause}", cause=e)
+            logger.info(u'Could not use Trakt to enrich with externals. Cause: {cause}', cause=e)
             return []
         else:
             return result


### PR DESCRIPTION
Trakt is used to enrich with external id's. If trakt is down, adding shows was not possible.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
