### PR TITLE
Fix associated file not recognized when torrent is RARed

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -226,7 +226,8 @@ class PostProcessor(object):
         # loop through all the files in the folder, and check if they are the same name
         # even when the cases don't match
         filelist = []
-        rar_file = [os.path.basename(f).rpartition('.')[0].lower() for f in file_list if f.rsplit('.', 1)[1].lower() == 'rar']
+        rar_file = [os.path.basename(f).rpartition('.')[0].lower() for f in file_list
+                    if helpers.get_extension(f).lower() == 'rar']
         for found_file in file_list:
 
             file_name = os.path.basename(found_file).lower()
@@ -263,7 +264,7 @@ class PostProcessor(object):
             # Add the extensions that the user doesn't allow to the 'extensions_to_delete' list
             if app.MOVE_ASSOCIATED_FILES:
                 allowed_extensions = app.ALLOWED_EXTENSIONS.split(',')
-                found_extension = associated_file_path.rpartition('.')[2]
+                found_extension = helpers.get_extension(associated_file_path)
                 if found_extension and found_extension not in allowed_extensions:
                     self._log(u'Associated file extension not found in allowed extensions: .{0}'.format
                               (found_extension.upper()), logger.DEBUG)

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -226,6 +226,7 @@ class PostProcessor(object):
         # loop through all the files in the folder, and check if they are the same name
         # even when the cases don't match
         filelist = []
+        rar_file = [os.path.basename(f).rpartition('.')[0].lower() for f in file_list if f.rsplit('.', 1)[1].lower() == 'rar']
         for found_file in file_list:
 
             file_name = os.path.basename(found_file).lower()
@@ -239,6 +240,9 @@ class PostProcessor(object):
                     if not language:
                         continue
 
+                filelist.append(found_file)
+            # List associated files based on .RAR files like Show.101.720p-GROUP.nfo and Show.101.720p-GROUP.rar
+            elif any([file_name.startswith(r) for r in rar_file]):
                 filelist.append(found_file)
 
         file_path_list = []
@@ -365,6 +369,9 @@ class PostProcessor(object):
             changed_extension = None
             # file extension without leading dot (for example: de.srt)
             extension = cur_file_path[old_base_name_length + 1:]
+            # If basename is different, then is a RAR associated file.
+            if not extension:
+                helpers.get_extension(cur_file_path)
             # initally set current extension as new extension
             new_extension = extension
 


### PR DESCRIPTION
Not that .nfo with different basename is detected
``` 
2017-02-09 16:19:04 DEBUG    Thread-27 :: [51ff22a] Found the following associated files for C:\Users\Fernando\Documents\PP\Quantico.S02E11.720p.HDTV.X264-DIMENSION\Quantico.S02E11.720p.HDTV.X264-DIMENSION.mkv: [u'C:\\Users\\Fernando\\Documents\\PP\\Quantico.S02E11.720p.HDTV.X264-DIMENSION\\quantico.211.720p-dimension.nfo', u'C:\\Users\\Fernando\\Documents\\PP\\Quantico.S02E11.720p.HDTV.X264-DIMENSION\\Quantico.S02E11.720p.HDTV.X264-DIMENSION.pt-BR.srt']
2017-02-09 16:20:20 DEBUG    Thread-27 :: [51ff22a] Hard linking file from C:\Users\Fernando\Documents\PP\Quantico.S02E11.720p.HDTV.X264-DIMENSION\quantico.211.720p-dimension.nfo to C:\Users\Fernando\Documents\Series\Quantico\Season 2\Quantico.S02E11.720p.HDTV.X264-DIMENSION.nfo
```

Its hardlinking with new base name so the seeding nfo file is untouched
Same way to move|copy

Example:

![image](https://cloud.githubusercontent.com/assets/2620870/22755191/3bb77196-ee29-11e6-84e7-fad4d3f359d7.png)
