### PR TITLE
Refactor generic provider search

### DIFF
--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
-"""Classes module."""
+"""Collection of generic used classes."""
 import logging
 
 from dateutil import parser
@@ -121,6 +121,7 @@ class SearchResult(object):
 
 class EvaluateSearchResult(SearchResult):
     """A subclass of SearchResult, to use as an evaluation class."""
+
     def __init__(self, episodes=None, provider=None):
         super(EvaluateSearchResult, self).__init__(episodes)
         # Reference to the search_provider

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -37,8 +37,12 @@ class ApplicationURLopener(FancyURLopener, object):
 class SearchResult(object):
     """Represents a search result from an indexer."""
 
-    def __init__(self, episodes=None):
-        self.provider = None
+    def __init__(self, episodes=None, provider=None):
+        # list of Episode objects that this result is associated with
+        self.episodes = episodes
+
+        # the search provider
+        self.provider = provider
 
         # release show object
         self.show = None
@@ -48,9 +52,6 @@ class SearchResult(object):
 
         # used by some providers to store extra info associated with the result
         self.extraInfo = []
-
-        # list of Episode objects that this result is associated with
-        self.episodes = episodes
 
         # quality of the release
         self.quality = Quality.UNKNOWN
@@ -91,50 +92,59 @@ class SearchResult(object):
         # Result type like: nzb, nzbdata, torrent
         self.resultType = u''
 
-        # Store the parse result, as it might be usefull of other information later on.
+        # Store the parse result, as it might be useful for other information later on.
         self.parsed_result = None
+
+        # Reference to the search_provider
+        self.provider = provider
+
+        # Raw result in a dictionary
+        self.item = None
+
+        # Search flag for specifying if we want to re-download the already downloaded quality.
+        self.download_current_quality = None
+
+        # Search flag for adding or not adding the search result to cache.
+        self.add_cache_entry = True
+
+        # Search flag for flagging if this is a same-day-special.
+        self.same_day_special = False
+
+        # Keep track if we really want to result.
+        self.result_wanted = False
+
+        # The actual parsed season.
+        self.actual_season = None
+
+        # The actual parsed episode.
+        self.actual_episodes = None
+
+        # Flag for multi-epp search result.
+        self.multi_epp = False
 
     def __str__(self):
 
         if self.provider is None:
             return u'Invalid provider, unable to print self'
 
-        my_string = u'{} @ {}\n'.format(self.provider.name, self.url)
+        my_string = u'{0} @ {1}\n'.format(self.provider.name, self.url)
         my_string += u'Extra Info:\n'
         for extra in self.extraInfo:
-            my_string += u' {}\n'.format(extra)
+            my_string += u' {0}\n'.format(extra)
 
         my_string += u'Episodes:\n'
         for ep in self.episodes:
-            my_string += u' {}\n'.format(ep)
+            my_string += u' {0}\n'.format(ep)
 
-        my_string += u'Quality: {}\n'.format(Quality.qualityStrings[self.quality])
-        my_string += u'Name: {}\n'.format(self.name)
-        my_string += u'Size: {}\n'.format(self.size)
-        my_string += u'Release Group: {}\n'.format(self.release_group)
+        my_string += u'Quality: {0}\n'.format(Quality.qualityStrings[self.quality])
+        my_string += u'Name: {0}\n'.format(self.name)
+        my_string += u'Size: {0}\n'.format(self.size)
+        my_string += u'Release Group: {0}\n'.format(self.release_group)
 
         return my_string
 
     def file_name(self):
-        return u'{}.{}'.format(self.episodes[0].pretty_name(), self.resultType)
-
-
-class EvaluateSearchResult(SearchResult):
-    """A subclass of SearchResult, to use as an evaluation class."""
-
-    def __init__(self, episodes=None, provider=None):
-        super(EvaluateSearchResult, self).__init__(episodes)
-        # Reference to the search_provider
-        self.provider = provider
-        # Raw result in a dictionary
-        self.item = None
-        self.download_current_quality = None
-        self.add_cache_entry = True
-        self.same_day_special = False
-        self.result_wanted = False
-        self.actual_season = None
-        self.actual_episodes = None
-        self.multi_epp = False
+        return u'{0}.{1}'.format(self.episodes[0].pretty_name(), self.resultType)
 
     def add_result_to_cache(self, cache):
         """Cache the item if needed."""
