### PR TITLE
Fix config patch ignored {u'selectedRootIndex': u'0'}. Needs to be int

### DIFF
--- a/medusa/server/api/v2/config.py
+++ b/medusa/server/api/v2/config.py
@@ -170,7 +170,7 @@ class ConfigHandler(BaseRequestHandler):
         config_data['layout']['show'] = NonEmptyDict()
         config_data['layout']['show']['allSeasons'] = bool(app.DISPLAY_ALL_SEASONS)
         config_data['layout']['show']['specials'] = bool(app.DISPLAY_SHOW_SPECIALS)
-        config_data['selectedRootIndex'] = int(app.SELECTED_ROOT) if app.SELECTED_ROOT else None
+        config_data['selectedRootIndex'] = int(app.SELECTED_ROOT) if app.SELECTED_ROOT is not None else -1  # All paths
         config_data['backlogOverview'] = NonEmptyDict()
         config_data['backlogOverview']['period'] = app.BACKLOG_PERIOD
         config_data['backlogOverview']['status'] = app.BACKLOG_STATUS

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -138,7 +138,12 @@ class Home(WebRoot):
         if selected_root is not None and app.ROOT_DIRS:
             backend_pieces = app.ROOT_DIRS.split('|')
             backend_dirs = backend_pieces[1:]
-            shows_dir = backend_dirs[selected_root] if selected_root != -1 else None
+            try:
+                shows_dir = backend_dirs[selected_root] if selected_root != -1 else None
+            except IndexError:
+                # If user have a root selected in /home and remove the root folder a IndexError is raised
+                shows_dir = None
+                app.SELECTED_ROOT = -1
 
         shows = []
         if app.ANIME_SPLIT_HOME:

--- a/static/js/home/index.js
+++ b/static/js/home/index.js
@@ -337,7 +337,7 @@ MEDUSA.home.index = function() {
 
     $('#showRootDir').on('change', function() {
         api.patch('config/main', {
-            selectedRootIndex: $(this).val()
+            selectedRootIndex: parseInt($(this).val(), 10)
         }).then(function(response) {
             log.info(response);
             window.location.reload();

--- a/tests/apiv2/test_config.py
+++ b/tests/apiv2/test_config.py
@@ -114,7 +114,7 @@ def config(monkeypatch, app_config):
     config_data['layout']['show'] = NonEmptyDict()
     config_data['layout']['show']['allSeasons'] = bool(app.DISPLAY_ALL_SEASONS)
     config_data['layout']['show']['specials'] = bool(app.DISPLAY_SHOW_SPECIALS)
-    config_data['selectedRootIndex'] = int(app.SELECTED_ROOT) if app.SELECTED_ROOT else None
+    config_data['selectedRootIndex'] = int(app.SELECTED_ROOT) if app.SELECTED_ROOT is not None else -1  # All paths
     config_data['backlogOverview'] = NonEmptyDict()
     config_data['backlogOverview']['period'] = app.BACKLOG_PERIOD
     config_data['backlogOverview']['status'] = app.BACKLOG_STATUS


### PR DESCRIPTION
Fixes https://github.com/pymedusa/Medusa/issues/2893

The value of the select is the index number of the root dirs list

Also fixes:
![image](https://user-images.githubusercontent.com/2620870/27357599-32cb25fa-55e9-11e7-9b12-9232f7bcc09d.png)

When selected root index is 0 it would set as None