### PR TITLE
Fix trakt duplicate warning

### DIFF
--- a/medusa/trakt_checker.py
+++ b/medusa/trakt_checker.py
@@ -620,7 +620,7 @@ class TraktChecker(object):
             self.show_watchlist = self._request('sync/watchlist/shows')
         except (TraktException, AuthException, ServerBusy, TokenExpiredException) as e:
             logger.log(u'Unable to retrieve shows from Trakt watchlist. Error: {error}'.format
-                       (error=e.message), logger.WARNING)
+                       (error=e.message), logger.DEBUG)
             return False
         return True
 


### PR DESCRIPTION
2017-03-23 16:11:07 WARNING  TRAKTCHECKER :: [624b1d3] Could not connect to Trakt. No http status code
2017-03-23 16:11:07 WARNING  TRAKTCHECKER :: [624b1d3] Unable to retrieve shows from Trakt watchlist. Error: Could not connect to Trakt. No http status code