### PR TITLE
Split up get_scene_exceptions in get and update.

### DIFF
--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -89,7 +89,7 @@ def saveNameCacheToDb():
         cache_db_con.action("INSERT OR REPLACE INTO scene_names (indexer_id, name) VALUES (?, ?)", [indexer_id, name])
 
 
-def build_name_cache(show=None, force=False):
+def build_name_cache(show=None):
     """Build internal name cache
 
     :param show: Specify show to build name cache for, if None, just do all shows
@@ -112,7 +112,7 @@ def build_name_cache(show=None, force=False):
         ), logger.DEBUG)
 
     with nameCacheLock:
-        retrieve_exceptions(force)
+        retrieve_exceptions()
 
     # Create cache from db for the scene_exceptions.
     refresh_exceptions_cache()

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -99,13 +99,20 @@ def build_name_cache(show=None):
         """Builds the name cache for a single show."""
         indexer_id = show.indexerid
         clear_cache(indexer_id)
+
+        # Add original name to name cache
+        show_name = full_sanitize_scene_name(show.name)
+        name_cache[show_name] = indexer_id
+
+        # Add scene exceptions to name cache
         scene_exceptions = exceptions_cache[indexer_id]
         names = {
             full_sanitize_scene_name(name): int(indexer_id)
             for season_exceptions in scene_exceptions.values()
             for name in season_exceptions
         }
-        name_cache.update()
+        name_cache.update(names)
+
         logger.log(u'Internal name cache for {show} set to: [{names}]'.format(
             show=show.name,
             names=names.keys()

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -118,9 +118,9 @@ def build_name_cache(show=None):
     refresh_exceptions_cache()
 
     if not show:
-        logger.log(u"Building internal name cache for all shows", logger.INFO)
+        logger.log(u'Building internal name cache for all shows', logger.INFO)
         for show in app.showList:
             _cache_name(show)
     else:
-        logger.log(u"Building internal name cache for " + show.name, logger.DEBUG)
+        logger.log(u'Building internal name cache for '.format(show.name), logger.DEBUG)
         _cache_name(show)

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -68,7 +68,7 @@ def clear_cache(indexerid=0):
     cache_db_con = db.DBConnection('cache.db')
     cache_db_con.action(
         "DELETE FROM scene_names "
-        "WHERE indexer_id = 0 or"
+        "WHERE indexer_id = 0 OR"
         "    indexer_id = ?",
         [indexerid]
     )

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -68,8 +68,9 @@ def clear_cache(indexerid=0):
     cache_db_con = db.DBConnection('cache.db')
     cache_db_con.action(
         "DELETE FROM scene_names "
-        "WHERE indexer_id IN ?",
-        [indexer_ids]
+        "WHERE indexer_id = 0 or"
+        "    indexer_id = ?",
+        [indexerid]
     )
     to_remove = (
         key

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -23,9 +23,9 @@ from six import iteritems
 from . import app, db, logger
 from .helpers import full_sanitize_scene_name
 from .scene_exceptions import (
+    exceptions_cache,
     refresh_exceptions_cache,
     retrieve_exceptions,
-    exceptions_cache,
 )
 
 name_cache = {}

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -122,5 +122,5 @@ def build_name_cache(show=None):
         for show in app.showList:
             _cache_name(show)
     else:
-        logger.log(u'Building internal name cache for '.format(show.name), logger.DEBUG)
+        logger.log(u'Building internal name cache for {show}'.format(show=show.name), logger.DEBUG)
         _cache_name(show)

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -85,7 +85,7 @@ def build_name_cache(show=None, force=False):
     def _cache_name(show):
         """Builds the name cache for a single show."""
         clear_cache(show.indexerid)
-        for season in [-1] + get_scene_seasons(show.indexerid):
+        for season in get_scene_seasons(show.indexerid):
             for name in set(get_scene_exceptions(show.indexerid, show.indexer, season=season) + [show.name]):
                 name = full_sanitize_scene_name(name)
                 if name in name_cache:

--- a/medusa/name_cache.py
+++ b/medusa/name_cache.py
@@ -76,10 +76,11 @@ def saveNameCacheToDb():
         cache_db_con.action("INSERT OR REPLACE INTO scene_names (indexer_id, name) VALUES (?, ?)", [indexer_id, name])
 
 
-def build_name_cache(show=None):
+def build_name_cache(show=None, force=False):
     """Build internal name cache
 
     :param show: Specify show to build name cache for, if None, just do all shows
+    :param force: Force the build name cache. Do not depend on the scene_exception_refresh table.
     """
     def _cache_name(show):
         """Builds the name cache for a single show."""
@@ -98,7 +99,7 @@ def build_name_cache(show=None):
         ), logger.DEBUG)
 
     with nameCacheLock:
-        retrieve_exceptions()
+        retrieve_exceptions(force)
 
     # Create cache from db for the scene_exceptions.
     refresh_exceptions_cache()

--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -88,7 +88,7 @@ def get_expected_titles(show_list):
     """
     expected_titles = []
     for show in show_list:
-        names = [show.name] + show.exceptions
+        names = {show.name}.union(show.exceptions)
         for name in names:
             if name.isdigit():
                 # do not add numbers to expected titles.

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -466,8 +466,9 @@ class GenericProvider(object):
             elif episode.show.anime:
                 # If the showname is a season scene exception, we want to use the indexer episode number.
                 if (episode.scene_season > 1 and
-                    show_name in get_scene_exceptions(episode.show.indexerid, episode.show.indexer,
-                                                      season=episode.scene_season)):
+                    show_name in get_scene_exceptions(episode.show.indexerid,
+                                                      episode.show.indexer,
+                                                      episode.scene_season)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
                     ep = episode.scene_episode
                 else:

--- a/medusa/providers/torrent/html/animetorrents.py
+++ b/medusa/providers/torrent/html/animetorrents.py
@@ -246,17 +246,20 @@ class AnimeTorrentsProvider(TorrentProvider):
             'Episode': []
         }
 
-        season_scene_names = scene_exceptions.get_scene_exceptions(episode.show.indexerid, episode.show.indexer,
-                                                                   season=episode.scene_season)
+        season_scene_names = scene_exceptions.get_scene_exceptions(
+            episode.show.indexerid,
+            episode.show.indexer,
+            episode.scene_season
+        )
 
-        for show_name in allPossibleShowNames(episode.show, season=episode.scene_season):
-            episode_string = '{name}%'.format(name=show_name)
-
-            if season_scene_names and show_name in season_scene_names:
+        for show_name in allPossibleShowNames(episode.show, episode.scene_season):
+            if show_name in season_scene_names:
                 episode_season = int(episode.scene_episode)
             else:
                 episode_season = int(episode.absolute_number)
-            episode_string += '{episode}'.format(episode=episode_season)
+            episode_string = '{name}%{episode}'.format(
+                name=show_name, episode=episode_season
+            )
 
             if add_string:
                 episode_string += '%{string}'.format(string=add_string)

--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -201,10 +201,11 @@ class BTNProvider(TorrentProvider):
             current_params['tvdb'] = self._get_tvdb_id()
             search_params.append(current_params)
         else:
-            name_exceptions = list(
-                set(scene_exceptions.get_scene_exceptions(ep_obj.show.indexerid,
-                                                          ep_obj.show.indexer) + [ep_obj.show.name]))
-            for name in name_exceptions:
+            name_exceptions = scene_exceptions.get_scene_exceptions(
+                ep_obj.show.indexerid,
+                ep_obj.show.indexer
+            )
+            for name in name_exceptions | {ep_obj.show.name}:
                 # Search by name if we don't have tvdb id
                 current_params['series'] = name
                 search_params.append(current_params)
