### PR TITLE
2) Make one snatch per show-season-episode

### DIFF
--- a/medusa/common.py
+++ b/medusa/common.py
@@ -613,7 +613,7 @@ class Quality(object):
 
         #  Can't be SNATCHED_BEST because the quality is already final (unless user changes qualities).
         #  All other status will return false: IGNORED, SKIPPED, FAILED.
-        if cur_status not in (WANTED, DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST):
+        if cur_status not in (WANTED, DOWNLOADED):
             return False, 'Status is not allowed: {0}. Skipping episode'.format(statusStrings[cur_status])
 
         # If current status is WANTED, we must always search

--- a/medusa/common.py
+++ b/medusa/common.py
@@ -653,9 +653,9 @@ class Quality(object):
         :param manually_searched: True if episode was manually searched by user
         :return: True if the old quality should be replaced with new quality.
         """
-        if ep_status and ep_status not in Quality.DOWNLOADED + Quality.SNATCHED + Quality.SNATCHED_PROPER:
+        if ep_status and ep_status not in Quality.DOWNLOADED:
             if not force:
-                return False, 'Episode status is not DOWNLOADED|SNATCHED|SNATCHED PROPER. Ignoring new quality'
+                return False, 'Episode status is not DOWNLOADED. Ignoring new quality'
 
         # If existing quality is UNKNOWN but Preferred is set, UNKNOWN should be replaced.
         if old_quality == Quality.UNKNOWN:

--- a/tests/test_should_replace.py
+++ b/tests/test_should_replace.py
@@ -39,7 +39,7 @@ import pytest
         'manually_searched': False,
         'expected': False
     },
-    {  # p3: Snatched 720p HDTV and found 720p BluRay: yes
+    {  # p3: Snatched 720p HDTV and found 720p BluRay: no
         'ep_status': SNATCHED,
         'cur_quality': Quality.HDTV,
         'new_quality': Quality.HDBLURAY,
@@ -48,7 +48,7 @@ import pytest
         'download_current_quality': False,
         'force': False,
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
     {  # p4: Snatched Proper 720p HDTV and found 720p BluRay, but 720p HDTV is preferred: no
         'ep_status': SNATCHED_PROPER,
@@ -413,7 +413,7 @@ import pytest
         'manually_searched': False,
         'expected': False
     },
-    {  # p37: Current quality is NONE: yes
+    {  # p37: Current quality is NONE: no
         'ep_status': SNATCHED,
         'cur_quality': Quality.NONE,
         'new_quality': Quality.HDTV,
@@ -422,7 +422,7 @@ import pytest
         'download_current_quality': False,
         'force': False,
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
     {  # p38: Downloaded UNKNOWN and its on Allowed: no
         'ep_status': DOWNLOADED,

--- a/tests/test_should_search.py
+++ b/tests/test_should_search.py
@@ -52,21 +52,21 @@ class TestTVShow(Series):
         'manually_searched': False,
         'expected': False
     },
-    {  # p4: Current status is SNATCHED: yes
+    {  # p4: Current status is SNATCHED: no
         'status': Quality.composite_status(SNATCHED, Quality.HDTV),
         'show_obj': TestTVShow(indexer=1, indexer_id=1, lang='',
                                quality=Quality.combine_qualities([Quality.HDTV],  # Allowed Qualities
                                                                  [Quality.HDWEBDL])),  # Preferred Qualities
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
-    {  # p5: Current status is SNATCHED_PROPER: yes
+    {  # p5: Current status is SNATCHED_PROPER: no
         'status': Quality.composite_status(SNATCHED_PROPER, Quality.HDTV),
         'show_obj': TestTVShow(indexer=1, indexer_id=1, lang='',
                                quality=Quality.combine_qualities([Quality.HDTV],  # Allowed Qualities
                                                                  [Quality.HDWEBDL])),  # Preferred Qualities
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
     {  # p6: Status is DOWNLOADED: yes
         'status': Quality.composite_status(DOWNLOADED, Quality.HDTV),
@@ -156,21 +156,21 @@ class TestTVShow(Series):
         'manually_searched': False,
         'expected': True
     },
-    {  # p17: ´SNATCHED BEST but this quality is no longer wanted: yes
+    {  # p17: ´SNATCHED BEST but this quality is no longer wanted: no
         'status': Quality.composite_status(SNATCHED_BEST, Quality.SDTV),
         'show_obj': TestTVShow(indexer=1, indexer_id=1, lang='',
                                quality=Quality.combine_qualities([Quality.HDTV],  # Allowed Qualities
                                                                  [Quality.HDBLURAY])),  # Preferred Qualities
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
-    {  # p18: ´SNATCHED BEST but this quality is no longer in preferred but in allowed. Preferred set: yes
+    {  # p18: ´SNATCHED BEST but this quality is no longer in preferred but in allowed. Preferred set: no
         'status': Quality.composite_status(SNATCHED_BEST, Quality.SDTV),
         'show_obj': TestTVShow(indexer=1, indexer_id=1, lang='',
                                quality=Quality.combine_qualities([Quality.HDTV, Quality.SDTV],  # Allowed Qualities
                                                                  [Quality.HDBLURAY])),  # Preferred Qualities
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
     {  # p19: ´SNATCHED BEST but this quality is no longer in preferred but in allowed. Preferred not set: no
         'status': Quality.composite_status(SNATCHED_BEST, Quality.SDTV),
@@ -180,13 +180,13 @@ class TestTVShow(Series):
         'manually_searched': False,
         'expected': False
     },
-    {  # p20: ´SNATCHED BEST but this quality is no longer wanted. Preferred not set: yes
+    {  # p20: ´SNATCHED BEST but this quality is no longer wanted. Preferred not set: no
         'status': Quality.composite_status(SNATCHED_BEST, Quality.SDTV),
         'show_obj': TestTVShow(indexer=1, indexer_id=1, lang='',
                                quality=Quality.combine_qualities([Quality.HDTV],  # Allowed Qualities
                                                                  [])),  # Preferred Qualities
         'manually_searched': False,
-        'expected': True
+        'expected': False
     },
 ])
 def test_should_search(p):


### PR DESCRIPTION
Fixes duplicates snatches for same show-season-episode
It's the best solution I could find without breaking other stuff

Also we also do the same with PROPERs (only snatch a proper if current ep status is DOWNLOADED)

The only disavantages is that preferred snatch will take a little more time.
BUT as daily searcher is 30min, in most cases, Medusa will PP the allowed quality, and in next daily, the preferred will be snatched.

Example: 10Mbps connection (1.25 mb/s), will transfer in 30min(1800s), 2.25 GB.
Which is necessary to download most qualities.

Worst cases, it will snatch in the second dailysearcher

@pymedusa/developers i won't try to fix this issue in another way.