### PR TITLE
Remove client log for now (REVERT LATER)

### DIFF
--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -60,15 +60,12 @@ class GenericClient(object):
             self.last_time = time.time()
             self._get_auth()
 
-        text = str(data)
         log.debug(
-            '{name}: Requested a {method} connection to {url} with'
-            ' params: {params} Data: {data}', {
+            '{name}: Requested a {method} connection to {url}',
+            {
                 'name': self.name,
                 'method': method.upper(),
                 'url': self.url,
-                'params': params,
-                'data': text[0:99] + '...' if len(text) > 102 else text
             }
         )
 


### PR DESCRIPTION
Fixes 

```
File "C:/Medusa\medusa\init\logconfig.py", line 79, in __str__
   return result.format(*self.args, **self.kwargs) if self.args or self.kwargs else result
KeyError: u'"arguments"'
Logged from file style.py, line 63
```

also this: https://pymedusa.slack.com/files/wimpyrbx/F4N1CRZKP/gistfile1.txt from @wimpyrbx 