### PR TITLE
remove extra alert display

### DIFF
--- a/views/snatchSelection.mako
+++ b/views/snatchSelection.mako
@@ -14,12 +14,6 @@
 <input type="hidden" id="showID" value="${show.indexerid}" />
 <div class="clearfix"></div><!-- div.clearfix //-->
 
-% if show_message:
-    <div class="alert alert-info">
-        ${show_message}
-    </div><!-- .alert .alert-info //-->
-% endif
-
 <%include file="/partials/showheader.mako"/>
 
 <div class="row">


### PR DESCRIPTION
Fixes extra alert display on snatchSelection when a show is updating.
alert display is contained in showHeader.mako

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
