### PR TITLE
Anime: Changed single digit absolute numbers to double digit, with a …

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -469,9 +469,9 @@ class GenericProvider(object):
                     show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
                                                       indexer=episode.show.indexer)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
-                    ep = episode.scene_episode
+                    ep = int(episode.scene_episode)
                 else:
-                    ep = episode.scene_absolute_number
+                    ep = int(episode.scene_absolute_number)
                 episode_string_fallback = episode_string + '{episode:03d}'.format(episode=ep)
                 episode_string += '{episode:02d}'.format(episode=ep)
             else:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -508,7 +508,7 @@ class GenericProvider(object):
             elif episode.show.anime:
                 episode_string += 'Season'
             else:
-                episode_string += 'S%02d' % int(episode.season)
+                episode_string += 'S{season:0>2}'.format(season=episode.season)
 
             search_string['Season'].append(episode_string.strip())
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -469,11 +469,11 @@ class GenericProvider(object):
                     show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
                                                       indexer=episode.show.indexer)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
-                    ep = int(episode.scene_episode)
+                    ep = episode.scene_episode
                 else:
-                    ep = int(episode.scene_absolute_number)
-                episode_string_fallback = episode_string + '{episode:03d}'.format(episode=ep)
-                episode_string += '{episode:02d}'.format(episode=ep)
+                    ep = episode.scene_absolute_number
+                episode_string_fallback = episode_string + '{episode:0>3}'.format(episode=ep)
+                episode_string += '{episode:0>2}'.format(episode=ep)
             else:
                 episode_string += config.naming_ep_type[2] % {
                     'seasonnumber': episode.scene_season,

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -53,6 +53,7 @@ class Anizb(NZBProvider):
         # Miscellaneous Options
         self.supports_absolute_numbering = True
         self.anime_only = True
+        self.search_separator = '*'
 
         # Torrent Stats
 
@@ -120,31 +121,6 @@ class Anizb(NZBProvider):
     def _get_size(self, item):
         """Override the default _get_size to prevent it from extracting using the default tags."""
         return try_int(item.get('size'))
-
-    def _get_episode_search_strings(self, episode):
-        """Get episode search strings."""
-        if not episode:
-            return []
-
-        search_string = {
-            'Episode': []
-        }
-
-        for show_name in allPossibleShowNames(episode.show, season=episode.scene_season):
-            episode_string = show_name + '*'
-
-            # If the showname is a season scene exception, we want to use the indexer episode number.
-            if show_name in get_scene_exceptions(episode.show.indexerid, season=episode.scene_season,
-                                                 indexer=episode.show.indexer):
-                # This is apparently a season exception, let's use the scene_episode instead of absolute
-                ep = '{episode:02d}'.format(episode=episode.scene_episode)
-            else:
-                ep = episode.scene_absolute_number
-            episode_string += str(ep)
-
-            search_string['Episode'].append(episode_string.strip())
-
-        return [search_string]
 
 
 provider = Anizb()

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -27,9 +27,6 @@ from ... import logger, tv_cache
 from ...bs4_parser import BS4Parser
 from ...helper.common import try_int
 
-from ...scene_exceptions import get_scene_exceptions
-from ...show_name_helpers import allPossibleShowNames
-
 
 class Anizb(NZBProvider):
     """Nzb Provider using the open api of anizb.org for daily (rss) and backlog/forced searches."""

--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -195,9 +195,9 @@ class BTNProvider(TorrentProvider):
             # Search for the year of the air by date show
             current_params['name'] = str(ep_obj.airdate).split('-')[0]
         elif ep_obj.show.is_anime:
-            current_params['name'] = '%d' % ep_obj.scene_absolute_number
+            current_params['name'] = '{0:d}'.format(ep_obj.scene_absolute_number)
         else:
-            current_params['name'] = 'Season ' + str(ep_obj.season)
+            current_params['name'] = 'Season {0}'.format(ep_obj.scene_season)
 
         # Search
         if ep_obj.show.indexer == 1:
@@ -228,7 +228,7 @@ class BTNProvider(TorrentProvider):
             # combined with the series identifier should result in just one episode
             search_params['name'] = date_str.replace('-', '.')
         elif ep_obj.show.anime:
-            search_params['name'] = '%i' % int(ep_obj.scene_absolute_number)
+            search_params['name'] = '{ep:d}'.format(ep=int(ep_obj.scene_absolute_number))
         else:
             # Do a general name search for the episode, formatted like SXXEYY
             search_params['name'] = '{ep}'.format(ep=episode_num(ep_obj.season, ep_obj.episode))

--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -65,7 +65,7 @@ class BTNProvider(TorrentProvider):
         self.minleech = None
 
         # Cache
-        self.cache = tv_cache.TVCache(self, min_time=15)  # Only poll BTN every 15 minutes max
+        self.cache = tv_cache.TVCache(self, min_time=10)  # Only poll BTN every 15 minutes max
 
     def search(self, search_strings, age=0, ep_obj=None):  # pylint:disable=too-many-locals
         """
@@ -194,10 +194,8 @@ class BTNProvider(TorrentProvider):
         if ep_obj.show.air_by_date or ep_obj.show.sports:
             # Search for the year of the air by date show
             current_params['name'] = str(ep_obj.airdate).split('-')[0]
-        elif ep_obj.show.is_anime:
-            current_params['name'] = '{0:d}'.format(ep_obj.scene_absolute_number)
         else:
-            current_params['name'] = 'Season {0}'.format(ep_obj.scene_season)
+            current_params['name'] = 'Season {0}'.format(ep_obj.season)
 
         # Search
         if ep_obj.show.indexer == 1:
@@ -227,8 +225,6 @@ class BTNProvider(TorrentProvider):
             # BTN uses dots in dates, we just search for the date since that
             # combined with the series identifier should result in just one episode
             search_params['name'] = date_str.replace('-', '.')
-        elif ep_obj.show.anime:
-            search_params['name'] = '{ep:d}'.format(ep=int(ep_obj.scene_absolute_number))
         else:
             # Do a general name search for the episode, formatted like SXXEYY
             search_params['name'] = '{ep}'.format(ep=episode_num(ep_obj.season, ep_obj.episode))

--- a/medusa/providers/torrent/json/hdbits.py
+++ b/medusa/providers/torrent/json/hdbits.py
@@ -160,7 +160,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'episode': '%i' % int(episode.scene_absolute_number)
+                    'episode': "{0:d}".format(int(episode.scene_absolute_number))
                 }
             else:
                 post_data['tvdb'] = {
@@ -178,7 +178,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'season': '%d' % season.scene_absolute_number,
+                    'season': "{0:d}".format(season.scene_absolute_number),
                 }
             else:
                 post_data['tvdb'] = {

--- a/medusa/providers/torrent/json/hdbits.py
+++ b/medusa/providers/torrent/json/hdbits.py
@@ -160,7 +160,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'episode': "{0:d}".format(int(episode.scene_absolute_number))
+                    'episode': "{0}".format(episode.scene_absolute_number)
                 }
             else:
                 post_data['tvdb'] = {
@@ -178,7 +178,7 @@ class HDBitsProvider(TorrentProvider):
             elif show.anime:
                 post_data['tvdb'] = {
                     'id': show.indexerid,
-                    'season': "{0:d}".format(season.scene_absolute_number),
+                    'season': "{0}".format(season.scene_absolute_number),
                 }
             else:
                 post_data['tvdb'] = {


### PR DESCRIPTION
…triple digit fallback.

* Added a search_separator attribute to the GenericProvider, to specify the separator for search strings. For example, anidb uses '*' instead of space. So we now only override this for anidb, instead of using a 99% the same _get_episode_search_strings() method.
* Changed hdbits and btn, as they don't make use of the get_episode_search_string.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Should fix #1978 
