### PR TITLE
Fix speedcd login page

### DIFF
--- a/medusa/providers/torrent/html/speedcd.py
+++ b/medusa/providers/torrent/html/speedcd.py
@@ -50,7 +50,7 @@ class SpeedCDProvider(TorrentProvider):
         # URLs
         self.url = 'https://speed.cd'
         self.urls = {
-            'login': urljoin(self.url, 'takeElogin.php'),
+            'login': urljoin(self.url, 'take_login.php'),
             'search': urljoin(self.url, 'browse.php'),
         }
 


### PR DESCRIPTION
I just logged from browser:
```
:authority:speed.cd
:method:POST
:path:/take_login.php
:scheme:https
```

```
2017-02-23 19:34:14 DEBUG    SEARCHQUEUE-MANUAL-257655 :: [Speedcd] :: [6399d78] Found result: Arrow S05E14 The Sin-Eate 1080p WEBRip DD5 1 x264 with 3 seeders and 0 leechers
2017-02-23 19:34:13 DEBUG    SEARCHQUEUE-MANUAL-257655 :: [Speedcd] :: [6399d78] GET URL: https://speed.cd/browse.php?c55=1&c52=1&search=Arrow+S05E14&c41=1&c50=1&c2=1&c30=1&c49=1 [Status: 200]
2017-02-23 19:34:12 DEBUG    SEARCHQUEUE-MANUAL-257655 :: [Speedcd] :: [6399d78] Search string: Arrow S05E14
```