### PR TITLE
Don't use knowit quality to check for quality in history

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -731,25 +731,32 @@ class PostProcessor(object):
 
         return root_ep
 
+    def _quality_from_status(self, status):
+        """
+        Determine the quality of the file that is being post processed with its status.
+
+        :param status: The status related to the file we are post processing
+        :return: A quality value found in common.Quality
+        """
+        quality = common.Quality.UNKNOWN
+
+        if status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
+            _, quality = common.Quality.split_composite_status(status)
+            if quality != common.Quality.UNKNOWN:
+                self._log(u'The snatched status has a quality in it, using that: {0}'.format
+                          (common.Quality.qualityStrings[quality]), logger.DEBUG)
+                return quality
+
+        return quality
+
     def _get_quality(self, ep_obj):
         """
-        Determine the quality of the file that is being post processed.
-
-        First by checking if it is directly available in the Episode's status or
-        otherwise by parsing through the data available.
+        Determine the quality of the file that is being post processed with alternative methods.
 
         :param ep_obj: The Episode object related to the file we are post processing
         :return: A quality value found in common.Quality
         """
         ep_quality = common.Quality.UNKNOWN
-
-        # Try getting quality from the episode (snatched) status first
-        if ep_obj.status in common.Quality.SNATCHED + common.Quality.SNATCHED_PROPER + common.Quality.SNATCHED_BEST:
-            _, ep_quality = common.Quality.split_composite_status(ep_obj.status)
-            if ep_quality != common.Quality.UNKNOWN:
-                self._log(u'The snatched status has a quality in it, using that: {0}'.format
-                          (common.Quality.qualityStrings[ep_quality]), logger.DEBUG)
-                return ep_quality
 
         for resource_name, cur_name in self.item_resources.items():
 
@@ -1011,15 +1018,18 @@ class PostProcessor(object):
                       (common.Quality.qualityStrings[quality]), logger.DEBUG)
             new_ep_quality = quality
         else:
-            new_ep_quality = self._get_quality(ep_obj)
-
-        logger.log(u'Quality of the episode we are processing: {0}'.format
-                   (common.Quality.qualityStrings[new_ep_quality]), logger.DEBUG)
+            new_ep_quality = self._quality_from_status(ep_obj.status)
 
         # check snatched history to see if we should set the download as priority
         self._priority_from_history(show.indexerid, season, episodes, new_ep_quality)
         if self.in_history:
             self._log(u'This episode was found in history as SNATCHED.', logger.DEBUG)
+
+        if new_ep_quality == common.Quality.UNKNOWN:
+            new_ep_quality = self._get_quality(ep_obj)
+
+        logger.log(u'Quality of the episode we are processing: {0}'.format
+                   (common.Quality.qualityStrings[new_ep_quality]), logger.DEBUG)
 
         # see if this is a priority download (is it snatched, in history, PROPER, or BEST)
         priority_download = self._is_priority(old_ep_quality, new_ep_quality)


### PR DESCRIPTION
As the snatched quality has to come from guessit. Avoid wrong matches in history and allows matches with unknown quality.

@fernandog @OmgImAlexis 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