@@ -180,7 +190,7 @@ class EvaluateSearchResult(SearchResult):
         self.pubdate = provider._get_pubdate(self.item)
 
 
-class NZBSearchResult(EvaluateSearchResult):
+class NZBSearchResult(SearchResult):
     """Regular NZB result with an URL to the NZB."""
 
     def __init__(self, episodes, provider=None):
@@ -188,7 +198,7 @@ class NZBSearchResult(EvaluateSearchResult):
         self.resultType = u'nzb'
 
 
-class NZBDataSearchResult(EvaluateSearchResult):
+class NZBDataSearchResult(SearchResult):
     """NZB result where the actual NZB XML data is stored in the extraInfo."""
 
     def __init__(self, episodes, provider=None):
@@ -196,7 +206,7 @@ class NZBDataSearchResult(EvaluateSearchResult):
         self.resultType = u'nzbdata'
 
 
-class TorrentSearchResult(EvaluateSearchResult):
+class TorrentSearchResult(SearchResult):
     """Torrent result with an URL to the torrent."""
 
     def __init__(self, episodes, provider=None):

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
-
+"""Classes module."""
 import logging
 
 from dateutil import parser
@@ -117,6 +117,7 @@ class SearchResult(object):
 
 class EvaluateSearchResult(SearchResult):
     """A subclass of SearchResult, to use as an evaluation class."""
+
     def __init__(self, item, download_current_quality):
         super(EvaluateSearchResult, self).__init__(None)
         # Raw result in a dictionary
@@ -129,7 +130,7 @@ class EvaluateSearchResult(SearchResult):
         self.actual_episodes = None
 
     def add_result_to_cache(self, cache):
-        # Cache the item if needed
+        """Cache the item if needed."""
         if self.add_cache_entry:
             logger.debug('Adding item from search to cache: {release_name}', release_name=self.name)
             return cache.add_cache_entry(self.name, self.url, self.seeders,
@@ -137,7 +138,9 @@ class EvaluateSearchResult(SearchResult):
         return None
 
     def check_episodes_for_quality(self, forced_search, download_current_quality):
-        """We could have gotten a multi-ep result, let's see if at least one if them is wat we want
+        """Check if that episode is wanted in that quality.
+
+        We could have gotten a multi-ep result, let's see if at least one if them is what we want
         in the correct quality.
         """
         if not self.actual_episodes or self.actual_season:
@@ -330,6 +333,7 @@ class Viewer(object):
         :rtype: list of medusa.logger.LogLine
         """
         return sorted(self._errors.values(), key=lambda error: error.timestamp, reverse=True)
+
 
 try:
     import urllib

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -88,6 +88,7 @@ class SearchResult(object):
         # content
         self.content = None
 
+        # Result type like: nzb, nzbdata, torrent
         self.resultType = u''
 
     def __str__(self):
@@ -128,6 +129,7 @@ class EvaluateSearchResult(SearchResult):
         self.episode_wanted = False
         self.actual_season = None
         self.actual_episodes = None
+        self.multi_epp = False
 
     def add_result_to_cache(self, cache):
         """Cache the item if needed."""

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -119,9 +119,6 @@ class SearchResult(object):
         # The actual parsed episode.
         self.actual_episodes = None
 
-        # Flag for multi-epp search result.
-        self.multi_epp = False
-
     def __str__(self):
 
         if self.provider is None:

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -140,7 +140,7 @@ class EvaluateSearchResult(SearchResult):
         """We could have gotten a multi-ep result, let's see if at least one if them is wat we want
         in the correct quality.
         """
-        if not self.actual_episodes or self.action_season:
+        if not self.actual_episodes or self.actual_season:
             return False
 
         episode_wanted = False

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -148,6 +148,7 @@ class NameParser(object):
                                                                        result.show.indexer, absolute_episode,
                                                                        True, scene_season)
 
+                # Translate the absolute episode number, back to the indexers season and episode.
                 (s, e) = helpers.get_all_episodes_from_absolute_number(result.show, [a])
                 logger.debug("Scene numbering enabled show '{name}' using indexer for absolute {absolute}: {ep}",
                              name=result.show.name, absolute=a, ep=episode_num(s, e, 'absolute'))
@@ -202,6 +203,13 @@ class NameParser(object):
         if new_season_numbers and new_episode_numbers:
             result.episode_numbers = new_episode_numbers
             result.season_number = new_season_numbers[0]
