### PR TITLE
Fix TypeError when updates_api returns None. Fixes #2424

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -562,9 +562,10 @@ class TVDBv2(BaseIndexer):
         try:
             while updates and count < weeks:
                 updates = self.updates_api.updated_query_get(from_time).data
-                last_update_ts = max(x.last_updated for x in updates)
-                from_time = last_update_ts
-                total_updates += [int(_.id) for _ in updates]
+                if updates is not None:
+                    last_update_ts = max(x.last_updated for x in updates)
+                    from_time = last_update_ts
+                    total_updates += [int(_.id) for _ in updates]
                 count += 1
         except (ApiException, MaxRetryError, RequestError) as e:
             raise IndexerUnavailable('Error connecting to Tvdb api. Caused by: {0!r}'.format(e))


### PR DESCRIPTION
As discussed in https://github.com/pymedusa/Medusa/issues/2424


- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
