### PR TITLE
Revert "Don't use all scene names when searching with tvdb"

### DIFF
--- a/medusa/providers/torrent/json/rarbg.py
+++ b/medusa/providers/torrent/json/rarbg.py
@@ -102,9 +102,6 @@ class RarbgProvider(TorrentProvider):
                 search_params['sort'] = self.sorting if self.sorting else 'seeders'
                 search_params['mode'] = 'search'
                 search_params['search_tvdb'] = self._get_tvdb_id()
-                if search_params['search_tvdb']:
-                    # If searching using tvdb, don't need to search using all scene names
-                    search_strings[mode] = search_strings[mode][:1]
 
             for search_string in search_strings[mode]:
                 if mode != 'RSS':


### PR DESCRIPTION
Needs to also remove the show name and there's is no easy way to do this now
the search string should be only "S01E01" and not "Show S01E01" when searching with tvdb_id
sorry about that