@@ -235,10 +236,11 @@ class BTNProvider(TorrentProvider):
             to_return.append(search_params)
         else:
             # Add new query string for every exception
-            name_exceptions = list(
-                set(scene_exceptions.get_scene_exceptions(ep_obj.show.indexerid,
-                                                          ep_obj.show.indexer) + [ep_obj.show.name]))
-            for cur_exception in name_exceptions:
+            name_exceptions = scene_exceptions.get_scene_exceptions(
+                ep_obj.show.indexerid,
+                ep_obj.show.indexer
+            )
+            for cur_exception in name_exceptions | {ep_obj.show.name}:
                 # Search by name if we don't have tvdb id
                 search_params['series'] = cur_exception
                 to_return.append(search_params)

--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -205,7 +205,8 @@ class BTNProvider(TorrentProvider):
                 ep_obj.show.indexerid,
                 ep_obj.show.indexer
             )
-            for name in name_exceptions | {ep_obj.show.name}:
+            name_exceptions.add(ep_obj.show.name)
+            for name in name_exceptions:
                 # Search by name if we don't have tvdb id
                 current_params['series'] = name
                 search_params.append(current_params)
@@ -240,7 +241,8 @@ class BTNProvider(TorrentProvider):
                 ep_obj.show.indexerid,
                 ep_obj.show.indexer
             )
-            for cur_exception in name_exceptions | {ep_obj.show.name}:
+            name_exceptions.add(ep_obj.show.name)
+            for cur_exception in name_exceptions:
                 # Search by name if we don't have tvdb id
                 search_params['series'] = cur_exception
                 to_return.append(search_params)

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -426,7 +426,7 @@ def _get_anidb_exceptions():
                     continue
 
                 if anime and anime.name != show.name:
-                    indexer_id = text_type(show.indexerid)
+                    indexer_id = int(show.indexerid)
                     exceptions[indexer_id] = [{anime.name.decode('utf-8'): -1}]
 
         set_last_refresh('anidb')

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -30,7 +30,7 @@ from six import iteritems, text_type
 from . import app, db, helpers
 from .indexers.indexer_config import INDEXER_TVDBV2
 
-exceptions_cache = {}
+exceptions_cache = defaultdict(lambda: defaultdict(list))
 exceptions_season_cache = defaultdict(list)
 
 exceptionLock = threading.Lock()
@@ -60,10 +60,6 @@ def refresh_exceptions_cache():
         indexer_id = int(exception[b'indexer_id'])
         season = int(exception[b'season'])
         show = exception[b'show_name']
-
-        # Create exceptions_cache[indexerid]
-        if indexer_id not in exceptions_cache:
-            exceptions_cache[indexer_id] = defaultdict(list)
 
         # exceptions_cache[indexerid][season] = ['showname 1', 'showname 2']
         if show not in exceptions_cache[indexer_id][season]:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -173,10 +173,15 @@ def get_scene_exception_by_name_multiple(show_name):
 
 
 def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
-    """Given a indexer_id, and a list of all show scene exceptions, update the db."""
+    """Update database with all show scene exceptions by indexer_id."""
     cache_db_con = db.DBConnection('cache.db')
-    cache_db_con.action(b'DELETE FROM scene_exceptions WHERE indexer_id=? and season=? and indexer=?',
-                        [indexer_id, season, indexer])
+    cache_db_con.action(
+        b'DELETE FROM scene_exceptions '
+        b'WHERE indexer_id=? and '
+        b'    season=? and '
+        b'    indexer=?',
+        [indexer_id, season, indexer]
+    )
 
     logger.info('Updating scene exceptions...')
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -191,7 +191,10 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     # TODO: make sure we add indexer when the exceptions_cache changes
     exceptions_cache[indexer_id].clear()
 
