### PR TITLE
Fix SNATCHED (BEST) render pill not working

### DIFF
--- a/static/js/ajax-episode-search.js
+++ b/static/js/ajax-episode-search.js
@@ -37,8 +37,6 @@ function updateImages(data) {
                 img.prop('alt', 'Searching');
                 img.prop('src', 'images/' + loadingImage);
                 disableLink(el);
-                // Update Status and Quality
-                rSearchTerm = /(\w+)\s\((.+?)\)/;
                 htmlContent = ep.searchstatus;
             } else if (ep.searchstatus.toLowerCase() === 'queued') {
                 // el=$('td#' + ep.season + 'x' + ep.episode + '.search img');

--- a/static/js/ajax-episode-search.js
+++ b/static/js/ajax-episode-search.js
@@ -56,8 +56,8 @@ function updateImages(data) {
                 enableLink(el);
 
                 // Update Status and Quality
-                rSearchTerm = /(\w+)\s\((.+?)\)/;
-                htmlContent = ep.status.replace(rSearchTerm, "$1" + ' <span class="quality ' + ep.quality + '">' + "$2" + '</span>'); // eslint-disable-line quotes, no-useless-concat
+                rSearchTerm = /(\w+(\s\(Best\))?)\s\((.+?)\)/;
+                htmlContent = ep.status.replace(rSearchTerm, "$1" + ' <span class="quality ' + ep.quality + '">' + "$3" + '</span>'); // eslint-disable-line quotes, no-useless-concat
                 parent.closest('tr').prop('class', ep.overview + ' season-' + ep.season + ' seasonstyle');
             }
             // update the status column if it exists


### PR DESCRIPTION
@OmgImAlexis @duramato  (finally fixed this one)

UPDATE: this issue happens only when you forced a search and gets a SNATCHED BEST and don't restart medusa, so JS keeps updating status. See this comment: https://github.com/pymedusa/Medusa/pull/2120#issuecomment-278142762


Existing regex creates this issue:
![image](https://cloud.githubusercontent.com/assets/2620870/22709742/0bb0cf5a-ed62-11e6-8a0c-4e151811b779.png)

![image](https://cloud.githubusercontent.com/assets/2620870/22709733/0454ec8c-ed62-11e6-8b72-d41e7543d1f6.png)



----------------------------
With this PR:
![image](https://cloud.githubusercontent.com/assets/2620870/22709751/1013c976-ed62-11e6-8e7a-b03af455eb18.png)

https://regex101.com/r/2yhi7u/3

