### PR TITLE
Fix multi episode downloads not getting marked as downloaded on the history page

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -1211,8 +1211,9 @@ class PostProcessor(object):
         except Exception:
             logger.log(u'Could not create/update meta files. Continuing with post-processing...')
 
-        # log it to history
-        history.logDownload(ep_obj, self.file_path, new_ep_quality, self.release_group, new_ep_version)
+        # log it to history episode and related episodes (multi-episode for example)
+        for cur_ep in [ep_obj] + ep_obj.related_episodes:
+            history.logDownload(cur_ep, self.file_path, new_ep_quality, self.release_group, new_ep_version)
 
         # If any notification fails, don't stop post_processor
         try:


### PR DESCRIPTION
@duramato 

Fixes https://github.com/pymedusa/Medusa/issues/1964


2017-02-14 11:04:35 DEBUG    Thread-28 :: [51ff22a] Parsed 'Under.the.Dome.S03E01E02.720p.HDTV.X264-DIMENSION' into title: Under the Dome, season: 3, episode: [1, 2], screen_size: 720p, format: HDTV, video_codec: h264, video_encoder: x264, release_group: DIMENSION, type: episode, parsing_time: 0.266000032425, total_time: 0.266000032425, absolute_episode: [], quality: 720p HDTV


![image](https://cloud.githubusercontent.com/assets/2620870/22930187/d3e42784-f29d-11e6-99c4-7262c90bcb1a.png)

Display show is ok (tv_episodes table):
![image](https://cloud.githubusercontent.com/assets/2620870/22930393/b914b3fa-f29e-11e6-943a-8eee18891b12.png)

