### PR TITLE
will fix multiple dirs removed when delete pressed for RootDirs

### DIFF
--- a/static/js/root-dirs.js
+++ b/static/js/root-dirs.js
@@ -99,6 +99,7 @@ $(document).ready(function() {
         $('#rootDirText').change();
         console.log('rootDirText: ' + $('#rootDirText').val());
     }
+
     function addRootDir(path) {
         if (path.length === 0) {
             return;

--- a/views/addShows_newShow.mako
+++ b/views/addShows_newShow.mako
@@ -7,7 +7,6 @@
 <%block name="scripts">
 <script type="text/javascript" src="js/quality-chooser.js?${sbPID}"></script>
 <script type="text/javascript" src="js/add-show-options.js?${sbPID}"></script>
-<script type="text/javascript" src="js/root-dirs.js?${sbPID}"></script>
 <script type="text/javascript" src="js/blackwhite.js?${sbPID}"></script>
 </%block>
 <%block name="content">

--- a/views/addShows_trendingShows.mako
+++ b/views/addShows_trendingShows.mako
@@ -3,7 +3,6 @@
     from medusa import app
 %>
 <%block name="scripts">
-<script type="text/javascript" src="js/root-dirs.js?${sbPID}"></script>
 <script type="text/javascript" src="js/plot-tooltip.js?${sbPID}"></script>
 <script type="text/javascript" src="js/quality-chooser.js?${sbPID}"></script>
 % if enable_anime_options:


### PR DESCRIPTION
root-dirs.js was included both in main.mako and in addShows_newShow.make and addShows_trendingShows.mako causing the delete event to fire multiple times.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
