### PR TITLE
Implemented smart caching for imdb recommended lists

### DIFF
--- a/medusa/show/recommendations/__init__.py
+++ b/medusa/show/recommendations/__init__.py
@@ -4,6 +4,10 @@ import time
 from collections import namedtuple
 
 
+class ExpectUniqueKeyException(Exception):
+    """Exception raised when multiple keys are detected, but a unique key is expected."""
+
+
 class ExpiringList(list):
     """Smart custom list, with a cache expiration."""
 
@@ -64,7 +68,7 @@ class ExpiringList(list):
             return None
 
         if len(matches) > 1:
-            raise Exception("Returned multiple items, you shouldn't store keys more than once")
+            raise ExpectUniqueKeyException("Returned multiple items, you shouldn't store keys more than once")
 
         if len(matches):
             return ExpiringList.CachedResult(time=matches[0][0], value=matches[0][1])
@@ -129,7 +133,8 @@ class ExpiringKeyValue(list):
         if not matches:
             return None
 
-        assert len(matches) <= 1, "Returned multiple items, you shouldn't store keys more than once"
+        if len(matches) > 1:
+            raise ExpectUniqueKeyException("Returned multiple items, you shouldn't store keys more than once")
 
         if len(matches):
             return ExpiringKeyValue.CachedResult(time=matches[0][0], key=matches[0][1], value=matches[0][2])

--- a/medusa/show/recommendations/__init__.py
+++ b/medusa/show/recommendations/__init__.py
@@ -1,1 +1,134 @@
 # coding=utf-8
+
+from collections import namedtuple
+import time
+
+
+class ExpiringList(list):
+    """Smart custom list, with a cache expiration."""
+    CachedResult = namedtuple('CachedResult', 'time value')
+
+    def __init__(self, items=None, cache_timeout=3600, implicit_clean=False):
+        """Initialize the MissingPosterList.
+
+        :param items: Provide the initial list.
+        :param cache_timeout: Timeout after which the item expires.
+        :param implicit_clean: If enabled, run the clean() method, to check for expired items. Else you'll have to run
+        this periodically.
+        """
+        list.__init__(self, items or [])
+        self.cache_timeout = cache_timeout
+        self.implicit_clean = implicit_clean
+
+    def append(self, item):
+        """Add new items to the list."""
+        if self.implicit_clean:
+            self.clean()
+        super(ExpiringList, self).append((int(time.time()), item))
+
+    def clean(self):
+        """Use the cache_timeout to remove expired items."""
+        new_list = [_ for _ in self if _[0] + self.cache_timeout > int(time.time())]
+        self.__init__(new_list, self.cache_timeout, self.implicit_clean)
+
+    def has(self, value):
+        """Check if the value is in the list.
+
+        We need a smarter method to check if an item is already in the list. This will return a list with items that
+        match the value.
+        :param value: The value to check for.
+        :return: A list of tuples with matches. For example: (141234234, '12342').
+        """
+        if self.implicit_clean:
+            self.clean()
+        return [
+            ExpiringList.CachedResult(time=match[0], value=match[1])
+            for match in self if match[1] == value
+        ]
+
+    def get(self, value):
+        """Check if the value is in the list.
+
+        We need a smarter method to check if an item is already in the list. This will return a list with items that
+        match the value.
+        :param value: The value to check for.
+        :return: A single item, if it matches. For example: <CachedResult()>.
+        """
+        if self.implicit_clean:
+            self.clean()
+
+        matches = [_ for _ in self if _[1] == value]
+
+        if not matches:
+            return None
+
+        if len(matches) > 1:
+            raise Exception("Returned multiple items, you shouldn't store keys more than once")
+
+        if len(matches):
+            return ExpiringList.CachedResult(time=matches[0][0], value=matches[0][1])
+
+
+class ExpiringKeyValue(list):
+    """Smart custom list, with a cache expiration."""
+    CachedResult = namedtuple('CachedResult', 'time key value')
+
+    def __init__(self, items=None, cache_timeout=3600, implicit_clean=False):
+        """Initialize the MissingPosterList.
+
+        :param items: Provide the initial list.
+        :param cache_timeout: Timeout after which the item expires.
+        :param implicit_clean: If enabled, run the clean() method, to check for expired items. Else you'll have to run
+        this periodically.
+        """
+        list.__init__(self, items or [])
+        self.cache_timeout = cache_timeout
+        self.implicit_clean = implicit_clean
+
+    def append(self, key, value):
+        """Add new items to the list."""
+        if self.implicit_clean:
+            self.clean()
+        super(ExpiringKeyValue, self).append((int(time.time()), key, value))
+
+    def clean(self):
+        """Use the cache_timeout to remove expired items."""
+        new_list = [_ for _ in self if _[0] + self.cache_timeout > int(time.time())]
+        self.__init__(new_list, self.cache_timeout, self.implicit_clean)
+
+    def has(self, key):
+        """Check if the value is in the list.
+
+        We need a smarter method to check if an item is already in the list. This will return a list with items that
+        match the value.
+        :param key: The key to check for.
+        :return: A list of tuples with matches. For example: [<CachedResult()>, <CachedResult()>].
+        """
+        if self.implicit_clean:
+            self.clean()
+        return [
+            ExpiringKeyValue.CachedResult(time=match[0], key=match[1], value=match[2])
+            for match in self if match[1] == key
+        ]
+
+    def get(self, key):
+        """Check if the value is in the list.
+
+        We need a smarter method to check if an item is already in the list. This will return a list with items that
+        match the value.
+        :param value: The value to check for.
+        :return: A single item, if it matches. For example: <CachedResult()>.
+        """
+        if self.implicit_clean:
+            self.clean()
+
+        matches = [_ for _ in self if _[1] == key]
+
+        if not matches:
+            return None
+
+        if len(matches) > 1:
+            raise Exception("Returned multiple items, you shouldn't store keys more than once")
+
+        if len(matches):
+            return ExpiringKeyValue.CachedResult(time=matches[0][0], key=matches[0][1], value=matches[0][2])

