### PR TITLE
fix disappearing git alert, allows git_path change without restart

### DIFF
--- a/medusa/config.py
+++ b/medusa/config.py
@@ -302,7 +302,9 @@ def change_GIT_PATH():
     Force a run to clear or set any error messages.
     """
     app.version_check_scheduler = None
-    app.version_check_scheduler = scheduler.Scheduler(CheckVersion(), cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY), threadName="CHECKVERSION", silent=False)
+    app.version_check_scheduler = scheduler.Scheduler(CheckVersion(),
+            cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY),
+            threadName="CHECKVERSION", silent=False)
     app.version_check_scheduler.enable = True
     app.version_check_scheduler.start()
     app.version_check_scheduler.forceRun()

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -25,8 +25,8 @@ from requests.compat import urlsplit
 from six import iteritems
 from six.moves.urllib.parse import urlunsplit, uses_netloc
 from . import app, common, db, helpers, logger, naming, scheduler
-from . version_checker import CheckVersion
 from .helper.common import try_int
+from . version_checker import CheckVersion
 
 # Address poor support for scgi over unix domain sockets
 # this is not nicely handled by python currently
@@ -295,18 +295,18 @@ def change_VERSION_NOTIFY(version_notify):
     if oldSetting is False and version_notify is True:
         app.version_check_scheduler.forceRun()
 
+
 def change_GIT_PATH():
     """
     Recreate the version_check scheduler when GIT_PATH is changed.
     Force a run to clear or set any error messages.
     """
     app.version_check_scheduler = None
-    app.version_check_scheduler = scheduler.Scheduler(CheckVersion(),
-                                                                cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY),
-                                                                threadName="CHECKVERSION", silent=False)
+    app.version_check_scheduler = scheduler.Scheduler(CheckVersion(), cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY), threadName="CHECKVERSION", silent=False)
     app.version_check_scheduler.enable = True
     app.version_check_scheduler.start()
     app.version_check_scheduler.forceRun()
+
 
 def change_DOWNLOAD_PROPERS(download_propers):
     """

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -302,9 +302,8 @@ def change_GIT_PATH():
     Force a run to clear or set any error messages.
     """
     app.version_check_scheduler = None
-    app.version_check_scheduler = scheduler.Scheduler(CheckVersion(),
-            cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY),
-            threadName="CHECKVERSION", silent=False)
+    app.version_check_scheduler = scheduler.Scheduler(
+        CheckVersion(), cycleTime=datetime.timedelta(hours=app.UPDATE_FREQUENCY), threadName="CHECKVERSION", silent=False)
     app.version_check_scheduler.enable = True
     app.version_check_scheduler.start()
     app.version_check_scheduler.forceRun()

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -26,7 +26,7 @@ from six import iteritems
 from six.moves.urllib.parse import urlunsplit, uses_netloc
 from . import app, common, db, helpers, logger, naming, scheduler
 from .helper.common import try_int
-from . version_checker import CheckVersion
+from .version_checker import CheckVersion
 
 # Address poor support for scgi over unix domain sockets
 # this is not nicely handled by python currently

--- a/medusa/server/web/config/general.py
+++ b/medusa/server/web/config/general.py
@@ -98,8 +98,9 @@ class ConfigGeneral(Config):
         app.GIT_TOKEN = git_token
         app.GIT_RESET = config.checkbox_to_value(git_reset)
         app.GIT_RESET_BRANCHES = helpers.ensure_list(git_reset_branches)
-        app.GIT_PATH = git_path
-        config.change_GIT_PATH()
+        if app.GIT_PATH != git_path:
+            app.GIT_PATH = git_path
+            config.change_GIT_PATH()
         app.GIT_REMOTE = git_remote
         app.CALENDAR_UNPROTECTED = config.checkbox_to_value(calendar_unprotected)
         app.CALENDAR_ICONS = config.checkbox_to_value(calendar_icons)

--- a/medusa/server/web/config/general.py
+++ b/medusa/server/web/config/general.py
@@ -99,7 +99,7 @@ class ConfigGeneral(Config):
         app.GIT_RESET = config.checkbox_to_value(git_reset)
         app.GIT_RESET_BRANCHES = helpers.ensure_list(git_reset_branches)
         app.GIT_PATH = git_path
-        config.change_GIT_PATH();
+        config.change_GIT_PATH()
         app.GIT_REMOTE = git_remote
         app.CALENDAR_UNPROTECTED = config.checkbox_to_value(calendar_unprotected)
         app.CALENDAR_ICONS = config.checkbox_to_value(calendar_icons)

--- a/medusa/server/web/config/general.py
+++ b/medusa/server/web/config/general.py
@@ -99,6 +99,7 @@ class ConfigGeneral(Config):
         app.GIT_RESET = config.checkbox_to_value(git_reset)
         app.GIT_RESET_BRANCHES = helpers.ensure_list(git_reset_branches)
         app.GIT_PATH = git_path
+        config.change_GIT_PATH();
         app.GIT_REMOTE = git_remote
         app.CALENDAR_UNPROTECTED = config.checkbox_to_value(calendar_unprotected)
         app.CALENDAR_ICONS = config.checkbox_to_value(calendar_icons)

--- a/medusa/version_checker.py
+++ b/medusa/version_checker.py
@@ -595,7 +595,7 @@ class GitUpdateManager(UpdateManager):
     def set_newest_text(self):
 
         # if we're up to date then don't set this
-        app.NEWEST_VERSION_STRING = None
+        newest_text = None
 
         if self._num_commits_behind > 0 or self._is_hard_reset_allowed():
 


### PR DESCRIPTION
- fix git alert disappearing on config change #2349
- allows git_path change while application is running

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
