### PR TITLE
Fix 'unknown' status for 'continuing' status shows

### DIFF
--- a/medusa/indexers/indexer_config.py
+++ b/medusa/indexers/indexer_config.py
@@ -70,6 +70,7 @@ STATUS_MAP = {
     'in production': 'Continuing',
     'pilot': 'Continuing',
     'cancelled': 'Ended',
+    'continuing': 'Continuing'
 }
 
 indexerConfig = {


### PR DESCRIPTION
All status need to be added in the map, including `continuing`