### PR TITLE
Don't fall back to show ID. Reverts #1957

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -214,7 +214,7 @@ class GenericProvider(object):
             pubdate = self._get_pubdate(item)
 
             try:
-                parse_result = NameParser(show=self.show, parse_method=('normal', 'anime')[show.is_anime]).parse(title)
+                parse_result = NameParser(parse_method=('normal', 'anime')[show.is_anime]).parse(title)
             except (InvalidNameException, InvalidShowException) as error:
                 logger.log(u"{error}".format(error=error), logger.DEBUG)
                 continue


### PR DESCRIPTION
As it can cause wrong results to be associated with the searched show.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
