### PR TITLE
Fix anime detection

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1066,7 +1066,16 @@ class AnimeAbsoluteEpisodeNumbers(Rule):
 
         # if it's not detected as anime and season (weak_duplicate) is not 0, then skip.
         if not matches.named('video_profile') and not matches.tagged('anime') and weak_duplicate.value > 0:
-            return
+            is_anime = False
+            groups = matches.markers.named('group')
+            for group in groups:
+                screen_size = matches.range(group.start, group.end, index=0, predicate=lambda match: match.name == 'screen_size')
+                if screen_size:
+                    is_anime = True
+                    screen_size.tags.append('anime')
+                    break
+            if not is_anime:
+                return
 
         fileparts = matches.markers.named('path')
         for filepart in marker_sorted(fileparts, matches):

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4112,3 +4112,14 @@
   release_group: 2HD
   screen_size: 720p
   type: episode
+
+# Regression 1986: Anime should be detected
+? Show Name - 722 [HD_1280x720].mp4
+: title: Show Name
+  absolute_episode: 722
+  episode: 722
+  other: HD
+  screen_size: 720p
+  container: mp4
+  mimetype: video/mp4
+  type: episode


### PR DESCRIPTION
Fix for #1986

Detect release as anime when screen_size is inside a group (e.g.: [720p] or [HD_1280x720p])
