### PR TITLE
Fix undesired words when the first item has undesired words

### DIFF
--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -327,7 +327,8 @@ def pick_best_result(results, show):  # pylint: disable=too-many-branches
             elif u'xvid' in best_result.name.lower() and u'x264' in cur_result.name.lower():
                 log.info(u'Preferring {0} (x264 over xvid)', cur_result.name)
                 best_result = cur_result
-            if any(ext in best_result.name.lower() for ext in undesired_words) and not any(ext in cur_result.name.lower() for ext in undesired_words):
+            if any(ext in best_result.name.lower() for ext in undesired_words) and \
+                    (best_result == cur_result or not any(ext in cur_result.name.lower() for ext in undesired_words)):
                 log.info(u'Unwanted release {0} (contains undesired word(s))', cur_result.name)
                 best_result = cur_result
 


### PR DESCRIPTION
In the first loop, best_result = cur_result, so if the first item has a undesired word, we don't log as undesired release when we should

Undesired words: DRACULA AND P2P

**Without the fix:**
SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] Picking the best result out of [u'Show.S05.1080p.WEB-DL.DD5.1.H264-DRACULA', u'Show.S05.1080p.WEBRip.DD5.1.x264-P2P']
SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] Unwanted release Show.S05.1080p.WEBRip.DD5.1.x264-P2P (contains undesired word(s))

**With the fix:**
SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] Picking the best result out of [u'Show.S05.1080p.WEB-DL.DD5.1.H264-DRACULA', u'Show.S05.1080p.WEBRip.DD5.1.x264-P2P']
**SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] Unwanted release Show.S05.1080p.WEB-DL.DD5.1.H264-DRACULA (contains undesired word(s))**
SEARCHQUEUE-BACKLOG-257655 :: [MoreThanTV] :: [b4a8a54] Unwanted release Show.S05.1080p.WEBRip.DD5.1.x264-P2P (contains undesired word(s))