-    decoded_scene_exceptions = [se.decode('utf-8') for se in scene_exceptions]
+    decoded_scene_exceptions = (
+        exception.decode('utf-8')
+        for exception in scene_exceptions
+    )
     for cur_exception in decoded_scene_exceptions:
         if indexer_id not in exceptions_cache:
             exceptions_cache[indexer_id] = {}

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -361,9 +361,10 @@ def _get_xem_exceptions():
             except (ValueError, AttributeError) as error:
                 logger.debug(
                     'Check scene exceptions update failed for {indexer}.'
-                    ' Unable to get URL: {xem_url}'.format(
+                    ' Unable to get URL: {xem_url} Error: {error}'.format(
                         indexer=indexer.name,
                         xem_url=url,
+                        error=error,
                     )
                 )
                 continue

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -33,7 +33,7 @@ from .indexers.indexer_config import INDEXER_TVDBV2
 
 logger = logging.getLogger(__name__)
 
-exceptions_cache = defaultdict(lambda: defaultdict(list))
+exceptions_cache = defaultdict(lambda: defaultdict(set))
 exceptionLock = threading.Lock()
 
 xem_session = helpers.make_session()
@@ -61,7 +61,7 @@ def refresh_exceptions_cache():
 
         # exceptions_cache[indexerid][season] = ['showname 1', 'showname 2']
         if show not in exceptions_cache[indexer_id][season]:
-            exceptions_cache[indexer_id][season].append(show)
+            exceptions_cache[indexer_id][season].add(show)
 
     logger.info('Finished processing {x} scene exceptions.', x=len(exceptions))
 
@@ -110,7 +110,7 @@ def get_scene_exceptions(indexer_id, indexer, season=-1):
     if season != -1 and not exceptions_list:
         exceptions_list = get_scene_exceptions(indexer_id, indexer)
 
-    return sorted(set(exceptions_list), key=len)
+    return set(exceptions_list)
 
 
 def get_all_scene_exceptions(indexer_id):
@@ -120,7 +120,7 @@ def get_all_scene_exceptions(indexer_id):
     :param indexer_id: ID to check
     :return: dict of exceptions (e.g. exceptions_cache[season][exception_name])
     """
-    return exceptions_cache.get(indexer_id, defaultdict(list))
+    return exceptions_cache.get(indexer_id, defaultdict(set))
 
 
 def get_scene_seasons(indexer_id):
@@ -194,7 +194,7 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     for exception in decoded_scene_exceptions:
         if exception not in exceptions_cache[indexer_id][season]:
             # Add to cache
-            exceptions_cache[indexer_id][season].append(exception)
+            exceptions_cache[indexer_id][season].add(exception)
 
             # Add to db
             cache_db_con.action(

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -174,6 +174,9 @@ def get_scene_exception_by_name_multiple(show_name):
 
 def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     """Update database with all show scene exceptions by indexer_id."""
+
+    logger.info('Updating scene exceptions...')
+
     cache_db_con = db.DBConnection('cache.db')
     cache_db_con.action(
         b'DELETE FROM scene_exceptions '
@@ -182,8 +185,6 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
         b'    indexer=?',
         [indexer_id, season, indexer]
     )
-
-    logger.info('Updating scene exceptions...')
 
     # A change has been made to the scene exception list. Let's clear the cache, to make this visible
     # TODO: make sure we add indexer, when the global exceptionsCache var has been changed.

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -209,7 +209,7 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
             )
 
 
-def retrieve_exceptions():
+def retrieve_exceptions(force=False):
     """
     Look up the exceptions from all sources.
 
@@ -217,13 +217,13 @@ def retrieve_exceptions():
     scene_exceptions table in cache.db. Also clears the scene name cache.
     """
     # Custom scene exceptions
-    custom_exceptions = _get_custom_exceptions()
+    custom_exceptions = _get_custom_exceptions(force)
 
     # XEM scene exceptions
-    xem_exceptions = _get_xem_exceptions()
+    xem_exceptions = _get_xem_exceptions(force)
 
     # AniDB scene exceptions
-    anidb_exceptions = _get_anidb_exceptions()
+    anidb_exceptions = _get_anidb_exceptions(force)
 
     # Combined scene exceptions from all sources
     combined_exceptions = combine_exceptions(custom_exceptions, xem_exceptions, anidb_exceptions)
@@ -264,10 +264,10 @@ def combine_exceptions(*scene_exceptions):
     return combined_ex
 
 
-def _get_custom_exceptions():
+def _get_custom_exceptions(force=False):
     custom_exceptions = {}
 
-    if should_refresh('custom_exceptions'):
+    if should_refresh('custom_exceptions') or force:
         for indexer in indexerApi().indexers:
             try:
                 location = indexerApi(indexer).config['scene_loc']
@@ -301,10 +301,10 @@ def _get_custom_exceptions():
     return custom_exceptions
 
 
-def _get_xem_exceptions():
+def _get_xem_exceptions(force=False):
     xem_exceptions = {}
 
-    if should_refresh('xem'):
+    if should_refresh('xem') or force:
         for indexer in indexerApi().indexers:
 
             # Not query XEM for unsupported indexers
@@ -346,10 +346,10 @@ def _get_xem_exceptions():
     return xem_exceptions
 
 
-def _get_anidb_exceptions():
+def _get_anidb_exceptions(force=False):
     anidb_exceptions = {}
 
-    if should_refresh('anidb'):
+    if should_refresh('anidb') or force:
         logger.info('Checking for scene exceptions updates from AniDB')
 
         for show in app.showList:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -81,7 +81,12 @@ def should_refresh(ex_list):
     max_refresh_age_secs = 86400  # 1 day
 
     cache_db_con = db.DBConnection('cache.db')
-    rows = cache_db_con.select(b'SELECT last_refreshed FROM scene_exceptions_refresh WHERE list = ?', [ex_list])
+    rows = cache_db_con.select(
+        b'SELECT last_refreshed '
+        b'FROM scene_exceptions_refresh '
+        b'WHERE list = ?',
+        [ex_list]
+    )
     if rows:
         last_refresh = int(rows[0][b'last_refreshed'])
         return int(time.time()) > last_refresh + max_refresh_age_secs
@@ -104,12 +109,11 @@ def set_last_refresh(ex_list):
 
 
 def get_scene_exceptions(indexer_id, indexer, season=-1):
-    """Given a indexer_id, return a list of all the scene exceptions from the scene_exception cache."""
-    exceptions_list = []
-    if indexer_id in exceptions_cache and season in exceptions_cache[indexer_id]:
-        exceptions_list = exceptions_cache[indexer_id][season]
+    """Get scene exceptions from exceptions_cache for an indexer id."""
+    exceptions_list = exceptions_cache[indexer_id][season]
 
-    # Add generic exceptions regardless of the season if there is no exception for season
+    # If there is no exception for season
+    # Add generic exceptions regardless of the season
     if season != -1 and not exceptions_list:
         exceptions_list += get_scene_exceptions(indexer_id, indexer, season=-1)
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -112,12 +112,10 @@ def get_scene_exceptions(indexer_id, indexer, season=-1):
     """Get scene exceptions from exceptions_cache for an indexer id."""
     exceptions_list = exceptions_cache[indexer_id][season]
 
-    # If there is no exception for season
-    # Add generic exceptions regardless of the season
     if season != -1 and not exceptions_list:
         exceptions_list += get_scene_exceptions(indexer_id, indexer)
 
-    return list({exception for exception in exceptions_list})
+    return list(set(exceptions_list))
 
 
 def get_all_scene_exceptions(indexer_id):

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -134,15 +134,15 @@ def get_scene_seasons(indexer_id):
     :param indexer_id: ID to check
     :return: list of seasons.
     """
-    warnings.warn(DeprecationWarning, 'Use dict.keys() directly instead.')
+    warnings.warn('Use dict.keys() directly instead.', DeprecationWarning)
     return exceptions_cache[indexer_id].keys()
 
 
 def get_scene_exception_by_name(show_name):
     """Get the first indexer_id and season of the scene exception."""
     warnings.warn(
+        'Use the first element of get_scene_exceptions_by_name instead.',
         DeprecationWarning,
-        'Use the first element of get_scene_exceptions_by_name instead.'
     )
     return get_scene_exceptions_by_name(show_name)[0]
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -113,7 +113,7 @@ def get_scene_exceptions(indexer_id, indexer, season=-1):
     exceptions_list = exceptions_cache[indexer_id][season]
 
     if season != -1 and not exceptions_list:
-        exceptions_list += get_scene_exceptions(indexer_id, indexer)
+        exceptions_list = get_scene_exceptions(indexer_id, indexer)
 
     return sorted(set(exceptions_list), key=len)
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -282,7 +282,7 @@ def combine_exceptions(*scene_exceptions):
 
 
 def _get_custom_exceptions():
-    custom_exceptions = {}
+    custom_exceptions = defaultdict(dict)
 
     if should_refresh('custom_exceptions'):
         for indexer in indexerApi().indexers:
@@ -309,9 +309,6 @@ def _get_custom_exceptions():
                         )
                     )
                     return custom_exceptions
-
-                if indexer not in custom_exceptions:
-                    custom_exceptions[indexer] = {}
 
                 indexer_ids = jdata[indexerApi(indexer).config['identifier']]
                 for indexer_id in indexer_ids:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -94,7 +94,7 @@ def should_refresh(ex_list):
     rows = cache_db_con.select(b'SELECT last_refreshed FROM scene_exceptions_refresh WHERE list = ?', [ex_list])
     if rows:
         last_refresh = int(rows[0][b'last_refreshed'])
-        return int(time.mktime(datetime.datetime.today().timetuple())) > last_refresh + max_refresh_age_secs
+        return int(time.time()) > last_refresh + max_refresh_age_secs
     else:
         return True
 
@@ -108,7 +108,7 @@ def set_last_refresh(ex_list):
     cache_db_con = db.DBConnection('cache.db')
     cache_db_con.upsert(
         b'scene_exceptions_refresh',
-        {b'last_refreshed': int(time.mktime(datetime.datetime.today().timetuple()))},
+        {b'last_refreshed': int(time.time())},
         {b'list': ex_list}
     )
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -189,8 +189,7 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     # A change has been made to the scene exception list.
     # Let's clear the cache, to make this visible
     # TODO: make sure we add indexer when the exceptions_cache changes
-    if indexer_id in exceptions_cache:
-        exceptions_cache[indexer_id] = {}
+    exceptions_cache[indexer_id] = {}
 
     decoded_scene_exceptions = [se.decode('utf-8') for se in scene_exceptions]
     for cur_exception in decoded_scene_exceptions:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -400,14 +400,27 @@ def _get_anidb_exceptions():
         for show in app.showList:
             if all([show.name, show.is_anime, show.indexer == INDEXER_TVDBV2]):
                 try:
-                    anime = adba.Anime(None, name=show.name, tvdbid=show.indexerid, autoCorrectName=True)
+                    anime = adba.Anime(
+                        None,
+                        name=show.name,
+                        tvdbid=show.indexerid,
+                        autoCorrectName=True
+                    )
                 except ValueError as error:
-                    logger.debug("Couldn't update scene exceptions for {show_name}, AniDB doesn't have this show.",
-                                 show_name=show.name)
+                    logger.debug(
+                        "Couldn't update scene exceptions for {show},"
+                        " AniDB doesn't have this show. Error: {msg}".format(
+                            show=show.name, msg=error,
+                        )
+                    )
                     continue
                 except Exception as error:
-                    logger.error('Checking AniDB scene exceptions update failed for {show_name}. Error: {e}',
-                                 show_name=show.name, e=error)
+                    logger.error(
+                        'Checking AniDB scene exceptions update failed'
+                        ' for {show}. Error: {msg}'.format(
+                            show=show.name, msg=error,
+                        )
+                    )
                     continue
 
                 if anime and anime.name != show.name:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -137,12 +137,12 @@ def get_scene_seasons(indexer_id):
 
 
 def get_scene_exception_by_name(show_name):
-    """Given a show name, return the first indexerid and season of the exceptions list."""
-    return get_scene_exception_by_name_multiple(show_name)[0]
+    """Get the first indexer_id and season of the scene exception."""
+    return get_scene_exceptions_by_name(show_name)[0]
 
 
-def get_scene_exception_by_name_multiple(show_name):
-    """Given a show name, return the indexerid of the exception, None if no exception is present."""
+def get_scene_exceptions_by_name(show_name):
+    """Get the indexer_id and season of the scene exception."""
     # Try the obvious case first
     cache_db_con = db.DBConnection('cache.db')
     exception_result = cache_db_con.select(
@@ -151,10 +151,14 @@ def get_scene_exception_by_name_multiple(show_name):
         b'WHERE LOWER(show_name) = ? ORDER BY season ASC',
         [show_name.lower()])
     if exception_result:
-        return [(int(x[b'indexer_id']), int(x[b'season'])) for x in exception_result]
+        return [(int(x[b'indexer_id']), int(x[b'season']))
+                for x in exception_result]
 
     out = []
-    all_exception_results = cache_db_con.select(b'SELECT show_name, indexer_id, season FROM scene_exceptions')
+    all_exception_results = cache_db_con.select(
+        b'SELECT show_name, indexer_id, season '
+        b'FROM scene_exceptions'
+    )
 
     for cur_exception in all_exception_results:
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -51,32 +51,31 @@ def refresh_exceptions_cache():
     cache_db_con = db.DBConnection('cache.db')
     exceptions = cache_db_con.select(b'SELECT indexer, indexer_id, show_name, season FROM scene_exceptions')
 
-    if exceptions:
-        # Start building up a new exceptions_cache.
-        for exception in exceptions:
-            # indexer = int(exception[b'indexer'])
-            indexer_id = int(exception[b'indexer_id'])
-            season = int(exception[b'season'])
+    # Start building up a new exceptions_cache.
+    for exception in exceptions:
+        # indexer = int(exception[b'indexer'])
+        indexer_id = int(exception[b'indexer_id'])
+        season = int(exception[b'season'])
 
-            # Create exceptions_cache[indexerid]
-            if indexer_id not in exceptions_cache:
-                exceptions_cache[indexer_id] = {}
+        # Create exceptions_cache[indexerid]
+        if indexer_id not in exceptions_cache:
+            exceptions_cache[indexer_id] = {}
 
-            # Create exceptions_cache[indexerid][season]
-            if season not in exceptions_cache[indexer_id]:
-                exceptions_cache[indexer_id][season] = []
+        # Create exceptions_cache[indexerid][season]
+        if season not in exceptions_cache[indexer_id]:
+            exceptions_cache[indexer_id][season] = []
 
-            # exceptions_cache[indexerid][season] = ['showname 1', 'showname 2']
-            if exception[b'show_name'] not in exceptions_cache[indexer_id][season]:
-                exceptions_cache[indexer_id][season].append(exception[b'show_name'])
+        # exceptions_cache[indexerid][season] = ['showname 1', 'showname 2']
+        if exception[b'show_name'] not in exceptions_cache[indexer_id][season]:
+            exceptions_cache[indexer_id][season].append(exception[b'show_name'])
 
-            # Do the same for the exceptions_season_cache
-            if int(indexer_id) not in exceptions_season_cache:
-                exceptions_season_cache[indexer_id] = []
+        # Do the same for the exceptions_season_cache
+        if int(indexer_id) not in exceptions_season_cache:
+            exceptions_season_cache[indexer_id] = []
 
-            # exception_season_cache[indexerid] = [-1, 2, 3]
-            if season not in exceptions_season_cache[indexer_id]:
-                exceptions_season_cache[indexer_id].append(season)
+        # exception_season_cache[indexerid] = [-1, 2, 3]
+        if season not in exceptions_season_cache[indexer_id]:
+            exceptions_season_cache[indexer_id].append(season)
 
     logger.info('Finished processing {nr} scene exceptions.', nr=len(exceptions or []))
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -189,7 +189,7 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     # A change has been made to the scene exception list.
     # Let's clear the cache, to make this visible
     # TODO: make sure we add indexer when the exceptions_cache changes
-    exceptions_cache[indexer_id] = {}
+    exceptions_cache[indexer_id].clear()
 
     decoded_scene_exceptions = [se.decode('utf-8') for se in scene_exceptions]
     for cur_exception in decoded_scene_exceptions:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -138,6 +138,10 @@ def get_scene_seasons(indexer_id):
 
 def get_scene_exception_by_name(show_name):
     """Get the first indexer_id and season of the scene exception."""
+    warnings.warn(
+        DeprecationWarning,
+        'Use the first element of get_scene_exceptions_by_name instead.'
+    )
     return get_scene_exceptions_by_name(show_name)[0]
 
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -115,7 +115,7 @@ def get_scene_exceptions(indexer_id, indexer, season=-1):
     if season != -1 and not exceptions_list:
         exceptions_list += get_scene_exceptions(indexer_id, indexer)
 
-    return list(set(exceptions_list))
+    return sorted(set(exceptions_list), key=len)
 
 
 def get_all_scene_exceptions(indexer_id):

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -196,12 +196,6 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
         for exception in scene_exceptions
     )
     for exception in decoded_scene_exceptions:
-        if indexer_id not in exceptions_cache:
-            exceptions_cache[indexer_id] = {}
-
-        if season not in exceptions_cache[indexer_id]:
-            exceptions_cache[indexer_id][season] = []
-
         if exception not in exceptions_cache[indexer_id][season]:
             # Add to cache
             exceptions_cache[indexer_id][season].append(exception)

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -337,21 +337,22 @@ def _get_xem_exceptions():
 
     if should_refresh('xem'):
         for indexer in indexerApi().indexers:
+            indexer = indexerApi(indexer)
 
             # Not query XEM for unsupported indexers
-            if not indexerApi(indexer).config.get('xem_origin'):
+            if not indexer.config.get('xem_origin'):
                 continue
 
             logger.info(
                 'Checking for XEM scene exceptions updates for'
                 ' {indexer_name}'.format(
-                    indexer_name=indexerApi(indexer).name
+                    indexer_name=indexer.name
                 )
             )
             if indexer not in xem_exceptions:
                 xem_exceptions[indexer] = {}
 
