### PR TITLE
Add list_associated_files test

### DIFF
--- a/tests/test_list_associated_files.py
+++ b/tests/test_list_associated_files.py
@@ -27,9 +27,8 @@ class TestPostProcessor(PostProcessor):
 
 
 @pytest.mark.parametrize('p', [
-    {  # p0: Process file and no associated files
+    {  # p0: No associated files. Wrong basename
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
             'bow.514.hdtv-lol.srt',
@@ -41,9 +40,8 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': [],
         'allowed_extensions': "nfo,srt"
     },
-    {  # p1: Process file and no associated file
+    {  # p1: No associated files
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
             {'samples': (
@@ -56,18 +54,16 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': [],
         'allowed_extensions': "nfo,srt"
     },
-    {  # p2: Don't Process file and not associated file
+    {  # p2: No media file, so can't list associated files
         'path': 'media/postprocess/',
-        'expected': False,
         'structure': (
             'bow.514.hdtv-lol.srt',
         ),
         'expected_associated_files': [],
         'allowed_extensions': "nfo,srt"
     },
-    {  # p3: Process file and .srt and .nfo associated files. Check subfolders
+    {  # p3: .srt and .nfo associated files. Check subfolders
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
@@ -87,9 +83,8 @@ class TestPostProcessor(PostProcessor):
         'subfolders': True
 
     },
-    {  # p4: Process file and only .nfo associated file
+    {  # p4: Only .nfo associated file allowed
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
@@ -100,9 +95,8 @@ class TestPostProcessor(PostProcessor):
                                       ],
         'allowed_extensions': "nfo"
     },
-    {  # p5: Process file and no allowed extensions
+    {  # p5: No allowed extensions
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
@@ -112,9 +106,8 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': [],
         'allowed_extensions': ""
     },
-    {  # p6: Process file. RARed file with .rar associated file
+    {  # p6: Associated file based on RARed file
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 'show.101.720p-dimension.rar',
@@ -123,9 +116,8 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': ['show.101.720p-dimension.nfo'],
         'allowed_extensions': "nfo"
     },
-    {  # p7: Process file and subtitles only for associated files
+    {  # p7: 'Subtitles only' param for associated files
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
@@ -136,9 +128,8 @@ class TestPostProcessor(PostProcessor):
         'allowed_extensions': "nfo,srt",
         'subtitles_only': True
     },
-    {  # p8: Process file and subtitle in subfolder. Check subfolders enabled
+    {  # p8: Subtitle in subfolder. Check subfolders enabled
         'path': 'media/postprocess/',
-        'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
                 {'subs': (

--- a/tests/test_list_associated_files.py
+++ b/tests/test_list_associated_files.py
@@ -18,9 +18,9 @@ class TestPostProcessor(PostProcessor):
 
     @staticmethod
     def _rar_basename(filepath, files):
-        for files in files:
-            if os.path.splitext(os.path.basename(files))[1] == '.rar':
-                return os.path.basename(os.path.splitext(os.path.basename(files))[0])
+        for found_file in files:
+            if os.path.splitext(os.path.basename(found_file))[1] == '.rar':
+                return os.path.basename(os.path.splitext(os.path.basename(found_file))[0])
 
     def _log(self, message=None, level=None):
         pass
@@ -148,17 +148,17 @@ def test_list_associated_files(p, create_structure):
     # Given
     test_path = create_structure(p['path'], structure=p['structure'])
     path = os.path.join(test_path, os.path.normcase(p['path']))
-    file = os.path.join(path, p['structure'][0])
+    media_file = os.path.join(path, p['structure'][0])
     expected_associated_files = p['expected_associated_files']
     subtitles_only = p.get('subtitles_only', False)
     subfolders = p.get('subfolders', False)
     app.ALLOWED_EXTENSIONS = p['allowed_extensions']
     app.MOVE_ASSOCIATED_FILES = 1
 
-    processor = TestPostProcessor(file)
+    processor = TestPostProcessor(media_file)
 
     # When
-    found_associated_files = processor.list_associated_files(file, subtitles_only=subtitles_only, subfolders=subfolders)
+    found_associated_files = processor.list_associated_files(media_file, subtitles_only=subtitles_only, subfolders=subfolders)
     associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
 
     # Then

--- a/tests/test_list_associated_files.py
+++ b/tests/test_list_associated_files.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+"""Tests for medusa/test_list_associated_files.py."""
+import os
+
+from medusa import app
+
+from medusa.post_processor import PostProcessor
+
+import pytest
+
+
+class TestPostProcessor(PostProcessor):
+    """A test `PostProcessor` object."""
+
+    def __init__(self, file_path=None, nzb_name=None, process_method=None, is_priority=None):
+        """Initialize the object."""
+        super(PostProcessor, self).__init__()
+
+    @staticmethod
+    def _rar_basename(filepath, files):
+        for files in files:
+            if os.path.splitext(os.path.basename(files))[1] == '.rar':
+                return os.path.basename(os.path.splitext(os.path.basename(files))[0])
+
+    def _log(self, message=None, level=None):
+        pass
+
+
+@pytest.mark.parametrize('p', [
+    {  # p0: Process file and no associated files
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+            'bow.514.hdtv-lol[ettv].mkv',
+            'bow.514.hdtv-lol.srt',
+            {'samples': (
+                'sample.mkv', 'other.mkv',
+                {'inception': ()}
+            )}
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
+    },
+    {  # p1: Process file and no associated file
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+            'bow.514.hdtv-lol[ettv].mkv',
+            {'samples': (
+                'sample.mkv', 'other.mkv',
+                {'inception': (
+                    'cool.txt', 'bla.nfo'
+                )}
+            )}
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
+    },
+    {  # p2: Don't Process file and not associated file
+        'path': 'media/postprocess/',
+        'expected': False,
+        'structure': (
+            'bow.514.hdtv-lol.srt',
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
+    },
+    {  # p3: Process file and .srt and .nfo associated files. Check subfolders
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv',
+                {'samples': (
+                    'sample.mkv', 'other.mkv',
+                    {'inception': (
+                        'cool.txt', 'bla.nfo'
+                    )}
+                )}
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                                      'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                                      ],
+        'allowed_extensions': "nfo,srt",
+        'subfolders': True
+
+    },
+    {  # p4: Process file and only .nfo associated file
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                                      ],
+        'allowed_extensions': "nfo"
+    },
+    {  # p5: Process file and no allowed extensions
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': ""
+    },
+    {  # p6: Process file. RARed file with .rar associated file
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'show.101.720p-dimension.rar',
+                'show.101.720p-dimension.nfo'
+        ),
+        'expected_associated_files': ['show.101.720p-dimension.nfo'],
+        'allowed_extensions': "nfo"
+    },
+    {  # p7: Process file and subtitles only for associated files
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt'],
+        'allowed_extensions': "nfo,srt",
+        'subtitles_only': True
+    },
+    {  # p8: Process file and subtitle in subfolder. Check subfolders enabled
+        'path': 'media/postprocess/',
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                {'subs': (
+                    'RARBG.txt', 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                )}
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                                      ],
+        'allowed_extensions': "nfo,srt",
+        'subfolders': True
+
+    },
+])
+def test_list_associated_files(p, create_structure):
+    """Run the test."""
+    # Given
+    test_path = create_structure(p['path'], structure=p['structure'])
+    path = os.path.join(test_path, os.path.normcase(p['path']))
+    file = os.path.join(path, p['structure'][0])
+    expected_associated_files = p['expected_associated_files']
+    subtitles_only = p.get('subtitles_only', False)
+    subfolders = p.get('subfolders', False)
+    app.ALLOWED_EXTENSIONS = p['allowed_extensions']
+    app.MOVE_ASSOCIATED_FILES = 1
+
+    processor = TestPostProcessor(file)
+
+    # When
+    found_associated_files = processor.list_associated_files(file, subtitles_only=subtitles_only, subfolders=subfolders)
+    associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
+
+    # Then
+    assert set(associated_files_basenames) == set(expected_associated_files)

--- a/tests/test_list_associated_files.py
+++ b/tests/test_list_associated_files.py
@@ -143,7 +143,7 @@ class TestPostProcessor(PostProcessor):
 
     },
 ])
-def test_list_associated_files(p, create_structure):
+def test_list_associated_files(p, create_structure, monkeypatch):
     """Run the test."""
     # Given
     test_path = create_structure(p['path'], structure=p['structure'])
@@ -152,8 +152,8 @@ def test_list_associated_files(p, create_structure):
     expected_associated_files = p['expected_associated_files']
     subtitles_only = p.get('subtitles_only', False)
     subfolders = p.get('subfolders', False)
-    app.ALLOWED_EXTENSIONS = p['allowed_extensions']
-    app.MOVE_ASSOCIATED_FILES = 1
+    monkeypatch.setattr(app, 'ALLOWED_EXTENSIONS', p['allowed_extensions'])
+    monkeypatch.setattr(app, 'MOVE_ASSOCIATED_FILES', 1)
 
     processor = TestPostProcessor(media_file)
 

--- a/tests/test_process_tv.py
+++ b/tests/test_process_tv.py
@@ -2,13 +2,33 @@
 """Tests for medusa/process_tv.py."""
 import os
 
+from medusa import app
+
+from medusa.post_processor import PostProcessor
 from medusa.process_tv import ProcessResult
 
 import pytest
 
 
+class TestPostProcessor(PostProcessor):
+    """A test `PostProcessor` object."""
+
+    def __init__(self, file_path=None, nzb_name=None, process_method=None, is_priority=None):
+        """Initialize the object."""
+        super(PostProcessor, self).__init__()
+
+    @staticmethod
+    def _rar_basename(filepath, files):
+        for files in files:
+            if os.path.splitext(os.path.basename(files))[1] == '.rar':
+                return os.path.basename(os.path.splitext(os.path.basename(files))[0])
+
+    def _log(self, message=None, level=None):
+        pass
+
+
 @pytest.mark.parametrize('p', [
-    {
+    {  # p0: Process file and no associated files
         'path': 'media/postprocess/',
         'nzb_name': None,
         'failed': False,
@@ -20,9 +40,11 @@ import pytest
                 'sample.mkv', 'other.mkv',
                 {'inception': ()}
             )}
-        )
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
     },
-    {
+    {  # p1: Process file and no associated file
         'path': 'media/postprocess/',
         'nzb_name': None,
         'failed': False,
@@ -35,16 +57,85 @@ import pytest
                     'cool.txt', 'bla.nfo'
                 )}
             )}
-        )
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
     },
-    {
+    {  # p2: Don't Process file and not associated file
         'path': 'media/postprocess/',
         'nzb_name': None,
         'failed': False,
         'expected': False,
         'structure': (
             'bow.514.hdtv-lol.srt',
-        )
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': "nfo,srt"
+    },
+    {  # p3: Process file and .srt and .nfo associated files
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv',
+                {'samples': (
+                    'sample.mkv', 'other.mkv',
+                    {'inception': (
+                        'cool.txt', 'bla.nfo'
+                    )}
+                )}
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                                      'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                                      ],
+        'allowed_extensions': "nfo,srt"
+
+    },
+    {  # p4: Process file and only .nfo associated file
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                                      ],
+        'allowed_extensions': "nfo"
+    },
+    {  # p5: Process file and no allowed extensions
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': [],
+        'allowed_extensions': ""
+    },
+    {  # p6: Process file. RARed file with .rar associated file
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'show.101.720p-dimension.rar',
+                'show.101.720p-dimension.nfo'
+        ),
+        'expected_associated_files': ['show.101.720p-dimension.nfo'],
+        'allowed_extensions': "nfo"
     },
 ])
 def test_should_process(p, create_structure):
@@ -52,10 +143,19 @@ def test_should_process(p, create_structure):
     # Given
     test_path = create_structure(p['path'], structure=p['structure'])
     path = os.path.join(test_path, os.path.normcase(p['path']))
+    file = os.path.join(path, p['structure'][0])
+    expected_associated_files = p['expected_associated_files']
+    app.ALLOWED_EXTENSIONS = p['allowed_extensions']
+    app.MOVE_ASSOCIATED_FILES = 1
+
     sut = ProcessResult(path)
+    processor = TestPostProcessor(file)
 
     # When
     result = sut.should_process(path, p['nzb_name'], p['failed'])
+    found_associated_files = processor.list_associated_files(file)
+    associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
 
     # Then
+    assert set(associated_files_basenames) == set(expected_associated_files)
     assert p['expected'] == result

--- a/tests/test_process_tv.py
+++ b/tests/test_process_tv.py
@@ -2,34 +2,16 @@
 """Tests for medusa/process_tv.py."""
 import os
 
-from medusa import app
-
-from medusa.post_processor import PostProcessor
 from medusa.process_tv import ProcessResult
 
 import pytest
 
 
-class TestPostProcessor(PostProcessor):
-    """A test `PostProcessor` object."""
-
-    def __init__(self, file_path=None, nzb_name=None, process_method=None, is_priority=None):
-        """Initialize the object."""
-        super(PostProcessor, self).__init__()
-
-    @staticmethod
-    def _rar_basename(filepath, files):
-        for files in files:
-            if os.path.splitext(os.path.basename(files))[1] == '.rar':
-                return os.path.basename(os.path.splitext(os.path.basename(files))[0])
-
-    def _log(self, message=None, level=None):
-        pass
-
-
 @pytest.mark.parametrize('p', [
-    {  # p0: Process file and no associated files
+    {
         'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
         'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
@@ -38,12 +20,12 @@ class TestPostProcessor(PostProcessor):
                 'sample.mkv', 'other.mkv',
                 {'inception': ()}
             )}
-        ),
-        'expected_associated_files': [],
-        'allowed_extensions': "nfo,srt"
+        )
     },
-    {  # p1: Process file and no associated file
+    {
         'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
         'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
@@ -53,104 +35,16 @@ class TestPostProcessor(PostProcessor):
                     'cool.txt', 'bla.nfo'
                 )}
             )}
