### PR TITLE
Add TMDB to externals after filtering. Otherwise info will be lost

### DIFF
--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -588,7 +588,8 @@ class Tmdb(BaseIndexer):
         :param imdb_id: An imdb id (inc. tt).
         :returns: A dict with externals, including the tvmaze id.
         """
-        for external_id in ['tvdb_id', 'imdb_id', 'tvrage_id']:
+        wanted_externals = ['tvdb_id', 'imdb_id', 'tvrage_id']
+        for external_id in wanted_externals:
             if kwargs.get(external_id):
                 result = self.tmdb.Find(kwargs.get(external_id)).info(**{'external_source': external_id})
                 if result.get('tv_results') and result['tv_results'][0]:
@@ -597,7 +598,7 @@ class Tmdb(BaseIndexer):
                     externals = {tmdb_external_id: external_value
                                  for tmdb_external_id, external_value
                                  in externals.items()
-                                 if external_value and tmdb_external_id in ['tvrage_id', 'imdb_id', 'tvdb_id']}
+                                 if external_value and tmdb_external_id in wanted_externals}
                     externals['tmdb_id'] = result['tv_results'][0]['id']
                     return externals
         return {}

--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -594,11 +594,10 @@ class Tmdb(BaseIndexer):
                 if result.get('tv_results') and result['tv_results'][0]:
                     # Get the external id's for the passed shows id.
                     externals = self.tmdb.TV(result['tv_results'][0]['id']).external_ids()
-                    externals['tmdb_id'] = result['tv_results'][0]['id']
-
                     externals = {tmdb_external_id: external_value
                                  for tmdb_external_id, external_value
                                  in externals.items()
                                  if external_value and tmdb_external_id in ['tvrage_id', 'imdb_id', 'tvdb_id']}
+                    externals['tmdb_id'] = result['tv_results'][0]['id']
                     return externals
         return {}

--- a/medusa/indexers/tvmaze/tvmaze_api.py
+++ b/medusa/indexers/tvmaze/tvmaze_api.py
@@ -483,7 +483,7 @@ class TVmaze(BaseIndexer):
         :returns: A dict with externals, including the tvmaze id.
         """
         mapping = {'thetvdb': 'tvdb_id', 'tvrage': 'tvrage_id', 'imdb': 'imdb_id'}
-        for external_id in ['tvdb_id', 'imdb_id', 'tvrage_id']:
+        for external_id in mapping.values():
             if kwargs.get(external_id):
                 try:
                     result = self.tvmaze_api.get_show(**{external_id: kwargs.get(external_id)})


### PR DESCRIPTION
The same way we do in tvmaze:
https://github.com/pymedusa/Medusa/blob/develop/medusa/indexers/tvmaze/tvmaze_api.py#L491-L496 @p0psicles

@duramato this is why your tmdb country doesn't work for non tmdb shows