### PR TITLE
Fix new log error when logging a dict/json

### DIFF
--- a/medusa/init/logconfig.py
+++ b/medusa/init/logconfig.py
@@ -76,7 +76,7 @@ class BraceMessage(object):
         :rtype: str
         """
         result = text_type(self.fmt)
-        return result.format(*self.args, **self.kwargs) if self.args or self.kwargs else result
+        return result.format(*self.args, **self.kwargs) if self.args or self.kwargs.get('extra') else result
 
 
 def initialize():


### PR DESCRIPTION
```
File "C:/Medusa\medusa\init\logconfig.py", line 79, in __str__
   return result.format(*self.args, **self.kwargs) if self.args or self.kwargs else result
KeyError: u'"arguments"'
Logged from file style.py, line 63
```

![image](https://cloud.githubusercontent.com/assets/2620870/24199972/436fd7de-0eea-11e7-93a0-dba05b984588.png)

also this: https://pymedusa.slack.com/files/wimpyrbx/F4N1CRZKP/gistfile1.txt from @wimpyrbx 

@ratoaq2 @labrys 
