### PR TITLE
Make get_xem_numbering_for_show lazy

### DIFF
--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -21,11 +21,12 @@
 # @copyright: Dermot Buckley
 #
 
-from collections import defaultdict
 import datetime
 import time
 import traceback
 import warnings
+
+from collections import defaultdict
 
 from . import app, db, helpers, logger
 from .helper.exceptions import ex


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This is a partial fix for #1989 as discussed in the issue it does not schedule any refresh of the numbering.