### PR TITLE
Fixing knowit random provider order

### DIFF
--- a/lib/knowit/__init__.py
+++ b/lib/knowit/__init__.py
@@ -3,11 +3,11 @@
 from __future__ import unicode_literals
 
 __title__ = 'knowit'
-__version__ = '0.2.2'
+__version__ = '0.2.3'
 __short_version__ = '.'.join(__version__.split('.')[:2])
 __author__ = 'Rato AQ2'
 __license__ = 'MIT'
-__copyright__ = 'Copyright 2016, Rato AQ2'
+__copyright__ = 'Copyright 2016-2017, Rato AQ2'
 __url__ = 'https://github.com/ratoaq2/knowit'
 
 #: Video extensions

--- a/lib/knowit/__main__.py
+++ b/lib/knowit/__main__.py
@@ -6,8 +6,6 @@ import logging
 import sys
 from argparse import ArgumentParser
 
-from enzyme import __version__ as enzyme_version
-from pymediainfo import __version__ as pymediainfo_version
 from six import PY2
 import yaml
 
@@ -146,29 +144,27 @@ def main(args=None):
                 console.info('Knowit %s knows everything. :-)', __version__)
 
     elif options.version:
-        api.initialize(vars(options))
-        mediainfo_executor = api.available_providers['mediainfo'].executor
-        mediainfo_location = mediainfo_executor.location if mediainfo_executor else None
-        ffmpeg_executor = api.available_providers['ffmpeg'].executor
-        ffmpeg_location = ffmpeg_executor.location if ffmpeg_executor else None
-
         console.info('+-------------------------------------------------------+')
         _print_centered('KnowIt {0}'.format(__version__))
         console.info('+-------------------------------------------------------+')
-        _print_centered('Enzyme {0}'.format(enzyme_version))
-        _print_centered('pymediainfo {0}'.format(pymediainfo_version))
-        if not mediainfo_location:
-            _print_centered('MediaInfo not available')
-            _print_centered('https://mediaarea.net/en/MediaInfo/Download')
-        else:
-            _print_centered('MediaInfo available')
-            _print_centered(mediainfo_location)
-        if not ffmpeg_location:
-            _print_centered('FFmpeg not available')
-            _print_centered('https://ffmpeg.org/download.html')
-        else:
-            _print_centered('FFmpeg available')
-            _print_centered(ffmpeg_location)
+
+        first = True
+        for key, info in api.dependencies(vars(options)).items():
+            if not first:
+                _print_centered('')
+            first = False
+
+            version, location = info
+            if version:
+                _print_centered('{0} {1}'.format(key, version))
+                if location:
+                    _print_centered(location)
+            elif not location:
+                _print_centered('{0} not available'.format(key, version))
+            else:
+                _print_centered(key)
+                _print_centered(location)
+
         console.info('+-------------------------------------------------------+')
         console.info('|      Please report any bug or feature request at      |')
         console.info('|     https://github.com/ratoaq2/knowit/issues.         |')
@@ -179,8 +175,7 @@ def main(args=None):
 
 def _print_centered(value):
     value = value[-52:]
-    spaces = max((53 - len(value)), 0)
-    console.info('| %s%s%s |', spaces / 2 * ' ', value, (spaces / 2 + spaces % 2) * ' ')
+    console.info('| {msg:^53} |'.format(msg=value))
 
 
 if __name__ == '__main__':

--- a/lib/knowit/api.py
+++ b/lib/knowit/api.py
@@ -9,11 +9,11 @@ from .providers import (
     MediaInfoProvider,
 )
 
-_provider_map = {
-    'ffmpeg': FFmpegProvider,
-    'mediainfo': MediaInfoProvider,
-    'enzyme': EnzymeProvider,
-}
+_provider_map = OrderedDict([
+    ('mediainfo', MediaInfoProvider),
+    ('ffmpeg', FFmpegProvider),
+    ('enzyme', EnzymeProvider),
+])
 
 available_providers = OrderedDict([])
 
@@ -49,3 +49,16 @@ def know(video_path, context=None):
             return provider.describe(video_path, context)
 
     return {}
+
+
+def dependencies(context=None):
+    """Return all dependencies detected by knowit."""
+    initialize(context)
+    deps = OrderedDict([])
+    for name, provider_cls in _provider_map.items():
+        if name in available_providers:
+            deps[name] = available_providers[name].version
+        else:
+            deps[name] = None, None
+
+    return deps

