### PR TITLE
Can't change status and select ep status (colored keys) in snatchSelection

### DIFF
--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -336,6 +336,7 @@
         </table>
     </div> <!-- end of col -->
 </div> <!-- row -->
+</div><!-- content -->
 
 
 

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -29,13 +29,35 @@
 <%include file="/partials/showheader.mako"/>
 
 <div class="row">
-    <div class="col-md-12" >
-        <div class="pull-right col-md-4">
-            <button id="popover" type="button" class="btn pull-right">Select Columns <b class="caret"></b></button>
+        <div class="pull-lg-left">
+            <select id="statusSelect" class="form-control form-control-inline input-sm">
+            <option selected value="">Change selected to:</option>
+            <option value=""">--------------------------------------------</option>
+            <% availableStatus = [WANTED, SKIPPED, IGNORED, FAILED] %>
+            % if not app.USE_FAILED_DOWNLOADS:
+            <% availableStatus.remove(FAILED) %>
+            % endif
+            % for cur_status in availableStatus + Quality.DOWNLOADED + Quality.ARCHIVED:
+                % if cur_status not in [DOWNLOADED, ARCHIVED]:
+                <option value="${cur_status}">${statusStrings[cur_status]}</option>
+                % endif
+            % endfor
+            </select>
+            <input type="hidden" id="showID" value="${show.indexerid}" />
+            <input type="hidden" id="indexer" value="${show.indexer}" />
+            <input class="btn btn-inline" type="button" id="changeStatus" value="Go" />
         </div>
-    </div>
+        <div class="pull-lg-right" id="checkboxControls">
+            <button class="btn btn-xs seriesCheck">Select Filtered Episodes</button>
+            <button class="btn btn-xs clearAll">Clear All</button>
+            <% total_snatched = ep_counts[Overview.SNATCHED] + ep_counts[Overview.SNATCHED_PROPER] + ep_counts[Overview.SNATCHED_BEST] %>
+            <label for="wanted"><span class="wanted"><input type="checkbox" id="wanted" checked="checked" /> Wanted: <b>${ep_counts[Overview.WANTED]}</b></span></label>
+            <label for="qual"><span class="qual"><input type="checkbox" id="qual" checked="checked" /> Allowed: <b>${ep_counts[Overview.QUAL]}</b></span></label>
+            <label for="good"><span class="good"><input type="checkbox" id="good" checked="checked" /> Preferred: <b>${ep_counts[Overview.GOOD]}</b></span></label>
+            <label for="skipped"><span class="skipped"><input type="checkbox" id="skipped" checked="checked" /> Skipped: <b>${ep_counts[Overview.SKIPPED]}</b></span></label>
+            <label for="snatched"><span class="snatched"><input type="checkbox" id="snatched" checked="checked" /> Snatched: <b>${total_snatched}</b></span></label>
+        </div>
 </div>
-
 <div class="row">
     <div class="col-md-12">
         <table id="${'animeTable' if show.is_anime else 'showTable'}" class="${'displayShowTableFanArt tablesorterFanArt' if app.FANART_BACKGROUND else 'displayShowTable'} display_show" cellspacing="0" border="0" cellpadding="0">
@@ -113,6 +135,7 @@
                         % if not app.DISPLAY_ALL_SEASONS:
                             <button id="showseason-${epResult['season']}" type="button" class="btn top-5 bottom-5 pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Hide Episodes</button>
                         % endif
+                        <button id="popover" type="button" class="btn top-5 bottom-5 pull-right">Select Columns <b class="caret"></b></button>
                     </th>
                 </tr>
             </tbody>

--- a/views/partials/showheader.mako
+++ b/views/partials/showheader.mako
@@ -229,43 +229,5 @@
                      </div> <!-- end of show-status -->
                 </div> <!-- end of summary -->
             </div> <!-- end of row -->
-            <div class="row"> <!-- Checkbox filter controls -->
-                <div class="col-lg-12" id="checkboxControls">
-                    <div class="key">
-                        <div class="row">
-                            <div class="pull-left col-lg-8 col-md-12">
-                                <% total_snatched = ep_counts[Overview.SNATCHED] + ep_counts[Overview.SNATCHED_PROPER] + ep_counts[Overview.SNATCHED_BEST] %>
-                                <label for="wanted"><span class="wanted"><input type="checkbox" id="wanted" checked="checked" /> Wanted: <b>${ep_counts[Overview.WANTED]}</b></span></label>
-                                <label for="qual"><span class="qual"><input type="checkbox" id="qual" checked="checked" /> Allowed: <b>${ep_counts[Overview.QUAL]}</b></span></label>
-                                <label for="good"><span class="good"><input type="checkbox" id="good" checked="checked" /> Preferred: <b>${ep_counts[Overview.GOOD]}</b></span></label>
-                                <label for="skipped"><span class="skipped"><input type="checkbox" id="skipped" checked="checked" /> Skipped: <b>${ep_counts[Overview.SKIPPED]}</b></span></label>
-                                <label for="snatched"><span class="snatched"><input type="checkbox" id="snatched" checked="checked" /> Snatched: <b>${total_snatched}</b></span></label>
-                                <button class="btn btn-xs seriesCheck">Select Filtered Episodes</button>
-                                <button class="btn btn-xs clearAll">Clear All</button>
-                            </div>
-                            <div class="pull-lg-right col-lg-4 col-md-12">
-                                <div class="pull-lg-right">
-                                    <select id="statusSelect" class="form-control form-control-inline input-sm">
-                                    <option selected value="">Change selected to:</option>
-                                    <option value=""">--------------------------------------------</option>
-                                    <% availableStatus = [WANTED, SKIPPED, IGNORED, FAILED] %>
-                                    % if not app.USE_FAILED_DOWNLOADS:
-                                    <% availableStatus.remove(FAILED) %>
-                                    % endif
-                                    % for cur_status in availableStatus + Quality.DOWNLOADED + Quality.ARCHIVED:
-                                        % if cur_status not in [DOWNLOADED, ARCHIVED]:
-                                        <option value="${cur_status}">${statusStrings[cur_status]}</option>
-                                        % endif
-                                    % endfor
-                                    </select>
-                                    <input type="hidden" id="showID" value="${show.indexerid}" />
-                                    <input type="hidden" id="indexer" value="${show.indexer}" />
-                                    <input class="btn btn-inline" type="button" id="changeStatus" value="Go" />
-                                </div>
-                            </div>
-                        </div> <!-- end of row -->
-                    </div> <!-- end of key -->
-                </div> <!-- checkboxControls -->
-            </div> <!-- end of row -->
         </div> <!-- show-info-container -->
     </div> <!-- end of col -->


### PR DESCRIPTION
With my commit:

the checkboxes select episodes to change status are on the left. That's why i moved the `select` to the left to be together with the checkboxes
The colored keys i moved to the right, as the "status" column is in the right part of the screen.

ping @Thraxis 

### DisplayShow
![image](https://cloud.githubusercontent.com/assets/2620870/23023511/b811e72e-f434-11e6-882d-16051046b54b.png)


-----------------

### Snatch selection:

Before: https://github.com/pymedusa/Medusa/pull/2174#issuecomment-280189997

Now:

![image](https://cloud.githubusercontent.com/assets/2620870/23023518/c4898c46-f434-11e6-94c7-ef28046ecf28.png)