+
+        # For anime that we still couldn't get a season, let's assume we should use 1.
+        if result.show.is_anime and result.season_number is None and result.episode_numbers:
+            result.season_number = 1
+            logger.warn("For this anime show {name}, we couldn't parse a season number, "
+                        "let's assume it's an absolute numbered anime show with season 1",
+                        name=result.show.name)
 
         if result.show.is_scene:
             logger.debug('Converted parsed result {original} into {result}', original=result.original_name,

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -357,10 +357,8 @@ class GenericProvider(object):
                 continue
 
             if not manual_search:
-                # Use all the previous rules to decide if we want to go on with this result.
                 # The second check, will loop through actual_episodes and check if there's anything useful in it.
-                if (not search_result.episode_wanted or
-                        not search_result.check_episodes_for_quality(forced_search, download_current_quality)):
+                if not search_result.check_episodes_for_quality(forced_search, download_current_quality):
                     logger.log('Ignoring result %s.' % search_result.name, logger.DEBUG)
                     continue
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -260,7 +260,7 @@ class GenericProvider(object):
                 self.episode_wanted = False
 
             def __str__(self):
-                return 'A SearchResult class for item: {title}'.format(item=self.item)
+                return 'A SearchResult class for item: {title}'.format(title=self.title)
 
         for item in items_list:
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -238,8 +238,6 @@ class GenericProvider(object):
         search_results = []
         for item in items_list:
 
-            # search_result = EvaluateSearchResult(item=item, download_current_quality=download_current_quality,
-            #                                      provider=self)
             # Make sure we start with a TorrentSearchResult, NZBDataSearchResult or NZBSearchResult search result obj.
             search_result = self.get_result()
             search_results.append(search_result)
@@ -283,7 +281,8 @@ class GenericProvider(object):
                             search_result.result_wanted = False
                             continue
                         elif not [ep for ep in episodes if
-                                  search_result.parsed_result.season_number == (ep.season, ep.scene_season)[ep.show.is_scene]]:
+                                  search_result.parsed_result.season_number == (ep.season, ep.scene_season)
+                                  [ep.show.is_scene]]:
                             logger.log(
                                 'This season result %s is for a season we are not searching for, '
                                 'skipping it' % search_result.name,
@@ -315,7 +314,8 @@ class GenericProvider(object):
                         if not [searched_episode for searched_episode in episodes
                                 if searched_episode.season == search_result.parsed_result.season_number and
                                 (searched_episode.episode, searched_episode.scene_episode)
-                                [searched_episode.show.is_scene] in search_result.parsed_result.episode_numbers]:
+                                [searched_episode.show.is_scene] in
+                                search_result.parsed_result.episode_numbers]:
                             logger.log(
                                 "The result %s doesn't seem to match an episode that we are currently trying to "
                                 "snatch, skipping it" % search_result.name, logger.DEBUG
@@ -513,9 +513,9 @@ class GenericProvider(object):
             elif episode.show.anime:
                 # If the showname is a season scene exception, we want to use the indexer episode number.
                 if (episode.scene_season > 1 and
-                    show_name in get_scene_exceptions(episode.show.indexerid,
-                                                      episode.show.indexer,
-                                                      episode.scene_season)):
+                            show_name in get_scene_exceptions(episode.show.indexerid,
+                                                              episode.show.indexer,
+                                                              episode.scene_season)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
                     ep = episode.scene_episode
                 else:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -313,8 +313,8 @@ class GenericProvider(object):
 
                         # Compare the episodes and season from the result with what was searched.
                         if not [searched_episode for searched_episode in episodes
-                                if searched_episode.season == search_result.parsed_result.season_number
-                                and (searched_episode.episode, searched_episode.scene_episode)
+                                if searched_episode.season == search_result.parsed_result.season_number and
+                                (searched_episode.episode, searched_episode.scene_episode)
                                 [searched_episode.show.is_scene] in search_result.parsed_result.episode_numbers]:
                             logger.log(
                                 "The result %s doesn't seem to match an episode that we are currently trying to "

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -513,9 +513,9 @@ class GenericProvider(object):
             elif episode.show.anime:
                 # If the showname is a season scene exception, we want to use the indexer episode number.
                 if (episode.scene_season > 1 and
-                            show_name in get_scene_exceptions(episode.show.indexerid,
-                                                              episode.show.indexer,
-                                                              episode.scene_season)):
+                        show_name in get_scene_exceptions(episode.show.indexerid,
+                                                          episode.show.indexer,
+                                                          episode.scene_season)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
                     ep = episode.scene_episode
                 else:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -404,7 +404,7 @@ class GenericProvider(object):
 
         return quality
 
-    def get_result(self, episodes, search_result):
+    def get_result(self, episodes):
         """Get result."""
         result = self._get_result(episodes)
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -282,9 +282,9 @@ class GenericProvider(object):
                             )
                             add_cache_entry = True
 
-                    if not add_cache_entry:
-                        actual_season = parse_result.season_number
-                        actual_episodes = parse_result.episode_numbers
+                    # we've added the results to cache, now assign them to the found season, episodes vars.
+                    actual_season = parse_result.season_number
+                    actual_episodes = parse_result.episode_numbers
                 else:
                     same_day_special = False
 
@@ -333,8 +333,6 @@ class GenericProvider(object):
 
                 if ci is not None:
                     cl.append(ci)
-
-                continue
 
             episode_wanted = True
 

--- a/medusa/providers/nzb/nzb_provider.py
+++ b/medusa/providers/nzb/nzb_provider.py
@@ -37,7 +37,7 @@ class NZBProvider(GenericProvider):
 
     def _get_result(self, episodes):
         """Return provider result."""
-        return NZBSearchResult(episodes)
+        return NZBSearchResult(episodes, provider=self)
 
     def _get_size(self, item):
         """Get result size."""

--- a/medusa/providers/torrent/torrent_provider.py
+++ b/medusa/providers/torrent/torrent_provider.py
@@ -54,8 +54,8 @@ class TorrentProvider(GenericProvider):
         return '&tr=' + '&tr='.join(x.strip() for x in app.TRACKERS_LIST.split(',') if x.strip())
 
     def _get_result(self, episodes):
-        """Return provider result."""
-        return TorrentSearchResult(episodes)
+        """Return a provider result object."""
+        return TorrentSearchResult(episodes, provider=self)
 
     def _get_size(self, item):
         """Get result size."""

--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -82,9 +82,9 @@ class SearchQueue(generic_queue.GenericQueue):
         length = {'backlog': 0, 'daily': 0}
         for cur_item in self.queue:
             if isinstance(cur_item, DailySearchQueueItem):
-                length['daily'] += 1
+                length[b'daily'] += 1
             elif isinstance(cur_item, BacklogQueueItem):
-                length['backlog'] += 1
+                length[b'backlog'] += 1
         return length
 
     def add_item(self, item):
@@ -171,11 +171,11 @@ class ForcedSearchQueue(generic_queue.GenericQueue):
         length = {'forced_search': 0, 'manual_search': 0, 'failed': 0}
         for cur_item in self.queue:
             if isinstance(cur_item, FailedQueueItem):
-                length['failed'] += 1
+                length[b'failed'] += 1
             elif isinstance(cur_item, ForcedSearchQueueItem) and not cur_item.manual_search:
-                length['forced_search'] += 1
+                length[b'forced_search'] += 1
             elif isinstance(cur_item, ForcedSearchQueueItem) and cur_item.manual_search:
-                length['manual_search'] += 1
+                length[b'manual_search'] += 1
         return length
 
     def add_item(self, item):
@@ -401,15 +401,15 @@ class ManualSnatchQueueItem(generic_queue.QueueItem):
 
         search_result = providers.get_provider_class(self.provider).get_result(self.segment)
         search_result.show = self.show
-        search_result.url = self.cached_result['url']
-        search_result.quality = int(self.cached_result['quality'])
-        search_result.name = self.cached_result['name']
-        search_result.size = int(self.cached_result['size'])
-        search_result.seeders = int(self.cached_result['seeders'])
-        search_result.leechers = int(self.cached_result['leechers'])
-        search_result.release_group = self.cached_result['release_group']
-        search_result.version = int(self.cached_result['version'])
-        search_result.proper_tags = self.cached_result['proper_tags'].split('|') if self.cached_result['proper_tags'] else u''
+        search_result.url = self.cached_result[b'url']
+        search_result.quality = int(self.cached_result[b'quality'])
+        search_result.name = self.cached_result[b'name']
+        search_result.size = int(self.cached_result[b'size'])
+        search_result.seeders = int(self.cached_result[b'seeders'])
+        search_result.leechers = int(self.cached_result[b'leechers'])
+        search_result.release_group = self.cached_result[b'release_group']
+        search_result.version = int(self.cached_result[b'version'])
+        search_result.proper_tags = self.cached_result[b'proper_tags'].split('|') if self.cached_result[b'proper_tags'] else ''
         search_result.manually_searched = True
 
         try:

--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Medusa. If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import unicode_literals
 
 import threading
 import time

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -412,7 +412,6 @@ class Cache(object):
 
     def add_cache_entry(self, name, url, seeders, leechers, size, pubdate, parsed_result=None):
         """Add item into cache database."""
-
         try:
             # Use the already passed parsed_result of possible.
             parse_result = parsed_result or NameParser().parse(name)

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -410,10 +410,12 @@ class Cache(object):
 
         return True
 
-    def add_cache_entry(self, name, url, seeders, leechers, size, pubdate):
+    def add_cache_entry(self, name, url, seeders, leechers, size, pubdate, parsed_result=None):
         """Add item into cache database."""
+
         try:
-            parse_result = NameParser().parse(name)
+            # Use the already passed parsed_result of possible.
+            parse_result = parsed_result or NameParser().parse(name)
         except (InvalidNameException, InvalidShowException) as error:
             logger.log('{0}'.format(error), logger.DEBUG)
             return None


### PR DESCRIPTION
This started as a PR to change the following apparent issue:
Apparently someone decided that when finding new results we store them in cache and then continue. This results in users having to perform two forced searches for a single episode.

While trying to come up with a proper fix for this issue. I noticed I had to make some more changes to fix it, without causing any new bugs. That's why i've decided to rewrite part of the GenericProvider search code.

This PR's has made some design choices, that could be debatable. And i'm open for that. I can provide arguments for most of them, but if anything can be done in a better/different way, let me know. In short i've made the following changes:

* Added a new class EvaluateSearchResult(SearchResult), that can be used as a Search result object, before we know if we want to keep this search result. Where the SearchResult was created at the end of "find_search_results" method, this is created at the start, and keeps more information. It could be argued to move all the logic for this class to SearchResult. But I like to keep it separated for now, although it doesn't have much use.
https://github.com/pymedusa/Medusa/pull/1997/files#diff-90b4db298132f61ff3ce451582cd4a63R122

* ASIS evaluated a providers result, for some criteria, like are we searching for a season pack (no), but the result is a season pack, then we dont want it now, but store it for later use. I've changed it to always store it in db. Then we start with a result that we want. And depending on passing some rules, it could change to a result we don't want.

* ASIS had a rule in tv_cache, where it set the season to 1, when it was not known. I've moved this to NameParser(), and only applied this to anime shows.
Note! I've added a warning. We might want to remove this. For now, it provides me better insight.
https://github.com/pymedusa/Medusa/pull/1997/files#diff-d17c57ab2ebb88b02c4ffb79a717869dR210
issue: #2013 

* ASIS had rule that would compare the parsed season (that's what the parser does, it already translates back) with the shows (indexer) season. I've changed to always compare it to the shows season.
@ratoaq2, i've also tried changing NameParser to return the scene_season, but that results in issues in other parts of medusa, where it compares against season.
https://github.com/pymedusa/Medusa/pull/1997/files#diff-9d0f0252087dd8c8f49e52642069a136R290

* ASIS used an any() with some evaluations. I've cut these up into smaller (better readable) evaluations.
https://github.com/pymedusa/Medusa/pull/1997/files#diff-9d0f0252087dd8c8f49e52642069a136L247

* ASIS did a NameParse for every item in the GenericProviders find_search_result method. And then for items that needed to be cached, they where parsed again. Although by then they where probably retrieved from cache, I think this is still resources wasted. I've added the parse result, to the result object. If available tv_cache will also use it.
https://github.com/pymedusa/Medusa/pull/1997/files#diff-cf2820685ee338f116fea75df512b6e2R370

* I've moved some of the result evaluations to the EvaluateSearchResult() class. This improves readability.

## Performance
I have to confess, I do not know what impact these changes have on performance. So we should try to perform some comparable test on low-end hardware using some larger libraries.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
