### PR TITLE
Add default to avoid raising exception with getattr(). Fixes #2665

### DIFF
--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -162,7 +162,7 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                            (provider=cur_provider.name, error=ex(e)), logger.DEBUG)
                 continue
             except Exception as e:
-                if 'ECONNRESET' in e or getattr(e, 'errno') == errno.ECONNRESET:
+                if 'ECONNRESET' in e or getattr(e, 'errno', None) == errno.ECONNRESET:
                     logger.log('Connection reset by peer while searching for propers in {provider}. '
                                'Skipping: {error}'.format
                                (provider=cur_provider.name, error=ex(e)), logger.DEBUG)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
