### PR TITLE
Don't delete extracted media file if it was postponed

### DIFF
--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -229,7 +229,8 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
             #  As is a hardlink/symlink we can't keep the extracted file in the folder
             #  Otherwise when torrent+data gets removed the folder won't be deleted because of hanging files
             #  That's why we don't check for app.DELRARCONTENTS here.
-            delete_files(path, rarContent, result)
+            # Don't delete extracted video file if it was Postponed by missing subtitles
+            delete_files(path, set(rarContent) - set(videoInRar), result)
             for video in set(videoFiles) - set(videoInRar):
                 process_media(path, [video], nzbName, process_method, force, is_priority, ignore_subs, result)
         elif app.DELRARCONTENTS and videoInRar:

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -280,7 +280,8 @@ def processDir(dirName, nzbName=None, process_method=None, force=False, is_prior
                     #  As is a hardlink/symlink we can't keep the extracted file in the folder
                     #  Otherwise when torrent+data gets removed the folder won't be deleted because of hanging files
                     #  That's why we don't check for app.DELRARCONTENTS here.
-                    delete_files(processPath, rarContent, result)
+                    # Don't delete extracted video file if it was Postponed by missing subtitles
+                    delete_files(processPath, set(rarContent) - set(videoInRar), result)
                 elif app.DELRARCONTENTS and videoInRar:
                     process_media(processPath, videoInRar, nzbName, process_method, force, is_priority, ignore_subs, result)
                     process_media(processPath, set(videoFiles) - set(videoInRar), nzbName, process_method, force,


### PR DESCRIPTION
When we call process_media it can postpone the PP of a media file because it doesn't have subtitles
so after that, we delete all rar content files (nfo, srt) that wasn't listed as wanted "associated files"
This fixes the deletion of the media file when media was postponed

2017-03-02 01:32:04 DEBUG    FINDSUBTITLES :: [32b3c7d] No subtitles associated. Postponing the post-process of this file: Show.S06E16.720p.HDTV.x264-AVS.mkv
2017-03-02 01:32:04 DEBUG    FINDSUBTITLES :: [32b3c7d] Deleting file: Show.S06E16.720p.HDTV.x264-AVS.mkv