### PR TITLE
 Deluge and DelugeD: add feature to remove torrent when ratio reached

### DIFF
--- a/medusa/clients/torrent/deluge_client.py
+++ b/medusa/clients/torrent/deluge_client.py
@@ -9,7 +9,15 @@ import logging
 from base64 import b64encode
 
 from medusa import app
+
 from medusa.clients.torrent.generic import GenericClient
+
+from medusa.helpers import (
+    is_already_processed_media,
+    is_info_hash_in_history,
+    is_info_hash_processed,
+)
+
 from medusa.logger.adapters.style import BraceAdapter
 
 from requests.exceptions import RequestException
@@ -198,7 +206,7 @@ class DelugeAPI(GenericClient):
         post_data = json.dumps({
             'method': 'core.remove_torrent',
             'params': [
-                [info_hash],
+                info_hash,
                 True,
             ],
             'id': 5,
@@ -361,6 +369,101 @@ class DelugeAPI(GenericClient):
             return not self.response.json()['error']
 
         return True
+
+    def remove_ratio_reached(self):
+        """Remove all Medusa torrents that ratio was reached.
+
+        It loops in all hashes returned from client and check if it is in the snatch history
+        if its then it checks if we already processed media from the torrent (episode status `Downloaded`)
+        If is a RARed torrent then we don't have a media file so we check if that hash is from an
+        episode that has a `Downloaded` status
+        """
+        post_data = json.dumps({
+            'method': 'core.get_torrents_status',
+            'params': [
+                {},
+                ['name', 'hash', 'progress', 'state', 'ratio', 'stop_ratio',
+                 'is_seed', 'is_finished', 'paused', 'files'],
+            ],
+            'id': 72,
+        })
+
+        log.info('Checking Deluge torrent status.')
+        if self._request(method='post', data=post_data):
+            if self.response.json()['error']:
+                log.info('Error while fetching torrents status')
+                return
+            else:
+                found_torrents = False
+                torrent_data = self.response.json()['result']
+
+        for torrent in torrent_data.items():
+            info_hash = str(torrent[0])
+            details = torrent[1]
+            if not is_info_hash_in_history(info_hash):
+                continue
+            found_torrents = True
+
+            to_remove = False
+            for i in details['files']:
+                # Check if media was processed
+                # OR check hash in case of RARed torrents
+                if is_already_processed_media(i['path']) or is_info_hash_processed(info_hash):
+                    to_remove = True
+
+            # Don't need to check status if we are not going to remove it.
+            if not to_remove:
+                log.info('Torrent not yet post-processed. Skipping: {torrent}',
+                         {'torrent': details['name']})
+                continue
+
+            status = 'busy'
+            if details['is_finished']:
+                status = 'completed'
+            elif details['is_seed']:
+                status = 'seeding'
+            elif details['paused']:
+                status = 'paused'
+            else:
+                status = details['state']
+
+            if status == 'completed':
+                log.info(
+                    'Torrent completed and reached minimum'
+                    ' ratio: [{ratio:.3f}/{ratio_limit:.3f}] or'
+                    ' seed idle limit'
+                    ' Removing it: [{name}]',
+                    ratio=details['ratio'],
+                    ratio_limit=torrent['stop_ratio'],
+                    name=torrent['name']
+                )
+                # Commented for now
+                # self.remove_torrent(info_hash)
+            elif status == 'seeding':
+                if float(details['ratio']) < float(details['stop_ratio']):
+                    log.info(
+                        'Torrent did not reach minimum'
+                        ' ratio: [{ratio:.3f}/{ratio_limit:.3f}].'
+                        ' Keeping it: [{name}]',
+                        ratio=torrent['ratio'],
+                        ratio_limit=torrent['stop_ratio'],
+                        name=torrent['name']
+                    )
+                else:
+                    log.info(
+                        'Torrent completed and reached minimum ratio but it'
+                        ' was force started again. Current'
+                        ' ratio: [{ratio:.3f}/{ratio_limit:.3f}].'
+                        ' Keeping it: [{name}]',
+                        ratio=torrent['uploadRatio'],
+                        ratio_limit=torrent['seedRatioLimit'],
+                        name=torrent['name']
+                    )
+            else:
+                log.info('Torrent is {status}. Keeping it: [{name}]', status=status, name=details['name'])
+
+        if not found_torrents:
+            log.info('No torrents found that were snatched by Medusa')
 
 
 api = DelugeAPI

--- a/views/config_search.mako
+++ b/views/config_search.mako
@@ -94,11 +94,11 @@
                                         </span>
                                 </label>
                             </div><!-- daily search frequency -->
-                            <div class="field-pair"${' hidden' if app.TORRENT_METHOD not in ('transmission', 'deluge') else ''}>
+                            <div class="field-pair"${' hidden' if app.TORRENT_METHOD not in ('transmission', 'deluge', 'deluged') else ''}>
                                 <label for="remove_from_client">
                                     <span class="component-title">Remove torrents from client</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="remove_from_client" id="remove_from_client" class="enabler" ${'checked="checked"' if app.REMOVE_FROM_CLIENT and app.TORRENT_METHOD in ('transmission', 'deluge') else ''}/>
+                                        <input type="checkbox" name="remove_from_client" id="remove_from_client" class="enabler" ${'checked="checked"' if app.REMOVE_FROM_CLIENT and app.TORRENT_METHOD in ('transmission', 'deluge', 'deluged') else ''}/>
                                         <p>Remove torrent from client (also torrent data) when provider ratio is reached</p>
                                         <p><b>Note:</b> For now only Transmission and Deluge are supported</p>
                                     </span>

--- a/views/config_search.mako
+++ b/views/config_search.mako
@@ -94,13 +94,13 @@
                                         </span>
                                 </label>
                             </div><!-- daily search frequency -->
-                            <div class="field-pair"${' hidden' if app.TORRENT_METHOD != 'transmission' else ''}>
+                            <div class="field-pair"${' hidden' if app.TORRENT_METHOD not in ('transmission', 'deluge') else ''}>
                                 <label for="remove_from_client">
                                     <span class="component-title">Remove torrents from client</span>
                                     <span class="component-desc">
-                                        <input type="checkbox" name="remove_from_client" id="remove_from_client" class="enabler" ${'checked="checked"' if app.REMOVE_FROM_CLIENT and app.TORRENT_METHOD == 'transmission' else ''}/>
+                                        <input type="checkbox" name="remove_from_client" id="remove_from_client" class="enabler" ${'checked="checked"' if app.REMOVE_FROM_CLIENT and app.TORRENT_METHOD in ('transmission', 'deluge') else ''}/>
                                         <p>Remove torrent from client (also torrent data) when provider ratio is reached</p>
-                                        <p><b>Note:</b> For now only Transmission is supported</p>
+                                        <p><b>Note:</b> For now only Transmission and Deluge are supported</p>
                                     </span>
                                 </label>
                             </div>


### PR DESCRIPTION
Continue the implementation of: https://github.com/pymedusa/Medusa/issues/1139

Now Deluge/Deluged has both features transmission has: 
1) remove when ratio reached
2) move to seeding folder

@OmgImAlexis @Nicoleoca @ratoaq2

TODO:

- [ ] Uncomment code to remove. For now it will only log the removal


This is the log when removal is uncommented:
```
2017-03-28 15:41:45 DEBUG    TORRENTCHECKER :: [b4a8a54] Deluge: Requested a POST connection to http://localhost:8112/json with params: None Data: {"params": ["3513ede325....", true], "method": "core.remove_torrent", "id...
2017-03-28 15:41:45 DEBUG    TORRENTCHECKER :: [b4a8a54] Deluge: Response to POST request is {"id": 5, "result": true, "error": null}
```