### PR TITLE
Fix forced backlogged not being limited by BACKLOG_DAYS

### DIFF
--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -44,7 +44,7 @@ class BacklogSearcher(object):
     def __init__(self):
 
         self._last_backlog = self._get_last_backlog()
-        self.cycleTime = app.BACKLOG_FREQUENCY / 60 / 24
+        self.cycleTime = app.BACKLOG_FREQUENCY / 60.0 / 24
         self.lock = threading.Lock()
         self.amActive = False
         self.amPaused = False

--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -49,6 +49,7 @@ class BacklogSearcher(object):
         self.amActive = False
         self.amPaused = False
         self.amWaiting = False
+        self.force = False
         self.currentSearchInfo = {}
 
         self._resetPI()
@@ -90,9 +91,11 @@ class BacklogSearcher(object):
         curDate = datetime.date.today().toordinal()
         from_date = datetime.date.fromordinal(1)
 
-        if not which_shows and not ((curDate - self._last_backlog) >= self.cycleTime):
-            logger.log(u"Running limited backlog on missed episodes " + str(app.BACKLOG_DAYS) + " day(s) and older only")
+        if not which_shows and self.force:
+            logger.log(u"Running limited backlog search on missed episodes from last {0} days".format(app.BACKLOG_DAYS))
             from_date = datetime.date.today() - datetime.timedelta(days=app.BACKLOG_DAYS)
+        else:
+            logger.log(u"Running full backlog search on missed episodes for selected shows")
 
         # go through non air-by-date shows and see if they need any episodes
         for cur_show in show_list:
@@ -186,6 +189,8 @@ class BacklogSearcher(object):
 
     def run(self, force=False):
         try:
+            if force:
+                self.force = True
             self.search_backlog()
         except:
             self.amActive = False

--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -92,10 +92,10 @@ class BacklogSearcher(object):
         from_date = datetime.date.fromordinal(1)
 
         if not which_shows and self.force:
-            logger.log(u"Running limited backlog search on missed episodes from last {0} days".format(app.BACKLOG_DAYS))
+            logger.log(u'Running limited backlog search on missed episodes from last {0} days'.format(app.BACKLOG_DAYS))
             from_date = datetime.date.today() - datetime.timedelta(days=app.BACKLOG_DAYS)
         else:
-            logger.log(u"Running full backlog search on missed episodes for selected shows")
+            logger.log(u'Running full backlog search on missed episodes for selected shows')
 
         # go through non air-by-date shows and see if they need any episodes
         for cur_show in show_list:

--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -49,7 +49,7 @@ class BacklogSearcher(object):
         self.amActive = False
         self.amPaused = False
         self.amWaiting = False
-        self.force = False
+        self.forced = False
         self.currentSearchInfo = {}
 
         self._resetPI()
@@ -91,7 +91,7 @@ class BacklogSearcher(object):
         curDate = datetime.date.today().toordinal()
         from_date = datetime.date.fromordinal(1)
 
-        if not which_shows and self.force:
+        if not which_shows and self.forced:
             logger.log(u'Running limited backlog search on missed episodes from last {0} days'.format(app.BACKLOG_DAYS))
             from_date = datetime.date.today() - datetime.timedelta(days=app.BACKLOG_DAYS)
         else:
@@ -190,7 +190,7 @@ class BacklogSearcher(object):
     def run(self, force=False):
         try:
             if force:
-                self.force = True
+                self.forced = True
             self.search_backlog()
         except:
             self.amActive = False

--- a/views/config_search.mako
+++ b/views/config_search.mako
@@ -70,7 +70,7 @@
                             </div>
                             <div class="field-pair">
                                 <label>
-                                    <span class="component-title">Backlog search day(s)</span>
+                                    <span class="component-title">Forced backlog search day(s)</span>
                                     <span class="component-desc">
                                         <input type="number" min="1" step="1" name="backlog_days" value="${app.BACKLOG_DAYS}" class="form-control input-sm input75"/>
                                         <p>number of day(s) that the "Forced Backlog Search" will cover (e.g. 7 Days)</p>

--- a/views/manage_manageSearches.mako
+++ b/views/manage_manageSearches.mako
@@ -17,6 +17,7 @@
 % endif
 <div id="summary2" class="align-left">
 <h3>Backlog Search:</h3>
+<h5>Note: Limited by backlog days setting: last ${app.BACKLOG_DAYS} days</h5>
 <a class="btn" href="manage/manageSearches/forceBacklog"><i class="icon-exclamation-sign"></i> Force</a>
 <a class="btn" href="manage/manageSearches/pauseBacklog?paused=${('1', '0')[bool(backlogPaused)]}"><i class="icon-${('paused', 'play')[bool(backlogPaused)]}"></i> ${('pause', 'Unpause')[bool(backlogPaused)]}</a>
 % if not backlogRunning:


### PR DESCRIPTION
as @ratoaq2 pointed

dividing integers will result in integer so
`self.cycleTime = app.BACKLOG_FREQUENCY / 60 / 24` will result 0.5 but value will be 0

so a backlog of 12 hours, will always have a cycleTime of  0 in case of the default of 720

So when checking if we should run a forced search, it will never reach that limit code:
`if not which_shows and not ((curDate - self._last_backlog) >= self.cycleTime):`
as `(curDate - self._last_backlog)` will always be higher than cycleTime

Imo this code was done to check if user runned a backlog before waiting for next backlog (so, a forced backlog)

![image](https://cloud.githubusercontent.com/assets/2620870/22883321/6dce1ae2-f1ce-11e6-9a13-ad62613771d2.png)




