### PR TITLE
Improve match of snatched NZB items in snatchSelection using size

### DIFF
--- a/medusa/databases/main_db.py
+++ b/medusa/databases/main_db.py
@@ -21,7 +21,7 @@ MIN_DB_VERSION = 40  # oldest db version we support migrating from
 MAX_DB_VERSION = 44
 
 # Used to check when checking for updates
-CURRENT_MINOR_DB_VERSION = 5
+CURRENT_MINOR_DB_VERSION = 6
 
 
 class MainSanityCheck(db.DBSanityCheck):
@@ -559,3 +559,22 @@ class AddPlot(AddInfoHash):
         if not self.hasColumn('tv_shows', 'plot'):
             self.addColumn('tv_shows', 'plot', 'TEXT', None)
         self.inc_minor_version()
+
+
+class AddResourceSize(AddPlot):
+    """Adds column resource_size to history table."""
+
+    def test(self):
+        """
+        Test if the version is at least 44.6
+        """
+        return self.connection.version >= (44, 6)
+
+    def execute(self):
+        backupDatabase(self.connection.version)
+
+        log.info(u"Adding column resource_size in history")
+        if not self.hasColumn("history", "resource_size"):
+            self.addColumn("history", "resource_size", 'NUMERIC', -1)
+
+        # self.inc_minor_version()

--- a/medusa/databases/main_db.py
+++ b/medusa/databases/main_db.py
@@ -562,7 +562,7 @@ class AddPlot(AddInfoHash):
 
 
 class AddResourceSize(AddPlot):
-    """Adds column resource_size to history table."""
+    """Adds column size to history table."""
 
     def test(self):
         """
@@ -573,8 +573,8 @@ class AddResourceSize(AddPlot):
     def execute(self):
         backupDatabase(self.connection.version)
 
-        log.info(u"Adding column resource_size in history")
-        if not self.hasColumn("history", "resource_size"):
-            self.addColumn("history", "resource_size", 'NUMERIC', -1)
+        log.info(u"Adding column size in history")
+        if not self.hasColumn("history", "size"):
+            self.addColumn("history", "size", 'NUMERIC', -1)
 
         # self.inc_minor_version()

--- a/medusa/databases/main_db.py
+++ b/medusa/databases/main_db.py
@@ -577,4 +577,4 @@ class AddResourceSize(AddPlot):
         if not self.hasColumn("history", "size"):
             self.addColumn("history", "size", 'NUMERIC', -1)
 
-        # self.inc_minor_version()
+        self.inc_minor_version()

--- a/medusa/history.py
+++ b/medusa/history.py
@@ -26,7 +26,7 @@ from .show.history import History
 
 
 def _logHistoryItem(action, showid, season, episode, quality, resource,
-                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None, resource_size=None):
+                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None, resource_size=-1):
     """
     Insert a history item in DB
 

--- a/medusa/history.py
+++ b/medusa/history.py
@@ -26,7 +26,7 @@ from .show.history import History
 
 
 def _logHistoryItem(action, showid, season, episode, quality, resource,
-                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None):
+                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None, resource_size=None):
     """
     Insert a history item in DB
 
@@ -46,10 +46,10 @@ def _logHistoryItem(action, showid, season, episode, quality, resource,
     main_db_con.action(
         "INSERT INTO history "
         "(action, date, showid, season, episode, quality, "
-        "resource, provider, version, proper_tags, manually_searched, info_hash) "
-        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        "resource, provider, version, proper_tags, manually_searched, info_hash, resource_size) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
         [action, logDate, showid, season, episode, quality,
-         resource, provider, version, proper_tags, manually_searched, info_hash])
+         resource, provider, version, proper_tags, manually_searched, info_hash, resource_size])
 
 
 def log_snatch(searchResult):
@@ -68,6 +68,7 @@ def log_snatch(searchResult):
         proper_tags = '|'.join(searchResult.proper_tags)
         manually_searched = searchResult.manually_searched
         info_hash = searchResult.hash.lower() if searchResult.hash else None
+        resource_size = searchResult.size
 
         providerClass = searchResult.provider
         if providerClass is not None:
@@ -80,7 +81,7 @@ def log_snatch(searchResult):
         resource = searchResult.name
 
         _logHistoryItem(action, showid, season, episode, quality, resource,
-                        provider, version, proper_tags, manually_searched, info_hash)
+                        provider, version, proper_tags, manually_searched, info_hash, resource_size)
 
 
 def logDownload(episode, filename, new_ep_quality, release_group=None, version=-1):

--- a/medusa/history.py
+++ b/medusa/history.py
@@ -26,7 +26,7 @@ from .show.history import History
 
 
 def _logHistoryItem(action, showid, season, episode, quality, resource,
-                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None, resource_size=-1):
+                    provider, version=-1, proper_tags='', manually_searched=False, info_hash=None, size=-1):
     """
     Insert a history item in DB
 
@@ -46,10 +46,10 @@ def _logHistoryItem(action, showid, season, episode, quality, resource,
     main_db_con.action(
         "INSERT INTO history "
         "(action, date, showid, season, episode, quality, "
-        "resource, provider, version, proper_tags, manually_searched, info_hash, resource_size) "
+        "resource, provider, version, proper_tags, manually_searched, info_hash, size) "
         "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
         [action, logDate, showid, season, episode, quality,
-         resource, provider, version, proper_tags, manually_searched, info_hash, resource_size])
+         resource, provider, version, proper_tags, manually_searched, info_hash, size])
 
 
 def log_snatch(searchResult):
