### PR TITLE
Will change manual search to fix loading of results

### DIFF
--- a/static/js/home/snatch-selection.js
+++ b/static/js/home/snatch-selection.js
@@ -40,7 +40,8 @@ MEDUSA.home.snatchSelection = function() {
 
     $.fn.loadContainer = function(path, loadingTxt, errorTxt, callback) {
         updateSpinner(loadingTxt);
-        $(this).load(path + ' #container', function(response, status) {
+        $('#manualSearchMeta').load(path + ' #manualSearchMeta meta');
+        $(this).load(path + ' #manualSearchTbody tr', function(response, status) {
             if (status === 'error') {
                 updateSpinner(errorTxt, false);
             }
@@ -112,7 +113,7 @@ MEDUSA.home.snatchSelection = function() {
         }
 
         self.refreshResults = function() {
-            $('#wrapper').loadContainer(
+            $('#manualSearchTbody').loadContainer(
                     'home/snatchSelection?show=' + urlParams,
                     'Loading new search results...',
                     'Time out, refresh page to try again',
@@ -141,28 +142,25 @@ MEDUSA.home.snatchSelection = function() {
             if (data.result === 'refresh') {
                 self.refreshResults();
                 updateSpinner('Refreshed results...', true);
-                initTableSorter('#srchresults');
             }
             if (data.result === 'searching') {
                 // ep is searched, you will get a results any minute now
                 pollInterval = 5000;
                 $('.manualSearchButton').prop('disabled', true);
                 updateSpinner('The episode is being searched, please wait......', true);
-                initTableSorter('#srchresults');
             }
             if (data.result === 'queued') {
                 // ep is queued, this might take some time to get results
                 pollInterval = 7000;
                 $('.manualSearchButton').prop('disabled', true);
                 updateSpinner('The episode has been queued, because another search is taking place. please wait..', true);
-                initTableSorter('#srchresults');
             }
             if (data.result === 'finished') {
                 // ep search is finished
                 updateSpinner('Search finished', false);
                 $('.manualSearchButton').removeAttr('disabled');
                 repeat = false;
-                initTableSorter('#srchresults');
+                $('#srchresults').trigger('update', true);
                 $('[datetime]').timeago();
             }
             if (data.result === 'error') {
@@ -170,7 +168,6 @@ MEDUSA.home.snatchSelection = function() {
                 console.log('Probably tried to call manualSelectCheckCache, while page was being refreshed.');
                 $('.manualSearchButton').removeAttr('disabled');
                 repeat = true;
-                initTableSorter('#srchresults');
             }
         });
     }
@@ -205,7 +202,6 @@ MEDUSA.home.snatchSelection = function() {
 
     // Moved and rewritten this from displayShow. This changes the button when clicked for collapsing/expanding the
     // "Show History" button to show or hide the snatch/download/failed history for a manual searched episode or pack.
-    initTableSorter('#showTable');
 
     $('#popover').popover({
         placement: 'bottom',
@@ -223,6 +219,7 @@ MEDUSA.home.snatchSelection = function() {
     });
 
     $(function() {
+        initTableSorter('#srchresults');
         moveSummaryBackground();
         $('body').on('hide.bs.collapse', '.collapse.toggle', function() {
             $('#showhistory').text('Show History');

--- a/views/snatchSelection.mako
+++ b/views/snatchSelection.mako
@@ -72,7 +72,9 @@
                 </table>
             % endif
             <!-- add provider meta data -->
-                <meta data-last-prov-updates='${provider_results["last_prov_updates"]}' data-show="${show.indexerid}" data-season="${season}" data-episode="${episode}" data-manual-search-type="${manual_search_type}">
+                <div id='manualSearchMeta'>
+                    <meta data-last-prov-updates='${provider_results["last_prov_updates"]}' data-show="${show.indexerid}" data-season="${season}" data-episode="${episode}" data-manual-search-type="${manual_search_type}">
+                </div>
                 <div class="col-md-12 bottom-15">
                     <div class="col-md-8 left-30">
                     <input class="btn manualSearchButton" type="button" id="reloadResults" value="Reload Results" data-force-search="0" />
@@ -102,7 +104,7 @@
                             <th data-priority="critical" class="col-search">Snatch</th>
                         </tr>
                     </thead>
-                    <tbody aria-live="polite" aria-relevant="all">
+                    <tbody id="manualSearchTbody" aria-live="polite" aria-relevant="all">
                     % for hItem in provider_results['found_items']:
                         <tr id='${hItem["name"]}' class="skipped season-${season} seasonstyle ${hItem['status_highlight']}" role="row">
                             <td class="release-name-ellipses triggerhighlight">


### PR DESCRIPTION
- Table is only initialized once
- results replace only table content
- sort and filter are restored after search is finished,


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
