### PR TITLE
1) PP only the last snatch. Don't PP old snatches - unless user set priority in manual PP

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -804,31 +804,8 @@ class PostProcessor(object):
                     # Check if the last snatch was a manual snatch
                     if history_result[0]['manually_searched']:
                         self.manually_searched = True
-
-                    download_result = main_db_con.select(
-                        'SELECT resource '
-                        'FROM history '
-                        'WHERE showid = ? '
-                        'AND season = ? '
-                        'AND episode = ? '
-                        'AND quality = ? '
-                        "AND action LIKE '%04' "
-                        'ORDER BY date DESC',
-                        [show_id, season, episode, quality])
-
-                    if download_result:
-                        download_name = os.path.basename(download_result[0]['resource'])
-                        # If the file name we are processing differs from the file
-                        # that was previously processed, we want this file
-                        if self.file_name != download_name:
-                            self.in_history = True
-                            return
-
-                    else:
-                        # There aren't any other files processed before for this
-                        # episode and quality, we can safely say we want this file
-                        self.in_history = True
-                        return
+                    self.in_history = True
+                return
 
     def _is_priority(self, old_ep_quality, new_ep_quality):
             """


### PR DESCRIPTION
Related to @labrys and @OmgImAlexis issue
ping @medariox as its his code

PP only the last snatch. Ignore old snatches - unless user set priority in manual PP

In a preferred scenario, it would snatch first the non-preferred and then the preferred, so this one would be the last snatched.

### Option 1 https://github.com/pymedusa/Medusa/pull/2319
This PR
Disadvantages: hanging release in PP folder only if user don't seed it (if option is move, it will hang there until do some action)

**OR**

### Option 2 https://github.com/pymedusa/Medusa/pull/2323
 we only search when status is WANTED or DOWNLOADED (remove the SNATCHED)
So we will always have one snatch per show-season-episode
(We already do this with PROPERs)

**Disadvantages**: snatch of preferred would take longer and user won't seeding the new release as soon it get release