--- a/lib/knowit/properties/audio/channels.py
+++ b/lib/knowit/properties/audio/channels.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
-
 from six import text_type
 
 from ...property import Property
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class AudioChannels(Property):

--- a/lib/knowit/properties/basic.py
+++ b/lib/knowit/properties/basic.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
-
 from six import text_type
 
 from ..property import Property
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class Basic(Property):

--- a/lib/knowit/properties/duration.py
+++ b/lib/knowit/properties/duration.py
@@ -4,13 +4,9 @@ from __future__ import unicode_literals
 import re
 
 from datetime import timedelta
-from logging import NullHandler, getLogger
 from six import text_type
 
 from ..property import Property
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class Duration(Property):

--- a/lib/knowit/properties/language.py
+++ b/lib/knowit/properties/language.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
 import babelfish
 
 from ..property import Property
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class Language(Property):

--- a/lib/knowit/properties/quantity.py
+++ b/lib/knowit/properties/quantity.py
@@ -1,13 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
 from six import text_type
 
 from ..property import Property
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class Quantity(Property):

--- a/lib/knowit/provider.py
+++ b/lib/knowit/provider.py
@@ -90,6 +90,11 @@ class Provider(object):
 
         return props
 
+    @property
+    def version(self):
+        """Return provider version information."""
+        raise NotImplementedError
+
 
 class ProviderError(Exception):
     """Base class for provider exceptions."""

--- a/lib/knowit/providers/enzyme.py
+++ b/lib/knowit/providers/enzyme.py
@@ -130,3 +130,8 @@ class EnzymeProvider(Provider):
 
         result['provider'] = 'Enzyme {0}'.format(enzyme.__version__)
         return result
+
+    @property
+    def version(self):
+        """Return enzyme version information."""
+        return enzyme.__version__, None

--- a/lib/knowit/providers/ffmpeg.py
+++ b/lib/knowit/providers/ffmpeg.py
@@ -236,3 +236,8 @@ class FFmpegProvider(Provider):
 
         result['provider'] = self.executor.location
         return result
+
+    @property
+    def version(self):
+        """Return ffmpeg version information."""
+        return None, self.executor.location if self.executor else None

--- a/lib/knowit/providers/mediainfo.py
+++ b/lib/knowit/providers/mediainfo.py
@@ -9,6 +9,7 @@ from ctypes import c_size_t, c_void_p, c_wchar_p
 from logging import NullHandler, getLogger
 from subprocess import check_output
 
+from pymediainfo import __version__ as pymediainfo_version
 from pymediainfo import MediaInfo
 
 from .. import (
@@ -354,3 +355,8 @@ class MediaInfoProvider(Provider):
 
         result['provider'] = self.executor.location
         return result
+
+    @property
+    def version(self):
+        """Return mediainfo version information."""
+        return pymediainfo_version, self.executor.location if self.executor else None

--- a/lib/knowit/providers/mediainfo.py
+++ b/lib/knowit/providers/mediainfo.py
@@ -9,8 +9,8 @@ from ctypes import c_size_t, c_void_p, c_wchar_p
 from logging import NullHandler, getLogger
 from subprocess import check_output
 
-from pymediainfo import __version__ as pymediainfo_version
 from pymediainfo import MediaInfo
+from pymediainfo import __version__ as pymediainfo_version
 
 from .. import (
     OrderedDict,

--- a/lib/knowit/rules/__init__.py
+++ b/lib/knowit/rules/__init__.py
@@ -1,14 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
-
 from .audio import AudioChannelsRule
 from .audio import AudioCodecRule
 from .language import LanguageRule
 from .subtitle import ClosedCaptionRule
 from .subtitle import HearingImpairedRule
 from .video import ResolutionRule
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())

--- a/lib/knowit/rules/video/resolution.py
+++ b/lib/knowit/rules/video/resolution.py
@@ -1,13 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from logging import NullHandler, getLogger
-
 from ...rule import Rule
 from ...units import units
-
-logger = getLogger(__name__)
-logger.addHandler(NullHandler())
 
 
 class ResolutionRule(Rule):


### PR DESCRIPTION
it should be mediainfo, ffmpeg, enzyme.

This should fix all windows/mac warnings related to ffmpeg since mediainfo is provided for these OSes