### PR TITLE
Fix could not authenticate to the indexer TheTvdb.com, with reason 'Unauthorized'

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -59,7 +59,7 @@ class TVDBv2(BaseIndexer):
 
         # client_id = 'username'  # (optional! Only required for the /user routes)
         # client_secret = 'pass'  # (optional! Only required for the /user routes)
-        apikey = '4EEBC22487003BC1'
+        apikey = '0629B785CE550C8D'
 
         authentication_string = {'apikey': apikey, 'username': '', 'userpass': ''}
 


### PR DESCRIPTION
@p0psicles don't know why our new API is not working. Reverting until we figure it out