-            url = xem_url.format(indexerApi(indexer).config['xem_origin'])
+            url = xem_url.format(indexer.config['xem_origin'])
 
             response = helpers.get_url(url, session=xem_session,
                                        timeout=60, returns='response')
@@ -361,7 +362,7 @@ def _get_xem_exceptions():
                 logger.debug(
                     'Check scene exceptions update failed for {indexer}.'
                     ' Unable to get URL: {xem_url}'.format(
-                        indexer=indexerApi(indexer).name,
+                        indexer=indexer.name,
                         xem_url=url,
                     )
                 )
@@ -371,7 +372,7 @@ def _get_xem_exceptions():
                 logger.debug(
                     'No data returned from XEM while checking for scene'
                     ' exceptions. Update failed for {indexer}'.format(
-                        indexer=indexerApi(indexer).name
+                        indexer=indexer.name
                     )
                 )
                 continue

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -288,29 +288,45 @@ def _get_custom_exceptions():
         for indexer in indexerApi().indexers:
             try:
                 location = indexerApi(indexer).config['scene_loc']
-                logger.info('Checking for scene exception updates from {location}', location=location)
+                logger.info(
+                    'Checking for scene exception updates from {location}',
+                    location=location
+                )
 
-                response = helpers.get_url(location, session=indexerApi(indexer).session,
-                                           timeout=60, returns='response')
+                response = helpers.get_url(
+                    location,
+                    session=indexerApi(indexer).session,
+                    timeout=60,
+                    returns='response'
+                )
                 try:
                     jdata = response.json()
                 except (ValueError, AttributeError) as error:
-                    logger.debug('Check scene exceptions update failed. Unable to update from {location}. '
-                                 'Error: {error}', location=location, error=error)
+                    logger.debug(
+                        'Check scene exceptions update failed. Unable to '
+                        'update from {location}. Error: {error}'.format(
+                            location=location, error=error
+                        )
+                    )
                     return custom_exceptions
 
                 if indexer not in custom_exceptions:
                     custom_exceptions[indexer] = {}
 
-                for indexer_id in jdata[indexerApi(indexer).config['identifier']]:
-                    alias_list = [{scene_exception: int(scene_season)}
-                                  for scene_season in jdata[indexerApi(indexer).config['identifier']][indexer_id]
-                                  for scene_exception in jdata[indexerApi(indexer).config
-                                  ['identifier']][indexer_id][scene_season]]
+                indexer_ids = jdata[indexerApi(indexer).config['identifier']]
+                for indexer_id in indexer_ids:
+                    indexer_exceptions = indexer_ids[indexer_id]
+                    alias_list = [{exception: int(season)}
+                                  for season in indexer_exceptions
+                                  for exception in indexer_exceptions[season]]
                     custom_exceptions[indexer][indexer_id] = alias_list
             except Exception as error:
-                logger.error('Unable to update scene exceptions for {indexer}. Error: {error}',
-                             indexer=indexer, error=error)
+                logger.error(
+                    'Unable to update scene exceptions for {indexer}.'
+                    ' Error: {error}'.format(
+                        indexer=indexer, error=error
+                    )
+                )
                 continue
 
             set_last_refresh('custom_exceptions')

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -19,10 +19,10 @@
 
 from __future__ import unicode_literals
 
-from collections import defaultdict
 import logging
 import threading
 import time
+from collections import defaultdict
 
 import adba
 from medusa.indexers.indexer_api import indexerApi

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -123,9 +123,9 @@ def get_all_scene_exceptions(indexer_id):
     Get all scene exceptions for a show ID.
 
     :param indexer_id: ID to check
-    :return: dict of exceptions. For example: exceptions_cache[season][exception_name]
+    :return: dict of exceptions (e.g. exceptions_cache[season][exception_name])
     """
-    return exceptions_cache.get(indexer_id, {})
+    return exceptions_cache.get(indexer_id, defaultdict(list))
 
 
 def get_scene_seasons(indexer_id):

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -115,7 +115,7 @@ def get_scene_exceptions(indexer_id, indexer, season=-1):
     # If there is no exception for season
     # Add generic exceptions regardless of the season
     if season != -1 and not exceptions_list:
-        exceptions_list += get_scene_exceptions(indexer_id, indexer, season=-1)
+        exceptions_list += get_scene_exceptions(indexer_id, indexer)
 
     return list({exception for exception in exceptions_list})
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -202,8 +202,11 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
 
             # Add to db
             cache_db_con.action(
-                b'INSERT INTO scene_exceptions (indexer_id, show_name, season, indexer) VALUES (?,?,?,?)',
-                [indexer_id, exception, season, indexer])
+                b'INSERT INTO scene_exceptions '
+                b'    (indexer_id, show_name, season, indexer)'
+                b'VALUES (?,?,?,?)',
+                [indexer_id, exception, season, indexer]
+            )
 
 
 def retrieve_exceptions():

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -48,7 +48,9 @@ def refresh_exceptions_cache():
     exceptions_season_cache.clear()
 
     cache_db_con = db.DBConnection('cache.db')
-    exceptions = cache_db_con.select(b'SELECT indexer, indexer_id, show_name, season FROM scene_exceptions')
+    exceptions = cache_db_con.select(
+        b'SELECT indexer, indexer_id, show_name, season FROM scene_exceptions'
+    ) or []
 
     # Start building up a new exceptions_cache.
     for exception in exceptions:
@@ -76,7 +78,7 @@ def refresh_exceptions_cache():
         if season not in exceptions_season_cache[indexer_id]:
             exceptions_season_cache[indexer_id].append(season)
 
-    logger.info('Finished processing {nr} scene exceptions.', nr=len(exceptions or []))
+    logger.info('Finished processing {x} scene exceptions.', x=len(exceptions))
 
 
 def should_refresh(ex_list):

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -195,21 +195,21 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
         exception.decode('utf-8')
         for exception in scene_exceptions
     )
-    for cur_exception in decoded_scene_exceptions:
+    for exception in decoded_scene_exceptions:
         if indexer_id not in exceptions_cache:
             exceptions_cache[indexer_id] = {}
 
         if season not in exceptions_cache[indexer_id]:
             exceptions_cache[indexer_id][season] = []
 
-        if cur_exception not in exceptions_cache[indexer_id][season]:
+        if exception not in exceptions_cache[indexer_id][season]:
             # Add to cache
-            exceptions_cache[indexer_id][season].append(cur_exception)
+            exceptions_cache[indexer_id][season].append(exception)
 
             # Add to db
             cache_db_con.action(
                 b'INSERT INTO scene_exceptions (indexer_id, show_name, season, indexer) VALUES (?,?,?,?)',
-                [indexer_id, cur_exception, season, indexer])
+                [indexer_id, exception, season, indexer])
 
 
 def retrieve_exceptions():

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -22,6 +22,7 @@ from __future__ import unicode_literals
 import logging
 import threading
 import time
+import warnings
 from collections import defaultdict
 
 import adba
@@ -129,6 +130,7 @@ def get_scene_seasons(indexer_id):
     :param indexer_id: ID to check
     :return: list of seasons.
     """
+    warnings.warn(DeprecationWarning, 'Use dict.keys() directly instead.')
     return exceptions_cache[indexer_id].keys()
 
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -30,14 +30,13 @@ from six import iteritems, text_type
 from . import app, db, helpers
 from .indexers.indexer_config import INDEXER_TVDBV2
 
