### PR TITLE
LegendasTV: return only valid archives for given season and episode

### DIFF
--- a/medusa/subtitle_providers/legendastv.py
+++ b/medusa/subtitle_providers/legendastv.py
@@ -273,11 +273,14 @@ class LegendasTVProvider(Provider):
         return titles
 
     @region.cache_on_arguments(expiration_time=timedelta(minutes=15).total_seconds())
-    def get_archives(self, title_id, language_code):
-        """Get the archive list from a given `title_id` and `language_code`.
+    def get_archives(self, title_id, language_code, title_type, season, episode):
+        """Get the archive list from a given `title_id`, `language_code`, `title_type`, `season` and `episode`.
 
         :param int title_id: title id.
         :param int language_code: language code.
+        :param str title_type: episode or movie
+        :param int season: season
+        :param int episode: episode
         :return: the archives.
         :rtype: list of :class:`LegendasTVArchive`
 
@@ -301,6 +304,22 @@ class LegendasTVProvider(Provider):
                                             'pack' in archive_soup.parent['class'],
                                             'destaque' in archive_soup.parent['class'],
                                             self.server_url + archive_soup.a['href'][1:])
+
+                # clean name of path separators and pack flags
+                clean_name = archive.name.replace('/', '-')
+                if archive.pack and clean_name.startswith('(p)'):
+                    clean_name = clean_name[3:]
+
+                # guess from name
+                guess = guessit(clean_name, {'type': title_type})
+
+                # episode
+                if season and episode:
+                    # discard mismatches on episode in non-pack archives
+                    if not archive.pack and 'episode' in guess and guess['episode'] != episode:
+                        logger.debug('Mismatched episode %s, discarding archive: %s',
+                                     guess['episode'], archive.name)
+                        continue
 
                 # extract text containing downloads, rating and timestamp
                 data_text = archive_soup.find('p', class_='data').text
@@ -402,23 +421,7 @@ class LegendasTVProvider(Provider):
                     continue
 
             # iterate over title's archives
-            for a in self.get_archives(title_id, language.legendastv):
-                # clean name of path separators and pack flags
-                clean_name = a.name.replace('/', '-')
-                if a.pack and clean_name.startswith('(p)'):
-                    clean_name = clean_name[3:]
-
-                # guess from name
-                guess = guessit(clean_name, {'type': t['type']})
-
-                # episode
-                if season and episode:
-                    # discard mismatches on episode in non-pack archives
-                    if not a.pack and 'episode' in guess and guess['episode'] != episode:
-                        logger.debug('Mismatched episode %s, discarding archive: %s',
-                                     guess['episode'], a.name)
-                        continue
-
+            for a in self.get_archives(title_id, language.legendastv, t['type'], season, episode):
                 # compute an expiration time based on the archive timestamp
                 expiration_time = (datetime.utcnow().replace(tzinfo=pytz.utc) - a.timestamp).total_seconds()
 


### PR DESCRIPTION
@ratoaq2 this is my idea but as `get_archives` cache expiration is 15minutes (subliminal and medusa) I don't know if is worth as Medusa subtitle search frequency is 1hour, archive cache will be always expired. 

What do you think?

With this PR and the title cache PR, all mismatch logic are not longer in the `def query`