### PR TITLE
LegendasTV: Log archive messages outside the method with dogpile decorator

### DIFF
--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -282,7 +282,6 @@ class LegendasTVProvider(Provider):
         :rtype: list of :class:`LegendasTVArchive`
 
         """
-        logger.info('Getting archives for title %d and language %d', title_id, language_code)
         archives = []
         page = 0
         while True:
@@ -401,8 +400,13 @@ class LegendasTVProvider(Provider):
                     logger.debug("Mismatched movie year, discarding title %d (%s)", title_id, sanitized_result)
                     continue
 
+            logger.info('Getting archives for title %d and language %d', title_id, language.legendastv)
+            archives = self.get_archives(title_id, language.legendastv)
+            if not archives:
+                logger.info('No archives found for title %d and language %d', title_id, language.legendastv)
+
             # iterate over title's archives
-            for a in self.get_archives(title_id, language.legendastv):
+            for a in archives:
                 # clean name of path separators and pack flags
                 clean_name = a.name.replace('/', '-')
                 if a.pack and clean_name.startswith('(p)'):


### PR DESCRIPTION
There is no archive logs as everything was cached and no archives found
With this we also show that which title was cached/used

@ratoaq2 If ok I will add this to the upstream PR about improved logs

Before:
```
DEBUG    Thread-16 :: [31685ad] Logged in
INFO     Thread-16 :: [31685ad] Searching episode title u'turn washingtons spies' for season 4
DEBUG    Thread-16 :: [31685ad] Found 0 titles
INFO     Thread-16 :: [31685ad] Searching episode title u"turn washington's spies" for season 4
DEBUG    Thread-16 :: [31685ad] Found 0 titles
DEBUG    Thread-16 :: [31685ad] Listing subtitles with provider 'opensubtitles' and languages set([<Language [pt-BR]>])
```

After:
```
DEBUG    Thread-17 :: [31685ad] Logged in
INFO     Thread-17 :: [31685ad] Searching episode title u'turn washingtons spies' for season 4
DEBUG    Thread-17 :: [31685ad] Found 0 titles
INFO     Thread-17 :: [31685ad] Searching episode title u"turn washington's spies" for season 4
DEBUG    Thread-17 :: [31685ad] Found 0 titles
INFO     Thread-17 :: [31685ad] Getting archives for title 44435 and language 1
INFO     Thread-17 :: [31685ad] No archives found for title 44435 and language 1
DEBUG    Thread-17 :: [31685ad] Listing subtitles with provider 'opensubtitles' and languages set([<Language [pt-BR]>])
```