@@ -68,7 +68,7 @@ def log_snatch(searchResult):
         proper_tags = '|'.join(searchResult.proper_tags)
         manually_searched = searchResult.manually_searched
         info_hash = searchResult.hash.lower() if searchResult.hash else None
-        resource_size = searchResult.size
+        size = searchResult.size
 
         providerClass = searchResult.provider
         if providerClass is not None:
@@ -81,7 +81,7 @@ def log_snatch(searchResult):
         resource = searchResult.name
 
         _logHistoryItem(action, showid, season, episode, quality, resource,
-                        provider, version, proper_tags, manually_searched, info_hash, resource_size)
+                        provider, version, proper_tags, manually_searched, info_hash, size)
 
 
 def logDownload(episode, filename, new_ep_quality, release_group=None, version=-1):

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -48,6 +48,7 @@ from medusa.common import (
 from medusa.failed_history import prepare_failed_name
 from medusa.helper.common import (
     enabled_providers,
+    pretty_file_size,
     try_int,
 )
 from medusa.helper.exceptions import (
@@ -109,7 +110,9 @@ from requests.compat import (
     unquote_plus,
 )
 from six import iteritems
+
 from tornroutes import route
+
 from traktor import (
     MissingTokenException,
     TokenExpiredException,
@@ -1259,6 +1262,7 @@ class Home(WebRoot):
                 i['status'], i['quality'] = Quality.split_composite_status(i['action'])
                 i['action_date'] = sbdatetime.sbfdatetime(datetime.strptime(str(i['date']), History.date_format), show_seconds=True)
                 i['resource_file'] = os.path.basename(i['resource'])
+                i['resource_size'] = pretty_file_size(i['resource_size']) if i['resource_size'] > -1 else 'N/A'
                 i['status_name'] = statusStrings[i['status']]
                 if i['status'] == DOWNLOADED:
                     i['status_color_style'] = 'downloaded'

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1245,7 +1245,7 @@ class Home(WebRoot):
         try:
             main_db_con = db.DBConnection()
             episode_status_result = main_db_con.action(
-                b'SELECT date, action, provider, resource '
+                b'SELECT date, action, provider, resource, resource_size '
                 b'FROM history '
                 b'WHERE showid = ? '
                 b'AND season = ? '
@@ -1287,7 +1287,8 @@ class Home(WebRoot):
                 elif any([item for item in episode_history
                           if all([provider_result['name'] in item['resource'],
                                   item['provider'] in (provider_result['provider'],),
-                                  item['status'] in snatched_statuses])
+                                  item['status'] in snatched_statuses,
+                                  item['resource_size'] == provider_result['size']],)
                           ]):
                     provider_result['status_highlight'] = 'snatched'
                 else:

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1248,7 +1248,7 @@ class Home(WebRoot):
         try:
             main_db_con = db.DBConnection()
             episode_status_result = main_db_con.action(
-                b'SELECT date, action, provider, resource, resource_size '
+                b'SELECT date, action, provider, resource, size '
                 b'FROM history '
                 b'WHERE showid = ? '
                 b'AND season = ? '
@@ -1262,7 +1262,7 @@ class Home(WebRoot):
                 i['status'], i['quality'] = Quality.split_composite_status(i['action'])
                 i['action_date'] = sbdatetime.sbfdatetime(datetime.strptime(str(i['date']), History.date_format), show_seconds=True)
                 i['resource_file'] = os.path.basename(i['resource'])
-                i['resource_size'] = pretty_file_size(i['resource_size']) if i['resource_size'] > -1 else 'N/A'
+                i['size'] = pretty_file_size(i['size']) if i['size'] > -1 else 'N/A'
                 i['status_name'] = statusStrings[i['status']]
                 if i['status'] == DOWNLOADED:
                     i['status_color_style'] = 'downloaded'
@@ -1292,7 +1292,7 @@ class Home(WebRoot):
                           if all([provider_result['name'] in item['resource'],
                                   item['provider'] in (provider_result['provider'],),
                                   item['status'] in snatched_statuses,
-                                  item['resource_size'] == provider_result['size']],)
+                                  item['size'] == provider_result['size']],)
                           ]):
                     provider_result['status_highlight'] = 'snatched'
                 else:

--- a/views/snatchSelection.mako
+++ b/views/snatchSelection.mako
@@ -24,7 +24,7 @@
                 <table id="snatchhistory" class="${"displayShowTableFanArt tablesorterFanArt" if app.FANART_BACKGROUND else "displayShowTable"} display_show tablesorter tablesorter-default" cellspacing="1" border="0" cellpadding="0">
                     <tbody class="tablesorter-no-sort" aria-live="polite" aria-relevant="all">
                         <tr role="row">
-                            <th colspan="4" class="row-seasonheader">
+                            <th colspan="5" class="row-seasonheader">
                                 <h3>
                                     History
                                 </h3>
@@ -40,6 +40,7 @@
                             <th>Status</th>
                             <th>Provider/Group</th>
                             <th>Release</th>
+                            <th>Size</th>
                         </tr>
                     </tbody>
                     <tbody class="toggle collapse" aria-live="polite" aria-relevant="all" id="historydata">
@@ -60,6 +61,9 @@
                                 </td>
                                 <td>
                                 ${item['resource_file']}
+                                </td>
+                                <td class="col-size">
+                                ${item['resource_size']}
                                 </td>
                             </tr>
                         % endfor


### PR DESCRIPTION
Fixes the issue where N releases names from same provider (with same release name) were marked as SNATCHED but user had only one SNATCH

@duramato as we talked

TODO:

- [x] Uncomment minor version increment


![image](https://cloud.githubusercontent.com/assets/2620870/23713489/cee5e2f4-0404-11e7-98f6-daa7b4beac9c.png)
