### PR TITLE
Don't assume same_file if size is 0 (unable to get size)

### DIFF
--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1317,9 +1317,13 @@ class Series(TV):
 
                 with cur_ep.lock:
                     old_size = cur_ep.file_size
+
+                    # Setting a location to cur_ep, we will get the size of the filepath
                     cur_ep.location = filepath
+
                     # if the sizes are the same then it's probably the same file
-                    same_file = old_size and cur_ep.file_size == old_size
+                    # If size from given filepath is 0 means we couldn't determine file size
+                    same_file = old_size and cur_ep.file_size > 0 and cur_ep.file_size == old_size
                     cur_ep.check_for_meta_files()
 
             if root_ep is None:


### PR DESCRIPTION
~~Possible fix to: https://github.com/pymedusa/Medusa/issues/2652~~

From his logs:
`SHOWQUEUE-REFRESH :: [a011615] 258368: Not changing **current status 'Unaired'** based on file: /tv/Inventions that Shook the World/Season 01/Inventions that Shook the World - S01E01 - The 1900s.wtv`
**Reason: New file is the same as current file**

if status is UNAIRED, then episode object file size is 0, and if we can't get a size, size will also be 0, thus the reason above showing both have the same size (which is wrong)

He copied the file to show folder without using the PP and hit re-scan files