### PR TITLE
Show number of backlogged episodes with new and existing qualities

### DIFF
--- a/medusa/server/api/v2/show.py
+++ b/medusa/server/api/v2/show.py
@@ -83,8 +83,8 @@ class ShowHandler(BaseRequestHandler):
                 allowed_qualities = map(int, allowed_qualities.split(',')) if allowed_qualities else []
                 preferred_qualities = self._parse(self.get_argument('preferred', default=None), str)
                 preferred_qualities = map(int, preferred_qualities.split(',')) if preferred_qualities else []
-                data = tv_show.get_backloged_episodes(allowed_qualities=allowed_qualities,
-                                                      preferred_qualities=preferred_qualities)
+                data = tv_show.get_backlogged_episodes(allowed_qualities=allowed_qualities,
+                                                       preferred_qualities=preferred_qualities)
             elif query == 'queue':
                 action, message = app.show_queue_scheduler.action.get_queue_action(tv_show)
                 data = {
@@ -192,20 +192,3 @@ class ShowHandler(BaseRequestHandler):
         """
         error, show = Show.delete(indexer_id=show_id, remove_files=self.get_argument('remove_files', default=False))
         return self.api_finish(error=error, data=show)
-
-    def backlogged_episodes(self, show_id, allowed_qualities, preferred_qualities):
-        """Get number of backlogged episodes for a show given new allowed and preferred qualities.
-
-        :param show_id:
-        :type show_id: str
-        :param allowed_qualities:
-        :type show_id: list
-        :param preferred_qualities:
-        :type show_id: list
-        """
-        backloged_episodes = None
-        if show_id is not None:
-            show_obj = Show.find(app.showList, show_id)
-            backloged_episodes = show_obj.get_backloged_episodes(allowed_qualities=allowed_qualities,
-                                                                 preferred_qualities=preferred_qualities)
-        return self.api_finish(data=backloged_episodes)

--- a/medusa/server/api/v2/show.py
+++ b/medusa/server/api/v2/show.py
@@ -77,19 +77,26 @@ class ShowHandler(BaseRequestHandler):
         return tv_show and (paused is None or tv_show.paused == paused)
 
     def _handle_detailed_show(self, tv_show, query):
-        data = tv_show.to_json()
         if query:
-            if query == 'queue':
+            if query == 'backlogged':
+                allowed_qualities = self._parse(self.get_argument('allowed', default=None), str)
+                allowed_qualities = map(int, allowed_qualities.split(',')) if allowed_qualities else []
+                preferred_qualities = self._parse(self.get_argument('preferred', default=None), str)
+                preferred_qualities = map(int, preferred_qualities.split(',')) if preferred_qualities else []
+                data = tv_show.get_backloged_episodes(allowed_qualities=allowed_qualities,
+                                                      preferred_qualities=preferred_qualities)
+            elif query == 'queue':
                 action, message = app.show_queue_scheduler.action.get_queue_action(tv_show)
                 data = {
                     'action': ShowQueueActions.names[action],
                     'message': message,
                 } if action is not None else dict()
-            elif query in data:
+            elif query in tv_show.to_json():
                 data = data[query]
             else:
                 return self.api_finish(status=400, error="Invalid resource path '{0}'".format(query))
-
+        else:
+            data = tv_show.to_json()
         self.api_finish(data=data)
 
     def _handle_episode(self, tv_show, ep_id, query):

--- a/medusa/server/api/v2/show.py
+++ b/medusa/server/api/v2/show.py
@@ -185,3 +185,20 @@ class ShowHandler(BaseRequestHandler):
         """
         error, show = Show.delete(indexer_id=show_id, remove_files=self.get_argument('remove_files', default=False))
         return self.api_finish(error=error, data=show)
+
+    def backlogged_episodes(self, show_id, allowed_qualities, preferred_qualities):
+        """Get number of backlogged episodes for a show given new allowed and preferred qualities.
+
+        :param show_id:
+        :type show_id: str
+        :param allowed_qualities:
+        :type show_id: list
+        :param preferred_qualities:
+        :type show_id: list
+        """
+        backloged_episodes = None
+        if show_id is not None:
+            show_obj = Show.find(app.showList, show_id)
+            backloged_episodes = show_obj.get_backloged_episodes(allowed_qualities=allowed_qualities,
+                                                                 preferred_qualities=preferred_qualities)
+        return self.api_finish(data=backloged_episodes)

--- a/medusa/tv.py
+++ b/medusa/tv.py
@@ -1934,8 +1934,8 @@ class TVShow(TVObject):
             logger.log(u'Could not parse episode status into a valid overview status: {status}'.format
                        (status=ep_status), logger.ERROR)
 
-    def get_backloged_episodes(self, allowed_qualities, preferred_qualities):
-        """Check how many episodes will be backloged when changing qualities."""
+    def get_backlogged_episodes(self, allowed_qualities, preferred_qualities):
+        """Check how many episodes will be backlogged when changing qualities."""
         BackloggedEpisodes = namedtuple('backlogged_episodes', ['new_backlogged', 'existing_backlogged'])
         new_backlogged = 0
         existing_backlogged = 0

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -37,13 +37,14 @@ $(document).ready(function() {
         $('#allowed_qualities :selected').each(function(i, selected){
             selectedAllowed[i] = $(selected).val();
         });
-        var url = '/api/v1/' + apiKey +
-              '/?cmd=show.backloggedepisodes' +
-              '&indexerid=' + $('#showID').attr('value') +
-             '&allowed=' + selectedAllowed.join('|') +
-              '&preferred=' + selectedPreffered.join('|')
+        var url = '/api/v2/' +
+                  'show/' +  $('#showIndexerName').attr('value') + $('#showID').attr('value') +
+                  '/backlogged' +
+                  '?api_key=' + apiKey +
+                  '&allowed=' + selectedAllowed +
+                  '&preferred=' + selectedPreffered
         $.getJSON(url, function(data) {
-            $('#backlogged_episodes').text('Currently you have ' + data.data[1] + ' backloged episodes. With this change you would have ' + data.data[0] + ' backlogged episodes');
+            $('#backlogged_episodes').text('Currently you have ' + data[1] + ' backloged episodes. With this change you would have ' + data[0] + ' backlogged episodes');
         });
     }
 

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -44,7 +44,7 @@ $(document).ready(function() {
                   '&allowed=' + selectedAllowed +
                   '&preferred=' + selectedPreffered
         $.getJSON(url, function(data) {
-            $('#backlogged_episodes').text('Currently you have ' + data[1] + ' backloged episodes. With this change you would have ' + data[0] + ' backlogged episodes');
+            $('#backlogged_episodes').text('Currently you have ' + data[1] + ' backlogged episodes. With this change you would have ' + data[0] + ' backlogged episodes');
         });
     }
 

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -29,37 +29,37 @@ $(document).ready(function() {
     }
 
     function setQualityText() {
-    	var preferred = $.map($('#preferred_qualities option:selected'), function(option) {
-    	    return option.text;
-    	});
-    	var allowed = $.map($('#allowed_qualities option:selected'), function(option) {
-    	    return option.text;
-    	});
-    	var both = allowed.concat(preferred.filter(function (item) {
-    	    return allowed.indexOf(item) < 0;
-    	}));
+        var preferred = $.map($('#preferred_qualities option:selected'), function(option) {
+            return option.text;
+        });
+        var allowed = $.map($('#allowed_qualities option:selected'), function(option) {
+            return option.text;
+        });
+        var both = allowed.concat(preferred.filter(function (item) {
+            return allowed.indexOf(item) < 0;
+        }));
 
-    	var allowed_preferred_explanation = both.join(', ');
-    	var preferred_explanation = preferred.join(', ');
-    	var allowed_explanation = allowed.join(', ');
+        var allowed_preferred_explanation = both.join(', ');
+        var preferred_explanation = preferred.join(', ');
+        var allowed_explanation = allowed.join(', ');
 
-    	$('#allowed_preferred_explanation').text(allowed_preferred_explanation);
-    	$('#preferred_explanation').text(preferred_explanation);
-    	$('#allowed_explanation').text(allowed_explanation);
+        $('#allowed_preferred_explanation').text(allowed_preferred_explanation);
+        $('#preferred_explanation').text(preferred_explanation);
+        $('#allowed_explanation').text(allowed_explanation);
 
-    	$('#allowed_text').hide();
-    	$('#preferred_text1').hide();
-    	$('#preferred_text2').hide();
-    	$('#quality_explanation').show();
+        $('#allowed_text').hide();
+        $('#preferred_text1').hide();
+        $('#preferred_text2').hide();
+        $('#quality_explanation').show();
 
-    	if (preferred.length) {
-    		$('#preferred_text1').show();
-    		$('#preferred_text2').show();
-    	} else if (allowed.length) {
-    		$('#allowed_text').show();
-    	} else {
-    		$('#quality_explanation').hide();
-    	}
+        if (preferred.length) {
+            $('#preferred_text1').show();
+            $('#preferred_text2').show();
+        } else if (allowed.length) {
+            $('#allowed_text').show();
+        } else {
+            $('#quality_explanation').hide();
+        }
     }
 
     $('#qualityPreset').on('change', function() {

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -28,6 +28,25 @@ $(document).ready(function() {
         return;
     }
 
+    function backloggedEpisodes() {
+        var selectedPreffered = [];
+        var selectedAllowed = [];
+        $('#preferred_qualities :selected').each(function(i, selected){
+            selectedPreffered[i] = $(selected).val();
+        });
+        $('#allowed_qualities :selected').each(function(i, selected){
+            selectedAllowed[i] = $(selected).val();
+        });
+        var url = '/api/v1/' + apiKey +
+              '/?cmd=show.backloggedepisodes' +
+              '&indexerid=' + $('#showID').attr('value') +
+             '&allowed=' + selectedAllowed.join('|') +
+              '&preferred=' + selectedPreffered.join('|')
+        $.getJSON(url, function(data) {
+            $('#backlogged_episodes').text('Currently you have ' + data.data[1] + ' backloged episodes. With this change you would have ' + data.data[0] + ' backlogged episodes');
+        });
+    }
+
     function setQualityText() {
         var preferred = $.map($('#preferred_qualities option:selected'), function(option) {
             return option.text;
@@ -68,6 +87,7 @@ $(document).ready(function() {
 
     $('#qualityPreset, #preferred_qualities, #allowed_qualities').on('change', function(){
         setQualityText();
+        backloggedEpisodes();
     });
 
     setFromPresets($('#qualityPreset :selected').val());

--- a/views/editShow.mako
+++ b/views/editShow.mako
@@ -6,6 +6,7 @@
     from medusa.common import statusStrings
     from medusa.helper import exceptions
     from medusa.indexers.indexer_api import indexerApi
+    from medusa.indexers.indexer_config import mappings
     from medusa import scene_exceptions
 %>
 <%block name="metas">
@@ -20,6 +21,7 @@
 </%block>
 <%block name="content">
 <input type="hidden" id="showID" value="${show.indexerid}" />
+<input type="hidden" id="showIndexerName" value="${mappings.get(show.indexer).replace('_id', '')}" />
 % if not header is UNDEFINED:
     <h1 class="header">${header}</h1>
 % else:

--- a/views/inc_qualityChooser.mako
+++ b/views/inc_qualityChooser.mako
@@ -45,4 +45,7 @@ selected = None
         <h5 id="preferred_text1">Downloads <b>any</b> of these qualities: <label id="allowed_preferred_explanation">${', '.join([Quality.qualityStrings[i] for i in allowed_qualities + preferred_qualities])}</label></h5>
         <h5 id="preferred_text2">But it will stop searching when one of these is downloaded:  <label id="preferred_explanation">${', '.join([Quality.qualityStrings[i] for i in preferred_qualities])}</label></h5>   
     </div>
+    <div>
+        <h5 class="red-text" id="backlogged_episodes">Change qualities to check if amount of backlogged episodes changes</h5>
+    </div>
 </div>

--- a/views/inc_qualityChooser.mako
+++ b/views/inc_qualityChooser.mako
@@ -46,6 +46,6 @@ selected = None
         <h5 id="preferred_text2">But it will stop searching when one of these is downloaded:  <label id="preferred_explanation">${', '.join([Quality.qualityStrings[i] for i in preferred_qualities])}</label></h5>   
     </div>
     <div>
-        <h5 class="red-text" id="backlogged_episodes">Change qualities to check if amount of backlogged episodes changes</h5>
+        <h5 class="red-text" id="backlogged_episodes"></h5>
     </div>
 </div>


### PR DESCRIPTION
Before user save new quality, a WARNING label in html will be shown with number of current backlogged episodes and the number of new backlogged episodes after quality change

ping @jxer

**User current settting:**

![load](https://cloud.githubusercontent.com/assets/2620870/22829950/93c6a20c-ef83-11e6-837a-eb00fe59b880.png)

-----------------------------------
**After changes quality:**
![load2](https://cloud.githubusercontent.com/assets/2620870/22829951/93f5912a-ef83-11e6-86d5-cb2d1d55f26f.png)