--- a/medusa/show/recommendations/__init__.py
+++ b/medusa/show/recommendations/__init__.py
@@ -1,11 +1,12 @@
 # coding=utf-8
 
-from collections import namedtuple
 import time
+from collections import namedtuple
 
 
 class ExpiringList(list):
     """Smart custom list, with a cache expiration."""
+
     CachedResult = namedtuple('CachedResult', 'time value')
 
     def __init__(self, items=None, cache_timeout=3600, implicit_clean=False):
@@ -70,7 +71,8 @@ class ExpiringList(list):
 
 
 class ExpiringKeyValue(list):
-    """Smart custom list, with a cache expiration."""
+    """Smart custom list (that acts like a dictionary, with a cache expiration."""
+
     CachedResult = namedtuple('CachedResult', 'time key value')
 
     def __init__(self, items=None, cache_timeout=3600, implicit_clean=False):
@@ -96,27 +98,27 @@ class ExpiringKeyValue(list):
         new_list = [_ for _ in self if _[0] + self.cache_timeout > int(time.time())]
         self.__init__(new_list, self.cache_timeout, self.implicit_clean)
 
-    def has(self, key):
+    def has(self, value):
         """Check if the value is in the list.
 
         We need a smarter method to check if an item is already in the list. This will return a list with items that
         match the value.
-        :param key: The key to check for.
+        :param value: The key to check for.
         :return: A list of tuples with matches. For example: [<CachedResult()>, <CachedResult()>].
         """
         if self.implicit_clean:
             self.clean()
         return [
             ExpiringKeyValue.CachedResult(time=match[0], key=match[1], value=match[2])
-            for match in self if match[1] == key
+            for match in self if match[2] == value
         ]
 
     def get(self, key):
-        """Check if the value is in the list.
+        """Check if the key is in the list.
 
         We need a smarter method to check if an item is already in the list. This will return a list with items that
         match the value.
-        :param value: The value to check for.
+        :param key: The value to check for.
         :return: A single item, if it matches. For example: <CachedResult()>.
         """
         if self.implicit_clean:
@@ -127,8 +129,7 @@ class ExpiringKeyValue(list):
         if not matches:
             return None
 
-        if len(matches) > 1:
-            raise Exception("Returned multiple items, you shouldn't store keys more than once")
+        assert len(matches) <= 1, "Returned multiple items, you shouldn't store keys more than once"
 
         if len(matches):
             return ExpiringKeyValue.CachedResult(time=matches[0][0], key=matches[0][1], value=matches[0][2])

--- a/medusa/show/recommendations/anidb.py
+++ b/medusa/show/recommendations/anidb.py
@@ -66,7 +66,7 @@ class AnidbPopular(object):  # pylint: disable=too-few-public-methods
         return rec_show
 
     def fetch_popular_shows(self, list_type=REQUEST_HOT):
-        """Get popular show information from IMDB"""
+        """Get popular show information from IMDB."""
         shows = []
         result = []
 


### PR DESCRIPTION
This will make imdb rec load fast after a first load.

Because we recently started to use imdbpy, it needs to load additional information for each show, as opposed to getting it in one request.

This will cache the detailed show info, for a duration of 7 days.

* Refactored the 'old' caching class. And added a caching class which can store a key and value. But does also expire. I could have used existing caching libs for this. But the code I added fit's my purpose perfect. And it's only needed until we properly store this info in db. Maybe dogpile was also an option.
* Cached imdb rec list. So it will be usable after the first load.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
