### PR TITLE
Improve anime episode search strings

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -35,6 +35,7 @@ from ..helper.exceptions import ex
 from ..helpers import download_file, get_url, make_session
 from ..indexers.indexer_config import INDEXER_TVDBV2
 from ..name_parser.parser import InvalidNameException, InvalidShowException, NameParser
+from ..scene_exceptions import get_scene_exceptions
 from ..show.show import Show
 from ..show_name_helpers import allPossibleShowNames
 from ..tv_cache import TVCache
@@ -460,7 +461,15 @@ class GenericProvider(object):
                 episode_string += ('|', ' ')[len(self.proper_strings) > 1]
                 episode_string += episode.airdate.strftime('%b')
             elif episode.show.anime:
-                episode_string += '%02d' % int(episode.scene_absolute_number)
+                # If the showname is a season scene exception, we want to use the indexer episode number.
+                if (episode.scene_season > 1 and
+                    show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
+                                                      indexer=episode.show.indexer)):
+                    # This is apparently a season exception, let's use the scene_episode instead of absolute
+                    ep = int(episode.scene_episode)
+                else:
+                    ep = int(episode.scene_absolute_number)
+                episode_string += str(ep)
             else:
                 episode_string += config.naming_ep_type[2] % {
                     'seasonnumber': episode.scene_season,

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -466,9 +466,9 @@ class GenericProvider(object):
                     show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
                                                       indexer=episode.show.indexer)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
-                    ep = int(episode.scene_episode)
+                    ep = episode.scene_episode
                 else:
-                    ep = int(episode.scene_absolute_number)
+                    ep = episode.scene_absolute_number
                 episode_string += str(ep)
             else:
                 episode_string += config.naming_ep_type[2] % {

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -121,8 +121,10 @@ class Anizb(NZBProvider):
         """Override the default _get_size to prevent it from extracting using the default tags."""
         return try_int(item.get('size'))
 
-    def _get_episode_search_strings(self, episode):
+    def _get_episode_search_strings(self, episode, add_string=''):
         """Get episode search strings."""
+        _ = add_string
+
         if not episode:
             return []
 

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -121,7 +121,7 @@ class Anizb(NZBProvider):
         """Override the default _get_size to prevent it from extracting using the default tags."""
         return try_int(item.get('size'))
 
-    def _get_episode_search_strings(self, episode, add_string=''):
+    def _get_episode_search_strings(self, episode):
         """Get episode search strings."""
         if not episode:
             return []
@@ -141,9 +141,6 @@ class Anizb(NZBProvider):
             else:
                 ep = int(episode.scene_absolute_number)
             episode_string += str(ep)
-
-            if add_string:
-                episode_string += ' ' + add_string
 
             search_string['Episode'].append(episode_string.strip())
 

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -121,10 +121,8 @@ class Anizb(NZBProvider):
         """Override the default _get_size to prevent it from extracting using the default tags."""
         return try_int(item.get('size'))
 
-    def _get_episode_search_strings(self, episode, add_string=''):
+    def _get_episode_search_strings(self, episode):
         """Get episode search strings."""
-        _ = add_string
-
         if not episode:
             return []
 
@@ -139,9 +137,9 @@ class Anizb(NZBProvider):
             if show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
                                                  indexer=episode.show.indexer):
                 # This is apparently a season exception, let's use the scene_episode instead of absolute
-                ep = int(episode.scene_episode)
+                ep = episode.scene_episode
             else:
-                ep = int(episode.scene_absolute_number)
+                ep = episode.scene_absolute_number
             episode_string += str(ep)
 
             search_string['Episode'].append(episode_string.strip())

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -69,17 +69,19 @@ def set_last_refresh(ex_list):
     )
 
 
-def get_scene_exceptions(indexer_id, season=-1):
+def get_scene_exceptions(indexer_id, season=-1, indexer=1):
     """Given a indexer_id, return a list of all the scene exceptions."""
     exceptions_list = []
 
     if indexer_id not in exceptionsCache or season not in exceptionsCache[indexer_id]:
         cache_db_con = db.DBConnection('cache.db')
-        exceptions = cache_db_con.select(b'SELECT show_name FROM scene_exceptions WHERE indexer_id = ? AND season = ?',
-                                         [indexer_id, season])
+        exceptions = cache_db_con.select(b'SELECT show_name FROM scene_exceptions WHERE '
+                                         b'indexer = ? AND indexer_id = ? AND season = ?',
+                                         [indexer, indexer_id, season])
         if exceptions:
             exceptions_list = list({cur_exception[b'show_name'] for cur_exception in exceptions})
 
+            # TODO: Refactor exceptionCache to be usable by multiple indexers.
             if indexer_id not in exceptionsCache:
                 exceptionsCache[indexer_id] = {}
             exceptionsCache[indexer_id][season] = exceptions_list

--- a/pytest.ini
+++ b/pytest.ini
@@ -90,6 +90,7 @@ flake8-ignore =
     medusa/nzb_splitter.py D100 D202 D400
     medusa/nzbget.py D100 D400 D401 N802 N806
     medusa/process_tv.py D100 D101 D102 D103 D202 D400 E265 N802 N803 N806
+    medusa/providers/nzb/anizb.py F841
     medusa/recompiled/__init__.py D104
     medusa/recompiled/tags.py D100
     medusa/rss_feeds.py D100 D103 N802

--- a/pytest.ini
+++ b/pytest.ini
@@ -90,7 +90,6 @@ flake8-ignore =
     medusa/nzb_splitter.py D100 D202 D400
     medusa/nzbget.py D100 D400 D401 N802 N806
     medusa/process_tv.py D100 D101 D102 D103 D202 D400 E265 N802 N803 N806
-    medusa/providers/nzb/anizb.py F841
     medusa/recompiled/__init__.py D104
     medusa/recompiled/tags.py D100
     medusa/rss_feeds.py D100 D103 N802

--- a/tests/legacy/scene_helpers_tests.py
+++ b/tests/legacy/scene_helpers_tests.py
@@ -39,7 +39,8 @@ class SceneTests(test.AppTestDBCase):
     def test_all_possible_show_names(self):
         # common.sceneExceptions[-1] = ['Exception Test']
         test_cache_db_con = db.DBConnection('cache.db')
-        test_cache_db_con.action("INSERT INTO scene_exceptions (indexer_id, show_name, season) VALUES (?,?,?)", [-1, 'Exception Test', -1])
+        test_cache_db_con.action("INSERT INTO scene_exceptions (indexer, indexer_id, show_name, season) "
+                                 "VALUES (?,?,?,?)", [1, -1, 'Exception Test', -1])
         common.countryList['Full Country Name'] = 'FCN'
 
         self._test_all_possible_show_names('Show Name', expected=['Show Name'])


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

If a anime show has a season scene exception with a scene_season > 1 use the scene_episode (indexers) as episode number.

As an example. The show ajin with season scene exception "Ajin 2nd season" for season 2. Searching for absolute episode 26, will now search for Ajin 2nd season 13, instead of Ajin 2nd season 26, as it is currently.

* Made sure get_scene_exceptions is multi-indexer.
* Use * wildcard for anizb searches, to increase results.