### PR TITLE
Eliminated ShellCheck warnings from init.gentoo

### DIFF
--- a/runscripts/init.gentoo
+++ b/runscripts/init.gentoo
@@ -12,7 +12,7 @@
 # MEDUSA_USER=<user you want medusa to run under>
 # MEDUSA_GROUP=<group you want medusa to run under>
 # MEDUSA_DIR=<path to start.py>
-# PATH_TO_PYTHON_2=/usr/bin/python2.7
+# PATH_TO_PYTHON_2=/usr/bin/python2
 # MEDUSA_DATADIR=<directory that contains main.db file>
 # MEDUSA_CONFDIR=<directory that contains Medusa's config.ini file>
 #
@@ -25,43 +25,38 @@ depend() {
 
 get_pidfile() {
     # Parse the config.ini file for the value of web_port in the General section
-    eval `sed -e 's/[[:space:]]*\=[[:space:]]*/=/g' \
-        -e 's/;.*$//' \
-        -e 's/[[:space:]]*$//' \
-        -e 's/^[[:space:]]*//' \
-        -e "s/^\(.*\)=\([^\"']*\)$/\1=\"\2\"/" \
-       <  ${MEDUSA_CONFDIR}/config.ini \
-        | sed -n -e "/^\[General\]/,/^\s*\[/{/^[^;].*\=.*/p;}"`
-
-    echo "${RUNDIR}/medusa-${web_port}.pid"
+   eval web_port="$(grep -Po 'web_port = \K[^ ]+' \
+   "${MEDUSA_CONFDIR}/config.ini")"
+   echo "${RUNDIR}/medusa-${web_port}.pid"
 }
 
 start() {
     ebegin "Starting Medusa"
 
-    checkpath -q -d -o ${MEDUSA_USER}:${MEDUSA_GROUP} -m 0770 "${RUNDIR}"
+    checkpath -q -d -o "${MEDUSA_USER}":"${MEDUSA_GROUP}" -m 0770 "${RUNDIR}"
 
     start-stop-daemon \
         --quiet \
         --start \
-        --user ${MEDUSA_USER} \
-        --group ${MEDUSA_GROUP} \
+        --user "${MEDUSA_USER}" \
+        --group "${MEDUSA_GROUP}" \
         --background \
-        --pidfile $(get_pidfile) \
-        --exec ${PATH_TO_PYTHON_2} \
+        --pidfile "$(get_pidfile)" \
+        --exec "${PATH_TO_PYTHON_2}" \
         -- \
-        ${MEDUSA_DIR}/start.py \
+        "${MEDUSA_DIR}/start.py" \
         -d \
-        --pidfile $(get_pidfile) \
-        --config ${MEDUSA_CONFDIR}/config.ini \
-        --datadir ${MEDUSA_DATADIR}
+        --pidfile "$(get_pidfile)" \
+        --config "${MEDUSA_CONFDIR}/config.ini" \
+        --datadir "${MEDUSA_DATADIR}"
     eend $?
 }
 
 start_pre() {
     if [ "$RC_CMD" == "restart" ]; then
-        local pidfile=$(get_pidfile)
-        while [ -e ${pidfile} ]; do
+        local pidfile
+        pidfile=$(get_pidfile)
+        while [ -e "${pidfile}" ]; do
             sleep 1
         done
     fi
@@ -70,10 +65,10 @@ start_pre() {
 }
 
 stop() {
-    local pidfile=$(get_pidfile)
-    local rc
+    local pidfile
+    pidfile=$(get_pidfile)
 
     ebegin "Stopping Medusa"
-    start-stop-daemon --stop --pidfile $(get_pidfile) --retry 15
+    start-stop-daemon --stop --pidfile "$(get_pidfile)" --retry 15
     eend $?
 }


### PR DESCRIPTION
Also rewrited old sed string, because of possible errors when unencrypted password in config.ini used
http://www.shellcheck.net/
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
