### PR TITLE
Fix wrong type while saving to DB. Indexer is TEXT, not INT

### DIFF
--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -865,7 +865,7 @@ class Episode(TV):
                         b'  manually_searched = ? '
                         b'WHERE '
                         b'  episode_id = ?',
-                        [self.indexerid, self.indexer, self.name, self.description, ','.join(self.subtitles),
+                        [self.indexerid, str(self.indexer), self.name, self.description, ','.join(self.subtitles),
                          self.subtitles_searchcount, self.subtitles_lastsearch, self.airdate.toordinal(), self.hasnfo,
                          self.hastbn, self.status, self.location, self.file_size, self.release_name, self.is_proper,
                          self.show.indexerid, self.season, self.episode, self.absolute_number, self.version,
@@ -900,7 +900,7 @@ class Episode(TV):
                         b'  manually_searched = ? '
                         b'WHERE '
                         b'  episode_id = ?',
-                        [self.indexerid, self.indexer, self.name, self.description,
+                        [self.indexerid, str(self.indexer), self.name, self.description,
                          self.subtitles_searchcount, self.subtitles_lastsearch, self.airdate.toordinal(), self.hasnfo,
                          self.hastbn, self.status, self.location, self.file_size, self.release_name, self.is_proper,
                          self.show.indexerid, self.season, self.episode, self.absolute_number, self.version,
@@ -935,7 +935,7 @@ class Episode(TV):
                     b'VALUES '
                     b'  ((SELECT episode_id FROM tv_episodes WHERE showid = ? AND season = ? AND episode = ?), '
                     b'  ?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);',
-                    [self.show.indexerid, self.season, self.episode, self.indexerid, self.indexer, self.name,
+                    [self.show.indexerid, self.season, self.episode, self.indexerid, str(self.indexer), self.name,
                      self.description, ','.join(self.subtitles), self.subtitles_searchcount, self.subtitles_lastsearch,
                      self.airdate.toordinal(), self.hasnfo, self.hastbn, self.status, self.location, self.file_size,
                      self.release_name, self.is_proper, self.show.indexerid, self.season, self.episode,
@@ -949,7 +949,7 @@ class Episode(TV):
             return
 
         new_value_dict = {b'indexerid': self.indexerid,
-                          b'indexer': self.indexer,
+                          b'indexer': str(self.indexer),
                           b'name': self.name,
                           b'description': self.description,
                           b'subtitles': ','.join(self.subtitles),


### PR DESCRIPTION
Indexer in DB is TEXT and we are saving as INT

FINDSUBTITLES :: [bde37e2] Episodes object keys that were modified: {'subtitles_searchcount': (1, 0), 'subtitles_lastsearch': ('2017-03-15 01:46:16', u'0001-01-01 00:00:00'), 'indexer': (1, u'1')}

subtitles_lastsearch is wrong but Im not sure where to fix