+logger = logging.getLogger(__name__)
+
 exceptions_cache = defaultdict(lambda: defaultdict(list))
 exceptions_season_cache = defaultdict(list)
-
 exceptionLock = threading.Lock()
 
 xem_session = helpers.make_session()
-
-logger = logging.getLogger(__name__)
 
 
 def refresh_exceptions_cache():
@@ -174,7 +173,6 @@ def get_scene_exception_by_name_multiple(show_name):
 
 def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
     """Update database with all show scene exceptions by indexer_id."""
-
     logger.info('Updating scene exceptions...')
 
     cache_db_con = db.DBConnection('cache.db')

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -337,20 +337,20 @@ def _get_xem_exceptions():
 
     if should_refresh('xem'):
         for indexer in indexerApi().indexers:
-            indexer = indexerApi(indexer)
+            indexer_api = indexerApi(indexer)
 
             # Not query XEM for unsupported indexers
-            if not indexer.config.get('xem_origin'):
+            if not indexer_api.config.get('xem_origin'):
                 continue
 
             logger.info(
                 'Checking for XEM scene exceptions updates for'
                 ' {indexer_name}'.format(
-                    indexer_name=indexer.name
+                    indexer_name=indexer_api.name
                 )
             )
 
-            url = xem_url.format(indexer.config['xem_origin'])
+            url = xem_url.format(indexer_api.config['xem_origin'])
             response = helpers.get_url(url, session=xem_session,
                                        timeout=60, returns='response')
             try:
@@ -359,7 +359,7 @@ def _get_xem_exceptions():
                 logger.debug(
                     'Check scene exceptions update failed for {indexer}.'
                     ' Unable to get URL: {url} Error: {error}'.format(
-                        indexer=indexer.name, url=url, error=error,
+                        indexer=indexer_api.name, url=url, error=error,
                     )
                 )
                 continue
@@ -368,7 +368,7 @@ def _get_xem_exceptions():
                 logger.debug(
                     'No data returned from XEM while checking for scene'
                     ' exceptions. Update failed for {indexer}'.format(
-                        indexer=indexer.name
+                        indexer=indexer_api.name
                     )
                 )
                 continue

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 
 import adba
 from medusa.indexers.indexer_api import indexerApi
-from six import iteritems, text_type
+from six import iteritems
 from . import app, db, helpers
 from .indexers.indexer_config import INDEXER_TVDBV2
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -205,7 +205,7 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
             )
 
 
-def retrieve_exceptions(force=False):
+def retrieve_exceptions():
     """
     Look up the exceptions from all sources.
 
@@ -213,13 +213,13 @@ def retrieve_exceptions(force=False):
     scene_exceptions table in cache.db. Also clears the scene name cache.
     """
     # Custom scene exceptions
-    custom_exceptions = _get_custom_exceptions(force)
+    custom_exceptions = _get_custom_exceptions()
 
     # XEM scene exceptions
-    xem_exceptions = _get_xem_exceptions(force)
+    xem_exceptions = _get_xem_exceptions()
 
     # AniDB scene exceptions
-    anidb_exceptions = _get_anidb_exceptions(force)
+    anidb_exceptions = _get_anidb_exceptions()
 
     # Combined scene exceptions from all sources
     combined_exceptions = combine_exceptions(custom_exceptions, xem_exceptions, anidb_exceptions)
@@ -260,10 +260,10 @@ def combine_exceptions(*scene_exceptions):
     return combined_ex
 
 
-def _get_custom_exceptions(force=False):
+def _get_custom_exceptions():
     custom_exceptions = {}
 
-    if should_refresh('custom_exceptions') or force:
+    if should_refresh('custom_exceptions'):
         for indexer in indexerApi().indexers:
             try:
                 location = indexerApi(indexer).config['scene_loc']
@@ -297,10 +297,10 @@ def _get_custom_exceptions(force=False):
     return custom_exceptions
 
 
-def _get_xem_exceptions(force=False):
+def _get_xem_exceptions():
     xem_exceptions = {}
 
-    if should_refresh('xem') or force:
+    if should_refresh('xem'):
         for indexer in indexerApi().indexers:
 
             # Not query XEM for unsupported indexers
@@ -342,10 +342,10 @@ def _get_xem_exceptions(force=False):
     return xem_exceptions
 
 
-def _get_anidb_exceptions(force=False):
+def _get_anidb_exceptions():
     anidb_exceptions = {}
 
-    if should_refresh('anidb') or force:
+    if should_refresh('anidb'):
         logger.info('Checking for scene exceptions updates from AniDB')
 
         for show in app.showList:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -272,14 +272,11 @@ def retrieve_exceptions():
 def combine_exceptions(*scene_exceptions):
     """Combine the exceptions from all sources."""
     # ex_dicts = iter(scene_exceptions)
-    combined_ex = {}
+    combined_ex = defaultdict(dict)
 
     for scene_exception in scene_exceptions:
-        if scene_exception:
-            for indexer in scene_exception:
-                if indexer not in combined_ex:
-                    combined_ex[indexer] = {}
-                combined_ex[indexer].update(scene_exception[indexer])
+        for indexer in scene_exception or []:
+            combined_ex[indexer].update(scene_exception[indexer])
 
     return combined_ex
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -19,7 +19,6 @@
 
 from __future__ import unicode_literals
 
-import datetime
 import logging
 import threading
 import time

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -392,7 +392,9 @@ def _get_xem_exceptions():
 
 
 def _get_anidb_exceptions():
-    anidb_exceptions = {}
+    anidb_exceptions = defaultdict(dict)
+    # AniDB exceptions use TVDB as indexer
+    exceptions = anidb_exceptions[INDEXER_TVDBV2]
 
     if should_refresh('anidb'):
         logger.info('Checking for scene exceptions updates from AniDB')
@@ -424,8 +426,8 @@ def _get_anidb_exceptions():
                     continue
 
                 if anime and anime.name != show.name:
-                    anidb_exceptions[INDEXER_TVDBV2] = {}
-                    anidb_exceptions[INDEXER_TVDBV2][text_type(show.indexerid)] = [{anime.name.decode('utf-8'): -1}]
+                    indexer_id = text_type(show.indexerid)
+                    exceptions[indexer_id] = [{anime.name.decode('utf-8'): -1}]
 
         set_last_refresh('anidb')
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -155,8 +155,8 @@ def get_scene_exceptions_by_name(show_name):
     scene_exceptions = cache_db_con.select(
         b'SELECT indexer_id, season '
         b'FROM scene_exceptions '
-        b'WHERE LOWER(show_name) = ? ORDER BY season ASC',
-        [show_name.lower()])
+        b'WHERE show_name = ? ORDER BY season ASC',
+        [show_name])
     if scene_exceptions:
         return [(int(exception[b'indexer_id']), int(exception[b'season']))
                 for exception in scene_exceptions]

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -332,7 +332,7 @@ def _get_custom_exceptions():
 
 
 def _get_xem_exceptions():
-    xem_exceptions = {}
+    xem_exceptions = defaultdict(dict)
     xem_url = 'http://thexem.de/map/allNames?origin={0}&seasonNumbers=1'
 
     if should_refresh('xem'):
@@ -349,11 +349,8 @@ def _get_xem_exceptions():
                     indexer_name=indexer.name
                 )
             )
