### PR TITLE
LTV: Use alias as fallback to original series name

### DIFF
--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -122,8 +122,8 @@ class LegendasTVSubtitle(Subtitle):
         # episode
         if isinstance(video, Episode) and self.type == 'episode':
             # series
-            if video.series and (sanitize(video.series) in (
-                    sanitize(name) for name in [self.title] + video.alternative_series)):
+            if video.series and (sanitize(self.title) in (
+                    sanitize(name) for name in [video.series] + video.alternative_series)):
                 matches.add('series')
 
             # year
@@ -137,8 +137,8 @@ class LegendasTVSubtitle(Subtitle):
         # movie
         elif isinstance(video, Movie) and self.type == 'movie':
             # title
-            if video.title and (sanitize(video.title) in (
-                    sanitize(name) for name in [self.title] + video.alternative_titles)):
+            if video.title and (sanitize(self.title) in (
+                    sanitize(name) for name in [video.title] + video.alternative_titles)):
                 matches.add('title')
 
             # year

--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -122,7 +122,9 @@ class LegendasTVSubtitle(Subtitle):
         # episode
         if isinstance(video, Episode) and self.type == 'episode':
             # series
-            if video.series and sanitize(self.title) == sanitize(video.series):
+            sanitized_alias = [sanitize(alias) for alias in video.alternative_series]
+            if video.series and (sanitize(self.title) == sanitize(video.series) or
+                                 sanitize(self.title) in sanitized_alias):
                 matches.add('series')
 
             # year
@@ -136,7 +138,9 @@ class LegendasTVSubtitle(Subtitle):
         # movie
         elif isinstance(video, Movie) and self.type == 'movie':
             # title
-            if video.title and sanitize(self.title) == sanitize(video.title):
+            sanitized_alias = [sanitize(alias) for alias in video.alternative_titles]
+            if video.title and (sanitize(self.title) == sanitize(video.title) or
+                                sanitize(self.title) in sanitized_alias):
                 matches.add('title')
 
             # year
@@ -465,10 +469,21 @@ class LegendasTVProvider(Provider):
             title = video.series
             season = video.season
             episode = video.episode
+            aliases = video.alternative_series
         else:
             title = video.title
+            aliases = video.alternative_titles
 
-        return [s for l in languages for s in self.query(l, title, season=season, episode=episode, year=video.year)]
+        found_subtitles = [s for l in languages for s in
+                           self.query(l, title, season=season, episode=episode, year=video.year)]
+
+        # Use video aliases as fallback
+        if not found_subtitles:
+            for alias in aliases:
+                found_subtitles.extend([s for l in languages for s in
+                                       self.query(l, alias, season=season, episode=episode, year=video.year)])
+
+        return found_subtitles
 
     def download_subtitle(self, subtitle):
         # download archive in case we previously hit the releases cache and didn't download it

--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -122,9 +122,8 @@ class LegendasTVSubtitle(Subtitle):
         # episode
         if isinstance(video, Episode) and self.type == 'episode':
             # series
-            sanitized_alias = [sanitize(alias) for alias in video.alternative_series]
-            if video.series and (sanitize(self.title) == sanitize(video.series) or
-                                 sanitize(self.title) in sanitized_alias):
+            if video.series and (sanitize(video.series) in (
+                    sanitize(name) for name in [self.title] + video.alternative_series)):
                 matches.add('series')
 
             # year
@@ -138,9 +137,8 @@ class LegendasTVSubtitle(Subtitle):
         # movie
         elif isinstance(video, Movie) and self.type == 'movie':
             # title
-            sanitized_alias = [sanitize(alias) for alias in video.alternative_titles]
-            if video.title and (sanitize(self.title) == sanitize(video.title) or
-                                sanitize(self.title) in sanitized_alias):
+            if video.title and (sanitize(video.title) in (
+                    sanitize(name) for name in [self.title] + video.alternative_titles)):
                 matches.add('title')
 
             # year
@@ -466,24 +464,19 @@ class LegendasTVProvider(Provider):
     def list_subtitles(self, video, languages):
         season = episode = None
         if isinstance(video, Episode):
-            title = video.series
+            titles = [video.series] + video.alternative_series
             season = video.season
             episode = video.episode
-            aliases = video.alternative_series
         else:
-            title = video.title
-            aliases = video.alternative_titles
+            titles = [video.title] + video.alternative_titles
 
-        found_subtitles = [s for l in languages for s in
-                           self.query(l, title, season=season, episode=episode, year=video.year)]
+        for title in titles:
+            subtitles = [s for l in languages for s in
+                         self.query(l, title, season=season, episode=episode, year=video.year)]
+            if subtitles:
+                return subtitles
 
-        # Use video aliases as fallback
-        if not found_subtitles:
-            for alias in aliases:
-                found_subtitles.extend([s for l in languages for s in
-                                       self.query(l, alias, season=season, episode=episode, year=video.year)])
-
-        return found_subtitles
+        return []
 
     def download_subtitle(self, subtitle):
         # download archive in case we previously hit the releases cache and didn't download it

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -711,6 +711,8 @@ def get_video(tv_episode, video_path, subtitles_dir=None, subtitles=True, embedd
         refine(video, episode_refiners=episode_refiners, embedded_subtitles=embedded_subtitles,
                release_name=release_name, tv_episode=tv_episode)
 
+        video.alternative_series = tv_episode.series.aliases
+
         payload['video'] = video
         memory_cache.set(key, payload)
         logger.debug(u'Video information cached under key %s', key)

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -711,7 +711,7 @@ def get_video(tv_episode, video_path, subtitles_dir=None, subtitles=True, embedd
         refine(video, episode_refiners=episode_refiners, embedded_subtitles=embedded_subtitles,
                release_name=release_name, tv_episode=tv_episode)
 
-        video.alternative_series = tv_episode.series.aliases
+        video.alternative_series = list(tv_episode.series.aliases)
 
         payload['video'] = video
         memory_cache.set(key, payload)


### PR DESCRIPTION
Fixes an old issue when it doesn't find subtitles because show in provider uses a different name

Examples:
`TURN` and `Turn: Washington's Spies`
`DC’s Legends of Tomorrow` and `Legends of Tomorrow`
`Marvels Agents of SHIELD` vs `Agents of SHIELD`
`Marvel's Jessica Jones` vs `Jessica Jones`
*Most Marvel's shows

It will also work for releases with translated releases like `La Lista Negra` for `The Blacklist`

@ratoaq2 @duramato

PR is in sync with upstream