### PR TITLE
Make "internal" and "xvid" undesired by default (like it was) but configurable

### DIFF
--- a/medusa/app.py
+++ b/medusa/app.py
@@ -558,7 +558,7 @@ IGNORE_WORDS = "german,french,core2hd,dutch,swedish,reenc,MrLss,dubbed"
 
 PREFERRED_WORDS = ""
 
-UNDESIRED_WORDS = ""
+UNDESIRED_WORDS = "internal,xvid"
 
 TRACKERS_LIST = "udp://tracker.coppersurfer.tk:6969/announce,udp://tracker.leechers-paradise.org:6969/announce,\
     udp://tracker.zer0day.to:1337/announce,udp://tracker.opentrackr.org:1337/announce,\

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -321,12 +321,6 @@ def pick_best_result(results, show):  # pylint: disable=too-many-branches
             if cur_result.proper_tags:
                 log.info(u'Preferring {0} (repack/proper/real/rerip over nuked)', cur_result.name)
                 best_result = cur_result
-            elif u'internal' in best_result.name.lower() and u'internal' not in cur_result.name.lower():
-                log.info(u'Preferring {0} (normal instead of internal)', cur_result.name)
-                best_result = cur_result
-            elif u'xvid' in best_result.name.lower() and u'x264' in cur_result.name.lower():
-                log.info(u'Preferring {0} (x264 over xvid)', cur_result.name)
-                best_result = cur_result
             if any(ext in best_result.name.lower() for ext in undesired_words) and not any(ext in cur_result.name.lower() for ext in undesired_words):
                 log.info(u'Unwanted release {0} (contains undesired word(s))', cur_result.name)
                 best_result = cur_result


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
