### PR TITLE
Fix season pack forced search

### DIFF
--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -151,27 +151,34 @@ class SearchResult(object):
                                          self.leechers, self.size, self.pubdate, parsed_result=self.parsed_result)
         return None
 
-    def check_episodes_for_quality(self, forced_search, download_current_quality):
+    def check_episodes_for_quality(self, forced_search, download_current_quality, search_mode):
         """Check if that episode is wanted in that quality.
 
         We could have gotten a multi-ep result, let's see if at least one if them is what we want
         in the correct quality.
         """
-        if not self.actual_episodes or not self.actual_season:
-            return False
+        if search_mode == 'eponly':
+            if not self.actual_episodes or not self.actual_season:
+                return False
+            episodes = self.actual_episodes
+
+        if search_mode == 'sponly':
+
+            if not self.actual_season:
+                return False
+            # Only need to check one episode quality in a season pack.
+            # Later we will check all episodes based on provider preferences
+            # 1) Snatch all episodes of the season pack or 2) Download season pack
+            episodes = [1]
 
         result_wanted = False
-        for episode_number in self.actual_episodes:
+        for episode_number in episodes:
             # Check whether or not the episode with the specified quality is wanted.
             if self.show.want_episode(self.actual_season, episode_number,
                                       self.quality, forced_search, download_current_quality):
                 result_wanted = True
 
-        if not result_wanted:
-            logger.debug('We could not find a result in the correct quality for {release_name} with url {url}',
-                         release_name=self.name, url=self.url)
-            return False
-        return True
+        return result_wanted
 
     def create_episode_object(self):
         """Use this result to create an episode segment out of it."""

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -186,7 +186,8 @@ class GenericProvider(object):
         results = {}
         items_list = []
 
-        for episode in episodes:
+        # Need to be sorted because in a season search we only need episode 01 to get season search string
+        for episode in sorted(episodes, key=lambda k: k.episode):
             if not manual_search:
                 cache_result = self.cache.search_cache(episode, forced_search=forced_search,
                                                        down_cur_quality=download_current_quality)
@@ -207,6 +208,10 @@ class GenericProvider(object):
             for search_string in search_strings:
                 # Find results from the provider
                 items_list += self.search(search_string, ep_obj=episode)
+
+            # In season search, we can't loop in episodes lists as we only need one episode to get the season string
+            if search_mode == 'sponly':
+                break
 
         if len(results) == len(episodes):
             return results
@@ -379,8 +384,9 @@ class GenericProvider(object):
                           search_result.name, search_result.url)
                 continue
 
-            if not manual_search:
+            if not (manual_search or search_mode == 'sponly'):
                 # The second check, will loop through actual_episodes and check if there's anything useful in it.
+                # If is a season pack search, we only have the season, not the episodes.
                 if not search_result.check_episodes_for_quality(forced_search, download_current_quality):
                     log.debug('Ignoring result {0}', search_result.name)
                     continue

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -323,12 +323,6 @@ class GenericProvider(object):
                             )
                             search_result.result_wanted = False
                             continue
-
-                    # We've performed some checks to decided if we want to continue with this result.
-                    # If we've hit this, that means this is not an air_by_date and not a sports show. And it seems to be
-                    # a valid result. Let's store the parsed season and episode number and continue.
-                    search_result.actual_season = search_result.parsed_result.season_number
-                    search_result.actual_episodes = search_result.parsed_result.episode_numbers
                 else:
                     # air_by_date or sportshow.
                     search_result.same_day_special = False
@@ -384,14 +378,17 @@ class GenericProvider(object):
                           search_result.name, search_result.url)
                 continue
 
-            if not (manual_search or search_mode == 'sponly'):
+            if not manual_search:
                 # The second check, will loop through actual_episodes and check if there's anything useful in it.
-                # If is a season pack search, we only have the season, not the episodes.
-                if not search_result.check_episodes_for_quality(forced_search, download_current_quality):
-                    log.debug('Ignoring result {0}', search_result.name)
+                if not search_result.check_episodes_for_quality(forced_search, download_current_quality, search_mode):
+                    log.debug('Ignoring result {0} with unwanted quality at {1}',
+                              search_result.name, search_result.url)
                     continue
 
-            log.debug('Found result {0} at {1}', search_result.name, search_result.url)
+            log.debug('Found result {0} {1}at {2}',
+                      search_result.name,
+                      '' if manual_search else 'with quanted quality ',
+                      search_result.url)
 
             episode_object = search_result.create_episode_object()
             # result = self.get_result(episode_object, search_result)
@@ -399,14 +396,16 @@ class GenericProvider(object):
 
             if not episode_object:
                 episode_number = SEASON_RESULT
-                log.debug('Separating full season result to check for later')
+                log.debug('Found season pack result {0} at {1}', search_result.name, search_result.url)
             elif len(episode_object) == 1:
                 episode_number = episode_object[0].episode
-                log.debug('Single episode result.')
+                log.debug('Found single episode result {0} at {1}', search_result.name, search_result.url)
             else:
                 episode_number = MULTI_EP_RESULT
-                log.debug('Separating multi-episode result to check for later - result contains episodes: {0}',
-                          search_result.parsed_result.episode_numbers)
+                log.debug('Found multi-episode ({0}) result {1} at {2}',
+                          ', '.join(search_result.parsed_result.episode_numbers),
+                          search_result.name,
+                          search_result.url)
 
             if episode_number not in results:
                 results[episode_number] = [search_result]

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -259,13 +259,7 @@ def pick_best_result(results, show):  # pylint: disable=too-many-branches
             if not show.release_groups.is_valid(cur_result):
                 continue
 
-        log.info(u'Quality of {0} is {1}', cur_result.name, Quality.qualityStrings[cur_result.quality])
-
         allowed_qualities, preferred_qualities = show.current_qualities
-
-        if cur_result.quality not in allowed_qualities + preferred_qualities:
-            log.debug(u'{0} is an unwanted quality, rejecting it', cur_result.name)
-            continue
 
         # If doesnt have min seeders OR min leechers then discard it
         if cur_result.seeders not in (-1, None) and cur_result.leechers not in (-1, None) \
@@ -327,7 +321,8 @@ def pick_best_result(results, show):  # pylint: disable=too-many-branches
             elif u'xvid' in best_result.name.lower() and u'x264' in cur_result.name.lower():
                 log.info(u'Preferring {0} (x264 over xvid)', cur_result.name)
                 best_result = cur_result
-            if any(ext in best_result.name.lower() for ext in undesired_words) and not any(ext in cur_result.name.lower() for ext in undesired_words):
+            if any(ext in best_result.name.lower() for ext in undesired_words) and \
+                    (best_result == cur_result or not any(ext in cur_result.name.lower() for ext in undesired_words)):
                 log.info(u'Unwanted release {0} (contains undesired word(s))', cur_result.name)
                 best_result = cur_result
 


### PR DESCRIPTION
Fixes: https://github.com/pymedusa/Medusa/issues/2830

Also fixes the providers hammering in a season search.
In a season search it searches for same string (Show Sxx) N times (where N is the number of episodes for that season)

Logs:
```
SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] All episodes in this season are needed, downloading torrent Show.S05.1080p.WEBRip.DD5.1.x264-P2P
SEARCHQUEUE-BACKLOG-257655 :: [b4a8a54] Downloading Show.S05.1080p.WEBRip.DD5.1.x264-P2P with 9 seeders and 1 leechers and size 100.48 GB from MoreThanTV
```