### PR TITLE
Fix Deluge 1.3.14 requires Content-Type header

### DIFF
--- a/medusa/clients/deluge_client.py
+++ b/medusa/clients/deluge_client.py
@@ -44,10 +44,10 @@ class DelugeAPI(GenericClient):
         :type password: string
         """
         super(DelugeAPI, self).__init__('Deluge', host, username, password)
+        self.session.headers.update({'Content-Type': 'application/json'})
         self.url = '{host}json'.format(host=self.host)
 
     def _get_auth(self):
-
         post_data = json.dumps({
             'method': 'auth.login',
             'params': [


### PR DESCRIPTION
Deluge 1.3.14 requires `Content-Type: application/json`

```
2017-03-11 19:07:56 DEBUG    SNATCHQUEUE-MANUALSNATCH-78901 :: [f51338e] Traceback (most recent call last):
  File "H:\usr\local\medusa\medusa\search\queue.py", line 426, in run
    self.success = snatch_episode(search_result)
  File "H:\usr\local\medusa\medusa\search\core.py", line 136, in snatch_episode
    result_downloaded = client.send_torrent(result)
  File "H:\usr\local\medusa\medusa\clients\generic.py", line 221, in send_torrent
    if not self._get_auth():
  File "H:\usr\local\medusa\medusa\clients\**********_client.py", line 65, in _get_auth
    self.auth = self.response.json()['result']
  File "H:\usr\local\medusa\lib\requests\models.py", line 812, in json
    return complexjson.loads(self.text, **kwargs)
  File "C:\Python\latest\lib\json\__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "C:\Python\latest\lib\json\decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "C:\Python\latest\lib\json\decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```

Thanks to **strike** for reporting in IRC and credits to @sharkykh for the fix.