### PR TITLE
Shows that have a unicode encoded show name with special chars, store…

### DIFF
--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -167,6 +167,11 @@ class HomeAddShows(Home):
                     if not (indexer_id and show_name):
                         (indexer_id, show_name, indexer) = cur_provider.retrieveShowMetadata(cur_path)
 
+                        # unicode encoded special character show names, should be encoded to byte, as the nfo can have a
+                        # show title with unicode encoded special chars. Like naruto shippuuden on tvmaze.
+                        if show_name:
+                            show_name = show_name.encode('utf-8')
+
                         # default to TVDB if indexer was not detected
                         if show_name and not (indexer or indexer_id):
                             (_, idxr, i) = helpers.search_indexer_for_show_id(show_name, indexer, indexer_id)


### PR DESCRIPTION
…d in the local nfo file. Will cause an endless reload of the addShows/existingShows/ page, because the mako is crashing on the unicode special char.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Content of nfo.
![image](https://cloud.githubusercontent.com/assets/1331394/22618507/5c05998a-eade-11e6-9f92-e8dadd0fea23.png)


You can reproduce by following these steps:
1. Make sure you have enabled metadata generator (kodi12).
2. Add Naruto Shippuuden using ~~tvmaze~~ tmdb.
3. Remove the show, but leave files on disk.
4. Try to add the same show from ~~tvmaze~~ tmdb, it will redirect you to the addExisting page, and that page will keep reloading.
