### PR TITLE
Fix wrong log about default previously aired episodes status

### DIFF
--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -24,7 +24,7 @@ from six import binary_type, text_type
 from traktor import TraktException
 from . import app, generic_queue, logger, name_cache, notifiers, scene_numbering, ui
 from .black_and_white_list import BlackAndWhiteList
-from .common import WANTED
+from .common import WANTED, statusStrings
 from .helper.common import episode_num, sanitize_filename
 from .helper.exceptions import (
     CantRefreshShowException, CantRemoveShowException, CantUpdateShowException,
@@ -446,7 +446,8 @@ class QueueItemAdd(ShowQueueItem):
             self.show.paused = self.paused if self.paused is not None else False
 
             # set up default new/missing episode status
-            logger.log(u"Setting all episodes to the specified default status: " + str(self.show.default_ep_status))
+            logger.log(u"Setting all previously aired episodes to the specified status: {status}".format
+                       (status=statusStrings[self.default_status]))
             self.show.default_ep_status = self.default_status
 
             if self.show.anime:


### PR DESCRIPTION
Fixes https://github.com/pymedusa/Medusa/issues/1538

I set:
![image](https://cloud.githubusercontent.com/assets/2620870/22931788/bd69889e-f2a4-11e6-93db-aa813430c29e.png)

It loads the page with default episode status, but if you change it. ofc it will use the one you choosed:
```html
 <option value="${cur_status}" ${'selected="selected"' if app.STATUS_DEFAULT == cur_status else ''}
```

SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S04E10 not found in the database
SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S04E10 has absolute number: 40 
SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S04E10 has already aired, marking it 'SKIPPED'
SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S05E01 not found in the database
SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S05E01 has absolute number: 41 
SHOWQUEUE-ADD :: [51ff22a] 262414: Bates Motel S05E01 airs in the future or has no airdate, marking it 'UNAIRED'

The default episode status will only be used after a show update when converting an UNAIRED episode to {default_ep_status}

We only use "status for all future episode" after we add the show:
```python
        # After initial add, set to default_status_after.
        self.show.default_ep_status = self.default_status_after
```

![image](https://cloud.githubusercontent.com/assets/2620870/22931278/cc944e3c-f2a2-11e6-9496-7f8317626609.png)
