### PR TITLE
Fix episode title notifications when there are unicode characters in it.

### DIFF
--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -337,7 +337,8 @@ class ForcedSearchQueueItem(generic_queue.QueueItem):
                     ui.notifications.message("We have found season packs for {0}".format(self.show.name),
                                              "These should become visible in the manual select page.")
                 else:
-                    ui.notifications.message("We have found results for {0}".format(self.segment[0].pretty_name()),
+                    ui.notifications.message("We have found results for {0}".format(self.segment[0].pretty_name()
+                                                                                    .encode('utf-8')),
                                              "These should become visible in the manual select page.")
             else:
                 ui.notifications.message('No results were found')

--- a/medusa/server/web/core/base.py
+++ b/medusa/server/web/core/base.py
@@ -400,8 +400,8 @@ class UI(WebRoot):
         cur_notification_num = 1
         for cur_notification in ui.notifications.get_notifications(self.request.remote_ip):
             messages['notification-{number}'.format(number=cur_notification_num)] = {
-                'title': '{0}'.format(cur_notification.title),
-                'message': '{0}'.format(cur_notification.message),
+                'title': '{0}'.format(cur_notification.title.decode('utf-8')),
+                'message': '{0}'.format(cur_notification.message.decode('utf-8')),
                 'type': '{0}'.format(cur_notification.notification_type),
             }
             cur_notification_num += 1


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This is reproducable by (manual) searching (and getting a result) for an episode which has unicode chars in the title.

Like for ex. Dragon ball super S04E13.
Protect Kai```ō```-shin Gowasu - Destroy Zamasu!

I tested this on Windows 7 x64.
Maybe it's not even an issue on linux like OS'.

![image](https://cloud.githubusercontent.com/assets/1331394/22504141/40bb43ac-e875-11e6-945c-5dfe04a680c2.png)
