### PR TITLE
 Add support to recently deleted global var for multi-indexer

### DIFF
--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -33,6 +33,7 @@ from .helper.exceptions import (
 from .helper.externals import check_existing_shows
 from .helpers import chmod_as_parent, delete_empty_folders, get_showname_from_indexer, make_dir
 from .indexers.indexer_api import indexerApi
+from .indexers.indexer_config import indexerConfig
 from .indexers.indexer_exceptions import (IndexerAttributeNotFound, IndexerError, IndexerException,
                                           IndexerShowAllreadyInLibrary, IndexerShowIncomplete,
                                           IndexerShowNotFoundInLanguage)
@@ -242,7 +243,7 @@ class ShowQueue(generic_queue.GenericQueue):
         self.add_item(queue_item_obj)
 
         # Show removal has been queued, let's updaste the app.RECENTLY_DELETED global, to keep track of it
-        app.RECENTLY_DELETED.update([show.indexerid])
+        app.RECENTLY_DELETED.update(['{0}{1}'.format(indexerConfig[show.indexer].get('identifier'), show.indexerid)])
 
         return queue_item_obj
 

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -242,7 +242,7 @@ class ShowQueue(generic_queue.GenericQueue):
         queue_item_obj = QueueItemRemove(show=show, full=full)
         self.add_item(queue_item_obj)
 
-        # Show removal has been queued, let's updaste the app.RECENTLY_DELETED global, to keep track of it
+        # Show removal has been queued, let's update the app.RECENTLY_DELETED global, to keep track of it
         app.RECENTLY_DELETED.update(['{0}{1}'.format(indexerConfig[show.indexer].get('identifier'), show.indexerid)])
 
         return queue_item_obj

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -242,7 +242,7 @@ class ShowQueue(generic_queue.GenericQueue):
         self.add_item(queue_item_obj)
 
         # Show removal has been queued, let's update the app.RECENTLY_DELETED global, to keep track of it
-        app.RECENTLY_DELETED.update([show.slug])
+        app.RECENTLY_DELETED.update([show.indexer_slug])
 
         return queue_item_obj
 

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -33,7 +33,6 @@ from .helper.exceptions import (
 from .helper.externals import check_existing_shows
 from .helpers import chmod_as_parent, delete_empty_folders, get_showname_from_indexer, make_dir
 from .indexers.indexer_api import indexerApi
-from .indexers.indexer_config import indexerConfig
 from .indexers.indexer_exceptions import (IndexerAttributeNotFound, IndexerError, IndexerException,
                                           IndexerShowAllreadyInLibrary, IndexerShowIncomplete,
                                           IndexerShowNotFoundInLanguage)
@@ -243,7 +242,7 @@ class ShowQueue(generic_queue.GenericQueue):
         self.add_item(queue_item_obj)
 
         # Show removal has been queued, let's update the app.RECENTLY_DELETED global, to keep track of it
-        app.RECENTLY_DELETED.update(['{0}{1}'.format(indexerConfig[show.indexer].get('identifier'), show.indexerid)])
+        app.RECENTLY_DELETED.update([show.slug])
 
         return queue_item_obj
 

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -215,7 +215,7 @@ class Series(TV):
         Can be used to suppress error messages such as attempting to use the
         show object just after being removed.
         """
-        return self.slug in app.RECENTLY_DELETED
+        return self.indexer_slug in app.RECENTLY_DELETED
 
     @property
     def is_scene(self):
@@ -252,7 +252,7 @@ class Series(TV):
         return indexerConfig[self.indexer].get('identifier')
 
     @property
-    def slug(self):
+    def indexer_slug(self):
         """Return the slug name of the show. Example: tvdb1234."""
         return '{name}{indexerid}'.format(name=self.indexer_name, indexerid=self.indexerid)
 
@@ -1669,7 +1669,7 @@ class Series(TV):
 
     def to_json(self, detailed=True):
         """Return JSON representation."""
-        indexer_name = self.slug
+        indexer_name = self.indexer_slug
         bw_list = self.release_groups or BlackAndWhiteList(self.indexerid)
         result = OrderedDict([
             ('id', OrderedDict([

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -90,6 +90,7 @@ from medusa.tv.base import TV
 from medusa.tv.episode import Episode
 
 import shutil_custom
+
 from six import text_type
 
 try:
@@ -214,8 +215,7 @@ class Series(TV):
         Can be used to suppress error messages such as attempting to use the
         show object just after being removed.
         """
-        # Uses same pattern as API v2: tvdb1234 or tvmaze4567
-        return '{0}{1}'.format(indexerConfig[self.indexer].get('identifier'), self.indexerid) in app.RECENTLY_DELETED
+        return self.slug in app.RECENTLY_DELETED
 
     @property
     def is_scene(self):
@@ -245,6 +245,16 @@ class Series(TV):
         if app.CREATE_MISSING_SHOW_DIRS or self.is_location_valid():
             return self._location
         raise ShowDirectoryNotFoundException(u'Show folder does not exist.')
+
+    @property
+    def indexer_name(self):
+        """Return the indexer name identifier. Example: tvdb."""
+        return indexerConfig[self.indexer].get('identifier')
+
+    @property
+    def slug(self):
+        """Return the slug name of the show. Example: tvdb1234."""
+        return '{name}{indexerid}'.format(name=self.indexer_name, indexerid=self.indexerid)
 
     @location.setter
     def location(self, value):
@@ -1659,7 +1669,7 @@ class Series(TV):
 
     def to_json(self, detailed=True):
         """Return JSON representation."""
-        indexer_name = indexerConfig[self.indexer]['identifier']
+        indexer_name = self.slug
         bw_list = self.release_groups or BlackAndWhiteList(self.indexerid)
         result = OrderedDict([
             ('id', OrderedDict([

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -214,9 +214,8 @@ class Series(TV):
         Can be used to suppress error messages such as attempting to use the
         show object just after being removed.
         """
-        # TODO: Fix for multi-indexer.
-        # https://github.com/pymedusa/Medusa/issues/2073
-        return self.indexerid in app.RECENTLY_DELETED
+        # Uses same pattern as API v2: tvdb1234 or tvmaze4567
+        return '{0}{1}'.format(indexerConfig[self.indexer].get('identifier'), self.indexerid) in app.RECENTLY_DELETED
 
     @property
     def is_scene(self):

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
         $('#allowed_qualities :selected').each(function(i, selected){
             selectedAllowed[i] = $(selected).val();
         });
-        var url = 'show/' +  $('#showSlug').attr('value') +
+        var url = 'show/' +  $('#showIndexerSlug').attr('value') +
                   '/backlogged' +
                   '?allowed=' + selectedAllowed +
                   '&preferred=' + selectedPreffered

--- a/static/js/quality-chooser.js
+++ b/static/js/quality-chooser.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
         $('#allowed_qualities :selected').each(function(i, selected){
             selectedAllowed[i] = $(selected).val();
         });
-        var url = 'show/' +  $('#showIndexerName').attr('value') + $('#showID').attr('value') +
+        var url = 'show/' +  $('#showSlug').attr('value') +
                   '/backlogged' +
                   '?allowed=' + selectedAllowed +
                   '&preferred=' + selectedPreffered

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -232,7 +232,7 @@
                     </td>
                     <td class="col-name hidden-xs">
                     % if epResult["description"] != "" and epResult["description"] is not None:
-                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${str(mappings.get(show.indexer).replace('_id', '')) + str(show.indexerid)}_${str(epResult["season"])}_${str(epResult["episode"])}" />
+                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
                     % else:
                         <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
                     % endif

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -232,7 +232,7 @@
                     </td>
                     <td class="col-name hidden-xs">
                     % if epResult["description"] != "" and epResult["description"] is not None:
-                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
+                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.indexer_slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
                     % else:
                         <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
                     % endif

--- a/views/editShow.mako
+++ b/views/editShow.mako
@@ -21,7 +21,7 @@
 </%block>
 <%block name="content">
 <input type="hidden" id="showID" value="${show.indexerid}" />
-<input type="hidden" id="showIndexerName" value="${mappings.get(show.indexer).replace('_id', '')}" />
+<input type="hidden" id="showSlug" value="${show.slug}" />
 % if not header is UNDEFINED:
     <h1 class="header">${header}</h1>
 % else:

--- a/views/editShow.mako
+++ b/views/editShow.mako
@@ -21,7 +21,7 @@
 </%block>
 <%block name="content">
 <input type="hidden" id="showID" value="${show.indexerid}" />
-<input type="hidden" id="showSlug" value="${show.slug}" />
+<input type="hidden" id="showIndexerSlug" value="${show.indexer_slug}" />
 % if not header is UNDEFINED:
     <h1 class="header">${header}</h1>
 % else:


### PR DESCRIPTION
IMO show object must have this unique identifier as an attribute, example 'tvmaze1234'

With new api V2, we will need it in mako and in JS, so it would be good to have in the show object
ping @OmgImAlexis 

Fixes https://github.com/pymedusa/Medusa/issues/2073