### PR TITLE
Improved logs for cached results and show match

### DIFF
--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -252,6 +252,9 @@ class NameParser(object):
             raise InvalidShowException('Unable to match {result.original_name} to a show in your database. '
                                        'Parser result: {result}'.format(result=result))
 
+        logger.debug("Matched release '{release}' to a show in your database: '{name}'",
+                     release=result.original_name, name=result.show.name)
+
         if result.season_number is None and not result.episode_numbers and \
                 result.air_date is None and not result.ab_episode_numbers and not result.series_name:
             raise InvalidNameException('Unable to parse {result.original_name}. No episode numbering info. '

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -519,15 +519,12 @@ class Cache(object):
                 sql_results = list(itertools.chain(*sql_results))
             else:
                 sql_results = []
-                logger.log(
-                    "No cached results in {provider} for show '{show_name}'"
-                    " episode '{ep}'".format(
-                        provider=self.provider_id,
-                        show_name=ep_obj.show.name,
-                        ep=episode_num(ep_obj.season, ep_obj.episode)
-                    ),
-                    logger.DEBUG
-                )
+                logger.log("{id}: No cached results in {provider} for show '{show_name}' episode '{ep}'".format
+                           (id=ep_obj.show.indexerid,
+                            provider=self.provider.name,
+                            show_name=ep_obj.show.name,
+                            ep=episode_num(ep_obj.season, ep_obj.episode)),
+                           logger.DEBUG)
 
         # for each cache entry
         for cur_result in sql_results:
@@ -578,7 +575,12 @@ class Cache(object):
             title = cur_result[b'name']
             url = cur_result[b'url']
 
-            logger.log('Found result {0} at {1}'.format(title, url))
+            logger.log("{id}: Using cached results from {provider} for show '{show_name}' episode '{ep}'".format
+                       (id=ep_obj.show.indexerid,
+                        provider=self.provider.name,
+                        show_name=ep_obj.show.name,
+                        ep=episode_num(ep_obj.season, ep_obj.episode)),
+                       logger.DEBUG)
 
             result = self.provider.get_result([ep_obj])
             result.show = show_obj


### PR DESCRIPTION
Now we can clearly know it was a cached result and know the indexer id
Also which show was matched in the database

This usefull if user adds one show with tvdb and later removed that show to add in tvmaze.
So when we get the cached result we will know we are using the correct cache item
