### PR TITLE
Fix manageTorrents not showing up if client url is not https and glob…

### DIFF
--- a/views/partials/header.mako
+++ b/views/partials/header.mako
@@ -63,7 +63,7 @@
                     % if app.USE_EMBY and app.EMBY_HOST != "" and app.EMBY_APIKEY != "":
                         <li><a href="home/updateEMBY/"><i class="menu-icon-emby"></i>&nbsp;Update Emby</a></li>
                     % endif
-                    % if app.USE_TORRENTS and app.TORRENT_METHOD != 'blackhole' and (app.ENABLE_HTTPS and app.TORRENT_HOST[:5] == 'https' or not app.ENABLE_HTTPS and app.TORRENT_HOST[:5] == 'http:'):
+                    % if app.USE_TORRENTS and app.TORRENT_METHOD != 'blackhole' and app.TORRENT_HOST[:4] == 'http':
                         <li><a href="manage/manageTorrents/"><i class="menu-icon-bittorrent"></i>&nbsp;Manage Torrents</a></li>
                     % endif
                     % if app.USE_FAILED_DOWNLOADS:


### PR DESCRIPTION
…al setting enable_https is set

enable_https has nothing to do with client url.
for example transmission doesn't have https webserver
