### PR TITLE
LegendasTV: LegendasTVSubtitle class storing page_link in hearing_impaired attribute

### DIFF
--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -103,7 +103,7 @@ class LegendasTVSubtitle(Subtitle):
     provider_name = 'legendastv'
 
     def __init__(self, language, type, title, year, imdb_id, season, archive, name):
-        super(LegendasTVSubtitle, self).__init__(language, archive.link)
+        super(LegendasTVSubtitle, self).__init__(language, page_link=archive.link)
         self.type = type
         self.title = title
         self.year = year


### PR DESCRIPTION
Subtitle class is: `__init__(self, language, hearing_impaired=False, page_link=None, encoding=None):`

@ratoaq2 added this commit upstream in the minor provider fix PR