-        ),
-        'expected_associated_files': [],
-        'allowed_extensions': "nfo,srt"
+        )
     },
-    {  # p2: Don't Process file and not associated file
+    {
         'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
         'expected': False,
         'structure': (
             'bow.514.hdtv-lol.srt',
-        ),
-        'expected_associated_files': [],
-        'allowed_extensions': "nfo,srt"
-    },
-    {  # p3: Process file and .srt and .nfo associated files. Check subfolders
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv',
-                {'samples': (
-                    'sample.mkv', 'other.mkv',
-                    {'inception': (
-                        'cool.txt', 'bla.nfo'
-                    )}
-                )}
-        ),
-        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                                      'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                                      ],
-        'allowed_extensions': "nfo,srt",
-        'subfolders': True
-
-    },
-    {  # p4: Process file and only .nfo associated file
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
-        ),
-        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                                      ],
-        'allowed_extensions': "nfo"
-    },
-    {  # p5: Process file and no allowed extensions
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
-        ),
-        'expected_associated_files': [],
-        'allowed_extensions': ""
-    },
-    {  # p6: Process file. RARed file with .rar associated file
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                'show.101.720p-dimension.rar',
-                'show.101.720p-dimension.nfo'
-        ),
-        'expected_associated_files': ['show.101.720p-dimension.nfo'],
-        'allowed_extensions': "nfo"
-    },
-    {  # p7: Process file and subtitles only for associated files
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
-        ),
-        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt'],
-        'allowed_extensions': "nfo,srt",
-        'subtitles_only': True
-    },
-    {  # p8: Process file and subtitle in subfolder. Check subfolders enabled
-        'path': 'media/postprocess/',
-        'expected': True,
-        'structure': (
-                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
-                {'subs': (
-                    'RARBG.txt', 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                )}
-        ),
-        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
-                                      ],
-        'allowed_extensions': "nfo,srt",
-        'subfolders': True
-
+        )
     },
 ])
 def test_should_process(p, create_structure):
