### PR TITLE
Hotfix/fix season scene exceptions not shown (#2259)

### DIFF
--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -124,7 +124,7 @@ def get_all_scene_exceptions(indexer_id):
     :param indexer_id: ID to check
     :return: dict of exceptions (e.g. exceptions_cache[season][exception_name])
     """
-    return exceptions_cache.get(indexer_id, defaultdict(set))
+    return exceptions_cache.get(int(indexer_id), defaultdict(set))
 
 
 def get_scene_seasons(indexer_id):
@@ -135,7 +135,7 @@ def get_scene_seasons(indexer_id):
     :return: list of seasons.
     """
     warnings.warn('Use dict.keys() directly instead.', DeprecationWarning)
-    return exceptions_cache[indexer_id].keys()
+    return exceptions_cache[int(indexer_id)].keys()
 
 
 def get_scene_exception_by_name(show_name):

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -685,7 +685,8 @@ class Home(WebRoot):
         :return: A json with the scene exceptions per season.
         """
         return json.dumps({
-            'seasonExceptions': get_all_scene_exceptions(indexer_id),
+            'seasonExceptions': {season: list(exception_name) for season, exception_name
+                                 in iteritems(get_all_scene_exceptions(indexer_id))},
             'xemNumbering': {tvdb_season_ep[0]: anidb_season_ep[0]
                              for (tvdb_season_ep, anidb_season_ep)
                              in iteritems(get_xem_numbering_for_show(indexer_id, indexer, refresh_data=False))}


### PR DESCRIPTION
Fixed missing season scene exception (medusa and xem) icons in displayShow page.
* Return key: list(list_of_exceptions) instead of key: set_of_exceptions. As a set is not json serializable.
* Cast to int, as a json requests was passing the indexer_id as str.
* Use iteritems from six, as i've already imported it. And it's a little bit faster.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
