### PR TITLE
Don't use all scene names when searching with tvdb

### DIFF
--- a/medusa/providers/torrent/json/rarbg.py
+++ b/medusa/providers/torrent/json/rarbg.py
@@ -102,6 +102,9 @@ class RarbgProvider(TorrentProvider):
                 search_params['sort'] = self.sorting if self.sorting else 'seeders'
                 search_params['mode'] = 'search'
                 search_params['search_tvdb'] = self._get_tvdb_id()
+                if search_params['search_tvdb']:
+                    # If searching using tvdb, don't need to search using all scene names
+                    search_strings[mode] = search_strings[mode][:1]
 
             for search_string in search_strings[mode]:
                 if mode != 'RSS':


### PR DESCRIPTION
@duramato you might confirm it works with BTN too

UPDATE: BTN does it correctly. It only adds scene names if not tvdb