### PR TITLE
Fix not finding subtitle ID in dopile cache while manual searching & snatching

### DIFF
--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -344,7 +344,7 @@ def save_subtitle(tv_episode, subtitle_id, video_path=None):
     """
     subtitle = cache.get(subtitle_key.format(id=subtitle_id).encode('utf-8'))
     if subtitle == NO_VALUE:
-        logger.error('Unable to found cached subtitle ID: %s', subtitle_id)
+        logger.error('Unable to find cached subtitle ID: %s', subtitle_id)
         return
 
     release_name = tv_episode.release_name

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -344,7 +344,7 @@ def save_subtitle(tv_episode, subtitle_id, video_path=None):
     """
     subtitle = cache.get(subtitle_key.format(id=subtitle_id).encode('utf-8'))
     if subtitle == NO_VALUE:
-        logger.error('Unable to found dogpile cached subtitle ID: %s', subtitle_id)
+        logger.error('Unable to found cached subtitle ID: %s', subtitle_id)
         return
 
     release_name = tv_episode.release_name

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -344,6 +344,7 @@ def save_subtitle(tv_episode, subtitle_id, video_path=None):
     """
     subtitle = cache.get(subtitle_key.format(id=subtitle_id).encode('utf-8'))
     if subtitle == NO_VALUE:
+        logger.error('Unable to found dogpile cached subtitle ID: %s', subtitle_id)
         return
 
     release_name = tv_episode.release_name

--- a/static/js/ajax-episode-subtitles.js
+++ b/static/js/ajax-episode-subtitles.js
@@ -71,7 +71,7 @@ var startAjaxEpisodeSubtitles = function() { // eslint-disable-line no-unused-va
             var url = selectedEpisode.prop('href');
             url = url.replace('searchEpisodeSubtitles', 'manual_search_subtitles');
             // Append the ID param that 'manual_search_subtitles' expect when picking subtitles
-            url += '&picked_id=' + subtitleID;
+            url += '&picked_id=' + encodeURIComponent(subtitleID);
             $.getJSON(url, function(data) {
                 // If user click to close the window before subtitle download finishes, show again the modal
                 if ((subtitlesResultModal.is(':visible')) === false) {


### PR DESCRIPTION
If subtitle id has a "+" (when audio codec is DD+), when requesting the URL with subtile ID,
the "+" becomes " " so it won't find in dogpile cache

Example:
subtitle_id=59644c416024b-fear.the.walking.dead.s03e07.1080p.amzn.web-dl
.dd+5.1.h.264-vlad.srt

in handler picked_id will be:
picked_id=59644c416024b-fear.the.walking.dead.s03e07.1080p.amzn
.web-dl.dd 5.1.h.264-vlad.srt

@ratoaq2 @duramato