### PR TITLE
Load config file as UTF-8

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -290,7 +290,7 @@ class Application(object):
         if self.console_logging and not os.path.isfile(app.CONFIG_FILE):
             sys.stdout.write('Unable to find %s, all settings will be default!\n' % app.CONFIG_FILE)
 
-        app.CFG = ConfigObj(app.CONFIG_FILE)
+        app.CFG = ConfigObj(app.CONFIG_FILE, encoding='UTF-8', default_encoding='UTF-8')
 
         # Initialize the config and our threads
         self.initialize(console_logging=self.console_logging)


### PR DESCRIPTION
Fix root dir not decoded

Related: https://github.com/pymedusa/Medusa/issues/1652#issuecomment-280756677


### Before:
![image](https://cloud.githubusercontent.com/assets/2620870/23087182/59f91d62-f559-11e6-8d39-decb62fefc30.png)

### After:

![image](https://cloud.githubusercontent.com/assets/2620870/23087189/62437d82-f559-11e6-81c6-97d5eb38cf46.png)