@@ -158,23 +52,10 @@ def test_should_process(p, create_structure):
     # Given
     test_path = create_structure(p['path'], structure=p['structure'])
     path = os.path.join(test_path, os.path.normcase(p['path']))
-    file = os.path.join(path, p['structure'][0])
-    expected_associated_files = p['expected_associated_files']
-    nzb_name = p.get('nzb_name', None)
-    failed = p.get('failed', False)
-    subtitles_only = p.get('subtitles_only', False)
-    subfolders = p.get('subfolders', False)
-    app.ALLOWED_EXTENSIONS = p['allowed_extensions']
-    app.MOVE_ASSOCIATED_FILES = 1
-
     sut = ProcessResult(path)
-    processor = TestPostProcessor(file)
 
     # When
-    result = sut.should_process(path, nzb_name, failed)
-    found_associated_files = processor.list_associated_files(file, subtitles_only=subtitles_only, subfolders=subfolders)
-    associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
+    result = sut.should_process(path, p['nzb_name'], p['failed'])
 
     # Then
-    assert set(associated_files_basenames) == set(expected_associated_files)
     assert p['expected'] == result

--- a/tests/test_process_tv.py
+++ b/tests/test_process_tv.py
@@ -72,7 +72,7 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': [],
         'allowed_extensions': "nfo,srt"
     },