-            if indexer not in xem_exceptions:
-                xem_exceptions[indexer] = {}
 
             url = xem_url.format(indexer.config['xem_origin'])
-
             response = helpers.get_url(url, session=xem_session,
                                        timeout=60, returns='response')
             try:
@@ -361,10 +358,8 @@ def _get_xem_exceptions():
             except (ValueError, AttributeError) as error:
                 logger.debug(
                     'Check scene exceptions update failed for {indexer}.'
-                    ' Unable to get URL: {xem_url} Error: {error}'.format(
-                        indexer=indexer.name,
-                        xem_url=url,
-                        error=error,
+                    ' Unable to get URL: {url} Error: {error}'.format(
+                        indexer=indexer.name, url=url, error=error,
                     )
                 )
                 continue

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -186,8 +186,9 @@ def update_scene_exceptions(indexer_id, indexer, scene_exceptions, season=-1):
         [indexer_id, season, indexer]
     )
 
-    # A change has been made to the scene exception list. Let's clear the cache, to make this visible
-    # TODO: make sure we add indexer, when the global exceptionsCache var has been changed.
+    # A change has been made to the scene exception list.
+    # Let's clear the cache, to make this visible
+    # TODO: make sure we add indexer when the exceptions_cache changes
     if indexer_id in exceptions_cache:
         exceptions_cache[indexer_id] = {}
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -33,7 +33,6 @@ from .indexers.indexer_config import INDEXER_TVDBV2
 logger = logging.getLogger(__name__)
 
 exceptions_cache = defaultdict(lambda: defaultdict(list))
-exceptions_season_cache = defaultdict(list)
 exceptionLock = threading.Lock()
 
 xem_session = helpers.make_session()
@@ -45,7 +44,6 @@ def refresh_exceptions_cache():
 
     # Empty the module level variables
     exceptions_cache.clear()
