### PR TITLE
Use t411 new domain

### DIFF
--- a/medusa/providers/torrent/json/t411.py
+++ b/medusa/providers/torrent/json/t411.py
@@ -51,7 +51,7 @@ class T411Provider(TorrentProvider):
         self.tokenLastUpdate = None
 
         # URLs
-        self.url = 'https://api.t411.ai'
+        self.url = 'https://api.t411.al'
         self.urls = {
             'search': urljoin(self.url, 'torrents/search/{search}'),
             'rss': urljoin(self.url, 'torrents/top/today'),


### PR DESCRIPTION
No easy solution to make remote URL like we do with broken providers. 
Also my design won't be approved anyway so someone more experience could do that.

For now just changing develop as redirect still works

@IDerr