-    {  # p3: Process file and .srt and .nfo associated files
+    {  # p3: Process file and .srt and .nfo associated files. Check subfolders
         'path': 'media/postprocess/',
         'nzb_name': None,
         'failed': False,
@@ -92,7 +92,8 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
                                       'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
                                       ],
-        'allowed_extensions': "nfo,srt"
+        'allowed_extensions': "nfo,srt",
+        'subfolders': True
 
     },
     {  # p4: Process file and only .nfo associated file
@@ -137,6 +138,38 @@ class TestPostProcessor(PostProcessor):
         'expected_associated_files': ['show.101.720p-dimension.nfo'],
         'allowed_extensions': "nfo"
     },
+    {  # p7: Process file and subtitles only for associated files
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.nfo',
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.sfv'
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt'],
+        'allowed_extensions': "nfo,srt",
+        'subtitles_only': True
+    },
+    {  # p8: Process file and subtitle in subfolder. Check subfolders enabled
+        'path': 'media/postprocess/',
+        'nzb_name': None,
+        'failed': False,
+        'expected': True,
+        'structure': (
+                'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
+                {'subs': (
+                    'RARBG.txt', 'Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                )}
+        ),
+        'expected_associated_files': ['Show.S01E01.720p.HDTV.X264-DIMENSION.pt-BR.srt',
+                                      ],
+        'allowed_extensions': "nfo,srt",
+        'subfolders': True
+
+    },
 ])
 def test_should_process(p, create_structure):
     """Run the test."""
