### PR TITLE
Fix Wrong group when "guessing" with file name

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1274,6 +1274,7 @@ class ReleaseGroupPostProcessor(Rule):
 
         # https://github.com/guessit-io/guessit/issues/302
         re.compile(r'\W*\b(obfuscated)\b\W*', flags=re.IGNORECASE),
+        re.compile(r'\W*\b(scrambled)\b\W*', flags=re.IGNORECASE),
         re.compile(r'\W*\b(vtv|sd|rp|norar|re-?up(loads?)?)\b\W*', flags=re.IGNORECASE),
         re.compile(r'\W*\b(hebits)\b\W*', flags=re.IGNORECASE),
 

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4146,3 +4146,27 @@
   language: und
   crc32: EDA6E7F1
   type: episode
+
+? "The.Walking.Dead.S07E13.720p.HDTV.x264-AVS-Scrambled/1e5e2f3464df439b92afea14932a87a4"
+: title: The Walking Dead
+  season: 7
+  episode: 13
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  video_encoder: x264
+  release_group: AVS
+  uuid: 1e5e2f3464df439b92afea14932a87a4
+  type: episode
+
+? "The.Walking.Dead.S07E13.720p.HDTV.x264-AVS-Obfuscated/1e5e2f3464df439b92afea14932a87a4"
+: title: The Walking Dead
+  season: 7
+  episode: 13
+  screen_size: 720p
+  format: HDTV
+  video_codec: h264
+  video_encoder: x264
+  release_group: AVS
+  uuid: 1e5e2f3464df439b92afea14932a87a4
+  type: episode


### PR DESCRIPTION
Don't know if this is the right fix @ratoaq2
Please review
Fix to: https://github.com/pymedusa/Medusa/issues/2386

```
# guessit: 2.1.3.dev0  rebulk: 0.8.3.dev0
? The.Walking.Dead.S07E13.720p.HDTV.x264-AVS-Scrambled/1e5e2f3464df439b92afea14932a87a4.mkv
: title: The Walking Dead
  season: 7
  episode: 13
  screen_size: 720p
  format: HDTV
  video_codec: h264
  video_encoder: x264
  release_group: AVS
  uuid: 1e5e2f3464df439b92afea14932a87a4
  container: mkv
  type: episode
  parsing_time: 0.155999898911
```