### PR TITLE
Fix reusing "wrong" guessit cached name parsing after new numbering

### DIFF
--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -500,7 +500,7 @@ class NameParserCache(object):
         """Remove cache item given indexer and indexer_id."""
         if not indexer or not indexer_id:
             return
-        to_remove = (cached_name for cached_name, cached_parsed_result in self.cache.items() if
+        to_remove = (cached_name for cached_name, cached_parsed_result in self.cache.iteritems() if
                      cached_parsed_result.show.indexer == indexer and cached_parsed_result.show.indexerid == indexer_id)
         for item in to_remove:
             self.cache.popitem(item)

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -26,6 +26,8 @@ from medusa.indexers.indexer_exceptions import (
 )
 from medusa.logger.adapters.style import BraceAdapter
 
+from six import iteritems
+
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
@@ -500,7 +502,7 @@ class NameParserCache(object):
         """Remove cache item given indexer and indexer_id."""
         if not indexer or not indexer_id:
             return
-        to_remove = (cached_name for cached_name, cached_parsed_result in self.cache.iteritems() if
+        to_remove = (cached_name for cached_name, cached_parsed_result in iteritems(self.cache) if
                      cached_parsed_result.show.indexer == indexer and cached_parsed_result.show.indexerid == indexer_id)
         for item in to_remove:
             self.cache.popitem(item)

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -504,7 +504,7 @@ class NameParserCache(object):
                      cached_parsed_result.show.indexer == indexer and cached_parsed_result.show.indexerid == indexer_id)
         for item in to_remove:
             self.cache.popitem(item)
-            logger.debug('Removed parsed cached result for release: {release}'.format(release=item))
+            log.debug('Removed parsed cached result for release: {release}'.format(release=item))
 
 
 name_parser_cache = NameParserCache()

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -252,6 +252,10 @@ class NameParser(object):
 
         return result
 
+    def unparse(self, indexer, indexer_id):
+        """Unparse all names from given indexer and indexer_id."""
+        name_parser_cache.remove(indexer, indexer_id)
+
     def parse(self, name, cache_result=True):
         """Parse the name into a ParseResult.
 
@@ -490,6 +494,16 @@ class NameParserCache(object):
         if name in self.cache:
             log.debug('Using cached parse result for {name}', {'name': name})
             return self.cache[name]
+
+    def remove(self, indexer, indexer_id):
+        """Remove cache item given indexer and indexer_id."""
+        if not indexer or not indexer_id:
+            return
+        to_remove = (cached_name for cached_name, cached_parsed_result in self.cache.items() if
+                     cached_parsed_result.show.indexer == indexer and cached_parsed_result.show.indexerid == indexer_id)
+        for item in to_remove:
+            self.cache.popitem(item)
+            logger.debug('Removed parsed cached result for release: {release}'.format(release=item))
 
 
 name_parser_cache = NameParserCache()

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -252,8 +252,9 @@ class NameParser(object):
 
         return result
 
-    def unparse(self, indexer, indexer_id):
-        """Unparse all names from given indexer and indexer_id."""
+    @staticmethod
+    def erase_cached_parse(indexer, indexer_id):
+        """Remove all names from given indexer and indexer_id."""
         name_parser_cache.remove(indexer, indexer_id)
 
     def parse(self, name, cache_result=True):

--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -223,6 +223,7 @@ def set_scene_numbering(indexer_id, indexer, season=None, episode=None,  # pylin
     # Reload data from DB so that cache and db are in sync
     show = Show.find(app.showList, indexer_id)
     show.flush_episodes()
+    show.erase_cached_parser()
 
 
 def find_xem_numbering(indexer_id, indexer, season, episode):

--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -223,7 +223,7 @@ def set_scene_numbering(indexer_id, indexer, season=None, episode=None,  # pylin
     # Reload data from DB so that cache and db are in sync
     show = Show.find(app.showList, indexer_id)
     show.flush_episodes()
-    show.erase_cached_parser()
+    show.erase_cached_parse()
 
 
 def find_xem_numbering(indexer_id, indexer, season, episode):

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1573,12 +1573,13 @@ class Home(WebRoot):
                     logger.log("Unable to refresh show '{show}': {error}".format
                                (show=show_obj.name, error=e.message), logger.WARNING)
 
-            # Check if we should erase parsed cached results f or that show
+            # Check if we should erase parsed cached results for that show
             do_erase_parsed_cache = False
-            for item in ['scene', 'anime', 'sports', 'air_by_date', 'dvd_order']:
-                if getattr(show_obj, item) != ast.parse(item):
+            for item in [('scene', scene), ('anime', anime), ('sports', sports),
+                         ('air_by_date', air_by_date), ('dvd_order', dvd_order)]:
+                if getattr(show_obj, item[0]) != item[1]:
                     do_erase_parsed_cache = True
-                    # Break if at least one was changed
+                    # Break if at least one setting was changed
                     break
 
             show_obj.paused = paused

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1667,7 +1667,7 @@ class Home(WebRoot):
 
             # Erase parsed cached names as we are changing scene numbering
             show_obj.flush_episodes()
-            show_obj.erase_cached_parser()
+            show_obj.erase_cached_parse()
 
             # Need to refresh show as we updated scene numbering or changed show format
             try:

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1675,8 +1675,8 @@ class Home(WebRoot):
                 app.show_queue_scheduler.action.refreshShow(show_obj)
             except CantRefreshShowException as e:
                 errors += 1
-                logger.log("Unable to refresh show '{show}'. You must manually refresh!. Error: {error}".format
-                           (show=show_obj.name, error=e.message), logger.WARNING)
+                logger.log("Unable to refresh show '{show}'. Please manually trigger a full show refresh. "
+                           "Error: {error}".format(show=show_obj.name, error=e.message), logger.WARNING)
 
         if directCall:
             return errors

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1576,7 +1576,7 @@ class Home(WebRoot):
             # Check if we should erase parsed cached results f or that show
             do_erase_parsed_cache = False
             for item in ['scene', 'anime', 'sports', 'air_by_date', 'dvd_order']:
-                if getattr(show_obj, item) != ast.literal_eval(item):
+                if getattr(show_obj, item) != ast.parse(item):
                     do_erase_parsed_cache = True
                     # Break if at least one was changed
                     break

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1576,7 +1576,7 @@ class Home(WebRoot):
             # Check if we should erase parsed cached results f or that show
             do_erase_parsed_cache = False
             for item in ['scene', 'anime', 'sports', 'air_by_date', 'dvd_order']:
-                if getattr(show_obj, item) != eval(item):
+                if getattr(show_obj, item) != ast.literal_eval(item):
                     do_erase_parsed_cache = True
                     # Break if at least one was changed
                     break

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -556,9 +556,9 @@ class Series(TV):
                 self.episodes[cur_season][cur_ep] = None
                 del my_ep
 
-    def erase_cached_parser(self):
-        """Erase parsed results because user changed xem numbering."""
-        NameParser().unparse(self.indexer, self.indexerid)
+    def erase_cached_parse(self):
+        """Erase parsed cached results."""
+        NameParser().erase_cached_parse(self.indexer, self.indexerid)
 
     def get_all_seasons(self, last_airdate=False):
         """Retrieve a dictionary of seasons with the number of episodes, using the episodes table.

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -556,6 +556,10 @@ class Series(TV):
                 self.episodes[cur_season][cur_ep] = None
                 del my_ep
 
+    def erase_cached_parser(self):
+        """Erase parsed results because user changed xem numbering."""
+        NameParser().unparse(self.indexer, self.indexerid)
+
     def get_all_seasons(self, last_airdate=False):
         """Retrieve a dictionary of seasons with the number of episodes, using the episodes table.
 


### PR DESCRIPTION
Fixes: https://github.com/pymedusa/Medusa/issues/1975

@p0psicles @duramato @ratoaq2

```
[b4a8a54] Removed parsed cached result for release: Bull.2016.S01E17.1080p.HDTV.X264-DIMENSION[rartv]
[b4a8a54] Removed parsed cached result for release: Bull.S01E17.REPACK.720p.HDTV.x264-AVS[rartv]
[b4a8a54] Removed parsed cached result for release: Bull.S01E17.HDTV.x264-SVA[rartv]
```