### PR TITLE
Add fallback for BraceMessage formatting

### DIFF
--- a/medusa/logger/adapters/style.py
+++ b/medusa/logger/adapters/style.py
@@ -8,6 +8,8 @@ import logging
 
 from six import text_type
 
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
 
 class BraceMessage(object):
     """Lazily convert a Brace-formatted message."""
@@ -31,6 +33,9 @@ class BraceMessage(object):
             return self.msg.format(*args, **kwargs)
         except IndexError:
             return self.msg.format(kwargs)
+        except Exception:
+            log.exception('BraceMessage string formatting failed. Using representation instead.')
+            return repr(self)
 
     def __repr__(self):
         """Convert to class representation."""

--- a/medusa/logger/adapters/style.py
+++ b/medusa/logger/adapters/style.py
@@ -11,6 +11,7 @@ from six import text_type
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
+
 class BraceMessage(object):
     """Lazily convert a Brace-formatted message."""
 


### PR DESCRIPTION
If string formatting of BraceMessage fails, fall back to the `repr` to log the message and log a traceback of the reason.