@@ -145,6 +178,8 @@ def test_should_process(p, create_structure):
     path = os.path.join(test_path, os.path.normcase(p['path']))
     file = os.path.join(path, p['structure'][0])
     expected_associated_files = p['expected_associated_files']
+    subtitles_only = p.get('subtitles_only', False)
+    subfolders = p.get('subfolders', False)
     app.ALLOWED_EXTENSIONS = p['allowed_extensions']
     app.MOVE_ASSOCIATED_FILES = 1
 
@@ -153,7 +188,7 @@ def test_should_process(p, create_structure):
 
     # When
     result = sut.should_process(path, p['nzb_name'], p['failed'])
-    found_associated_files = processor.list_associated_files(file)
+    found_associated_files = processor.list_associated_files(file, subtitles_only=subtitles_only, subfolders=subfolders)
     associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
 
     # Then

--- a/tests/test_process_tv.py
+++ b/tests/test_process_tv.py
@@ -30,8 +30,6 @@ class TestPostProcessor(PostProcessor):
 @pytest.mark.parametrize('p', [
     {  # p0: Process file and no associated files
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
@@ -46,8 +44,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p1: Process file and no associated file
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
             'bow.514.hdtv-lol[ettv].mkv',
@@ -63,8 +59,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p2: Don't Process file and not associated file
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': False,
         'structure': (
             'bow.514.hdtv-lol.srt',
@@ -74,8 +68,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p3: Process file and .srt and .nfo associated files. Check subfolders
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -98,8 +90,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p4: Process file and only .nfo associated file
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -113,8 +103,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p5: Process file and no allowed extensions
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -127,8 +115,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p6: Process file. RARed file with .rar associated file
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -140,8 +126,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p7: Process file and subtitles only for associated files
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -155,8 +139,6 @@ class TestPostProcessor(PostProcessor):
     },
     {  # p8: Process file and subtitle in subfolder. Check subfolders enabled
         'path': 'media/postprocess/',
-        'nzb_name': None,
-        'failed': False,
         'expected': True,
         'structure': (
                 'Show.S01E01.720p.HDTV.X264-DIMENSION.mkv',
@@ -178,6 +160,8 @@ def test_should_process(p, create_structure):
     path = os.path.join(test_path, os.path.normcase(p['path']))
     file = os.path.join(path, p['structure'][0])
     expected_associated_files = p['expected_associated_files']
+    nzb_name = p.get('nzb_name', None)
+    failed = p.get('failed', False)
     subtitles_only = p.get('subtitles_only', False)
     subfolders = p.get('subfolders', False)
     app.ALLOWED_EXTENSIONS = p['allowed_extensions']
@@ -187,7 +171,7 @@ def test_should_process(p, create_structure):
     processor = TestPostProcessor(file)
 
     # When
-    result = sut.should_process(path, p['nzb_name'], p['failed'])
+    result = sut.should_process(path, nzb_name, failed)
     found_associated_files = processor.list_associated_files(file, subtitles_only=subtitles_only, subfolders=subfolders)
     associated_files_basenames = [os.path.basename(i) for i in found_associated_files]
 


### PR DESCRIPTION
Need to switch base after `rewrite-process-tv` gets merged as I'm not allowed to PR to that branch =)

~~ratoaq2 confirm i can't run two tests?~~

~~I tried to use the existing structure from `test_should_process`  to avoid call `test_path = create_structure(p['path'], structure=p['structure'])` twice by creating another function called `def test_list_associated_files` but didn't worked~~

~~is there a way ?~~