-    exceptions_season_cache.clear()
 
     cache_db_con = db.DBConnection('cache.db')
     exceptions = cache_db_con.select(
@@ -63,10 +61,6 @@ def refresh_exceptions_cache():
         # exceptions_cache[indexerid][season] = ['showname 1', 'showname 2']
         if show not in exceptions_cache[indexer_id][season]:
             exceptions_cache[indexer_id][season].append(show)
-
-        # exception_season_cache[indexerid] = [-1, 2, 3]
-        if season not in exceptions_season_cache[indexer_id]:
-            exceptions_season_cache[indexer_id].append(season)
 
     logger.info('Finished processing {x} scene exceptions.', x=len(exceptions))
 
@@ -130,12 +124,12 @@ def get_all_scene_exceptions(indexer_id):
 
 def get_scene_seasons(indexer_id):
     """
-    Get a list of season numbers form the scene_exceptions, for which exceptions have been added.
+    Get season numbers with scene exceptions.
 
     :param indexer_id: ID to check
     :return: list of seasons.
     """
-    return exceptions_season_cache.get(indexer_id, [])
+    return exceptions_cache[indexer_id].keys()
 
 
 def get_scene_exception_by_name(show_name):

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -147,6 +147,7 @@ def get_scene_exception_by_name(show_name):
 
 def get_scene_exceptions_by_name(show_name):
     """Get the indexer_id and season of the scene exception."""
+    # TODO: Rewrite to use exceptions_cache since there is no need to hit db.
     # Try the obvious case first
     cache_db_con = db.DBConnection('cache.db')
     exception_result = cache_db_con.select(
@@ -169,10 +170,17 @@ def get_scene_exceptions_by_name(show_name):
         cur_exception_name = cur_exception[b'show_name']
         cur_indexer_id = int(cur_exception[b'indexer_id'])
 
-        if show_name.lower() in (cur_exception_name.lower(),
-                                 helpers.sanitize_scene_name(cur_exception_name).lower().replace('.', ' ')):
-            logger.debug('Scene exception lookup got indexer ID {cur_indexer}, using that', cur_indexer=cur_indexer_id)
+        sanitized_name = helpers.sanitize_scene_name(cur_exception_name)
+        show_names = (
+            cur_exception_name.lower(),
+            sanitized_name.lower().replace('.', ' '),
+        )
 
+        if show_name.lower() in show_names:
+            logger.debug(
+                'Scene exception lookup got indexer ID {cur_indexer},'
+                ' using that', cur_indexer=cur_indexer_id
+            )
             out.append((cur_indexer_id, int(cur_exception[b'season'])))
 
     if out:

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1307,7 +1307,7 @@ class Home(WebRoot):
             return True
 
     def editShow(self, show=None, location=None, allowed_qualities=None, preferred_qualities=None,
-                 exceptions_list=None, flatten_folders=None, paused=None, directCall=False,
+                 exceptions=None, flatten_folders=None, paused=None, directCall=False,
                  air_by_date=None, sports=None, dvd_order=None, indexer_lang=None,
                  subtitles=None, rls_ignore_words=None, rls_require_words=None,
                  anime=None, blacklist=None, whitelist=None, scene=None,
@@ -1316,7 +1316,7 @@ class Home(WebRoot):
 
         allowed_qualities = allowed_qualities or []
         preferred_qualities = preferred_qualities or []
-        exceptions_list = exceptions_list or []
+        exceptions = exceptions or set()
 
         anidb_failed = False
         errors = []
@@ -1425,15 +1425,15 @@ class Home(WebRoot):
         if not isinstance(preferred_qualities, list):
             preferred_qualities = [preferred_qualities]
 
-        if not isinstance(exceptions_list, list):
-            exceptions_list = [exceptions_list]
+        if not isinstance(exceptions, set):
+            exceptions = {exceptions}
 
         # If directCall from mass_edit_update no scene exceptions handling or
         # blackandwhite list handling
         if directCall:
             do_update_exceptions = False
         else:
-            if set(exceptions_list) == set(show_obj.exceptions):
+            if exceptions == show_obj.exceptions:
                 do_update_exceptions = False
             else:
                 do_update_exceptions = True
@@ -1519,7 +1519,7 @@ class Home(WebRoot):
 
         if do_update_exceptions:
             try:
-                update_scene_exceptions(show_obj.indexerid, show_obj.indexer, exceptions_list)  # @UndefinedVdexerid)
+                update_scene_exceptions(show_obj.indexerid, show_obj.indexer, exceptions)  # @UndefinedVdexerid)
                 time.sleep(cpu_presets[app.CPU_PRESET])
             except CantUpdateShowException:
                 errors.append('Unable to force an update on scene exceptions of the show.')

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1307,7 +1307,7 @@ class Home(WebRoot):
             return True
 
     def editShow(self, show=None, location=None, allowed_qualities=None, preferred_qualities=None,
-                 exceptions=None, flatten_folders=None, paused=None, directCall=False,
+                 exceptions_list=None, flatten_folders=None, paused=None, directCall=False,
                  air_by_date=None, sports=None, dvd_order=None, indexer_lang=None,
                  subtitles=None, rls_ignore_words=None, rls_require_words=None,
                  anime=None, blacklist=None, whitelist=None, scene=None,
@@ -1316,7 +1316,9 @@ class Home(WebRoot):
 
         allowed_qualities = allowed_qualities or []
         preferred_qualities = preferred_qualities or []
-        exceptions = exceptions or set()
+        exceptions = set()
+        if exceptions_list:
+            exceptions.update(exceptions_list)
 
         anidb_failed = False
         errors = []

--- a/medusa/show_name_helpers.py
+++ b/medusa/show_name_helpers.py
@@ -105,10 +105,9 @@ def allPossibleShowNames(show, season=-1):
     Returns: all possible show names
     """
 
-    show_names = {show.name}
-    show_names.update(
-        get_scene_exceptions(show.indexerid, show.indexer, season)
-    )
+    show_names = get_scene_exceptions(show.indexerid, show.indexer, season)
+    show_names.add(show.name)
+
     new_show_names = set()
 
     if not show.is_anime:

--- a/medusa/show_name_helpers.py
+++ b/medusa/show_name_helpers.py
@@ -105,31 +105,28 @@ def allPossibleShowNames(show, season=-1):
     """
 
     showNames = get_scene_exceptions(show.indexerid, show.indexer, season=season)
-    showNames.append(show.name)
+    showNames.add(show.name)
 
     if not show.is_anime:
-        newShowNames = []
+        newShowNames = set()
         country_list = common.countryList
         country_list.update(dict(zip(common.countryList.values(), common.countryList.keys())))
-        for curName in set(showNames):
+        for curName in showNames:
             if not curName:
                 continue
 
-            # if we have "Show Name Australia" or "Show Name (Australia)" this will add "Show Name (AU)" for
-            # any countries defined in common.countryList
-            # (and vice versa)
+            # if we have "Show Name Australia" or "Show Name (Australia)"
+            # this will add "Show Name (AU)" for any countries defined in
+            # common.countryList (and vice versa)
             for curCountry in country_list:
                 if curName.endswith(' ' + curCountry):
-                    newShowNames.append(curName.replace(' ' + curCountry, ' (' + country_list[curCountry] + ')'))
+                    newShowNames.add(curName.replace(' ' + curCountry, ' (' + country_list[curCountry] + ')'))
                 elif curName.endswith(' (' + curCountry + ')'):
-                    newShowNames.append(curName.replace(' (' + curCountry + ')', ' (' + country_list[curCountry] + ')'))
-
-            # # if we have "Show Name (2013)" this will strip the (2013) show year from the show name
-            # newShowNames.append(re.sub('\(\d{4}\)', '', curName))
+                    newShowNames.add(curName.replace(' (' + curCountry + ')', ' (' + country_list[curCountry] + ')'))
 
         showNames += newShowNames
 
-    return set(showNames)
+    return showNames
 
 
 def determineReleaseName(dir_name=None, nzb_name=None):

--- a/medusa/show_name_helpers.py
+++ b/medusa/show_name_helpers.py
@@ -109,6 +109,7 @@ def allPossibleShowNames(show, season=-1):
     show_names.update(
         get_scene_exceptions(show.indexerid, show.indexer, season)
     )
+    new_show_names = set()
 
     if not show.is_anime:
         country_list = {}
@@ -129,11 +130,11 @@ def allPossibleShowNames(show, season=-1):
                 pattern_2 = ' ({0})'.format(country)
                 replacement = ' ({0})'.format(country_list[country])
                 if name.endswith(pattern_1):
-                    show_names.add(name.replace(pattern_1, replacement))
+                    new_show_names.add(name.replace(pattern_1, replacement))
                 elif name.endswith(pattern_2):
-                    show_names.add(name.replace(pattern_2, replacement))
+                    new_show_names.add(name.replace(pattern_2, replacement))
 
-    return show_names
+    return show_names.union(new_show_names)
 
 
 def determineReleaseName(dir_name=None, nzb_name=None):

--- a/medusa/show_name_helpers.py
+++ b/medusa/show_name_helpers.py
@@ -105,10 +105,6 @@ def allPossibleShowNames(show, season=-1):
     """
 
     showNames = get_scene_exceptions(show.indexerid, show.indexer, season=season)
-    if not showNames:  # if we dont have any season specific exceptions fallback to generic exceptions
-        season = -1
-        showNames = get_scene_exceptions(show.indexerid, show.indexer, season=season)
-
     showNames.append(show.name)
 
     if not show.is_anime:

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -518,7 +518,7 @@ class QueueItemAdd(ShowQueueItem):
             logger.log(traceback.format_exc(), logger.DEBUG)
 
         # update internal name cache
-        name_cache.build_name_cache(self.show, force=True)
+        name_cache.build_name_cache(self.show)
 
         try:
             self.show.load_episodes_from_dir()

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -518,7 +518,7 @@ class QueueItemAdd(ShowQueueItem):
             logger.log(traceback.format_exc(), logger.DEBUG)
 
         # update internal name cache
-        name_cache.build_name_cache(self.show)
+        name_cache.build_name_cache(self.show, force=True)
 
         try:
             self.show.load_episodes_from_dir()

--- a/medusa/show_updater.py
+++ b/medusa/show_updater.py
@@ -46,7 +46,7 @@ class ShowUpdater(object):
 
         network_timezones.update_network_dict()
 
-        # Refresh the exceptions_cache and exceptions_season_cache from db.
+        # Refresh the exceptions_cache from db.
         refresh_exceptions_cache()
 
         logger.info(u'Started periodic show updates')

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -193,7 +193,7 @@ class TVShow(TVObject):
         self.episodes = {}
         self.next_aired = ''
         self.release_groups = None
-        self.exceptions = []
+        self.exceptions = set()
         self.externals = {}
         self._cached_indexer_api = None
 

--- a/tests/legacy/scene_helpers_tests.py
+++ b/tests/legacy/scene_helpers_tests.py
@@ -72,11 +72,14 @@ class SceneExceptionTestCase(test.AppTestDBCase):
         scene_exceptions.refresh_exceptions_cache()
 
     def test_scene_ex_empty(self):
-        self.assertEqual(scene_exceptions.get_scene_exceptions(0, 0), [])
+        self.assertEqual(scene_exceptions.get_scene_exceptions(0, 0), set())
 
     @unittest.expectedFailure
     def test_scene_ex_babylon_5(self):
-        self.assertEqual(sorted(scene_exceptions.get_scene_exceptions(70726, 1)), ['Babylon 5', 'Babylon5'])
+        self.assertEqual(
+            sorted(scene_exceptions.get_scene_exceptions(70726, 1)),
+            sorted({'Babylon 5', 'Babylon5'})
+        )
 
     @unittest.expectedFailure
     def test_scene_ex_by_name(self):


### PR DESCRIPTION
get_scene_exceptions did two things. 1. Check if a indexerid, indexer, (optional) season combination is available in exceptionsCache. If not search in db, and update the exceptionCache in the process.

Now those are two methods. We now "trust" the cache, as in, when it can't find in cache, it isn't there.
And the second methods constructs the cache.

This PR will also improve startup time, as previously it was creating the cache, trough looping by show and creating the cache per show.

Now i'm doing one db query, and creating two caches in one go.

* ~~Update is only run on startup and on editShow.~~
* Update is only run on editShow.
* get_scene_exceptions only get's exceptions from cache
* update_scene_exceptions_cache, updates the cache (db) for a specific show.
* refresh_exceptions_cache, re-caches the exceptions_cache and exceptions_season_cache cache.
* refresh_exceptions_cache is run on startup and show_updater.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

## TODO:
- [ ] Refactor the same for get_scene_seasons.

~~## Force retrieve exception cache on show add.
With this PR we are forcing the retrieval of the exception in "retrieve_exceptions". I added this because, i'd like to know for sure I have all required scene exceptions for a show I just added. But the fact is, that the retrieve_exceptions is not really an efficient written method. So i'm having doubt, we should do this right now~~