### PR TITLE
New logging for scheduler, failed_processor and issue_submitter

### DIFF
--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -33,41 +33,41 @@ class FailedProcessor(object):
 
         :return: True
         """
-        self._log(u'Failed download detected: ({nzb}, {dir})', {'nzb': self.nzb_name, 'dir': self.dir_name})
+        self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
 
         releaseName = naming.determine_release_name(self.dir_name, self.nzb_name)
         if not releaseName:
-            self._log(u'Warning: unable to find a valid release name.', logger.WARNING)
+            self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
             raise FailedPostProcessingFailedException()
 
         try:
             parsed = NameParser().parse(releaseName)
         except (InvalidNameException, InvalidShowException):
-            self._log(u'Not enough information to parse release name into a valid show. '
+            self.log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
                       u'Consider adding scene exceptions or improve naming for: {release}'.format
-                      (release=releaseName), logger.WARNING)
+                      (release=releaseName))
             raise FailedPostProcessingFailedException()
 
-        self._log(u'Parsed info: {result}'.format(result=parsed), logger.DEBUG)
+        self.log(u'Parsed info: {result}'.format(result=parsed), logger.DEBUG)
 
         segment = []
         if not parsed.episode_numbers:
             # Get all episode objects from that season
-            self._log(u'Detected as season pack: {release}'.format(release=releaseName), logger.DEBUG)
+            self.log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=releaseName))
             segment.extend(parsed.show.get_all_episodes(parsed.season_number))
         else:
-            self._log(u'Detected as single/multi episode: {release}'.format(release=releaseName), logger.DEBUG)
+            self.log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=releaseName))
             for episode in parsed.episode_numbers:
                 segment.append(parsed.show.get_episode(parsed.season_number, episode))
 
         if segment:
-            self._log(u'Adding this release to failed queue: {release}'.format(release=releaseName), logger.DEBUG)
+            self.log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=releaseName))
             cur_failed_queue_item = FailedQueueItem(parsed.show, segment)
             app.forced_search_queue_scheduler.action.add_item(cur_failed_queue_item)
 
         return True
 
-    def _log(self, message, level=logger.INFO):
+    def log(self, level, message):
         """Log to regular logfile and save for return for PP script log."""
         log.log(level, message)
         self.log += message + "\n"

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -33,41 +33,41 @@ class FailedProcessor(object):
 
         :return: True
         """
-        self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
+        self._log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
 
         releaseName = naming.determine_release_name(self.dir_name, self.nzb_name)
         if not releaseName:
-            self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
+            self._log(logger.WARNING, u'Warning: unable to find a valid release name.')
             raise FailedPostProcessingFailedException()
 
         try:
             parsed = NameParser().parse(releaseName)
         except (InvalidNameException, InvalidShowException):
-            self.log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
+            self._log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
                       u'Consider adding scene exceptions or improve naming for: {release}'.format
                       (release=releaseName))
             raise FailedPostProcessingFailedException()
 
-        self.log(u'Parsed info: {result}'.format(result=parsed), logger.DEBUG)
+        self._log(u'Parsed info: {result}'.format(result=parsed), logger.DEBUG)
 
         segment = []
         if not parsed.episode_numbers:
             # Get all episode objects from that season
-            self.log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=releaseName))
+            self._log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=releaseName))
             segment.extend(parsed.show.get_all_episodes(parsed.season_number))
         else:
-            self.log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=releaseName))
+            self._log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=releaseName))
             for episode in parsed.episode_numbers:
                 segment.append(parsed.show.get_episode(parsed.season_number, episode))
 
         if segment:
-            self.log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=releaseName))
+            self._log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=releaseName))
             cur_failed_queue_item = FailedQueueItem(parsed.show, segment)
             app.forced_search_queue_scheduler.action.add_item(cur_failed_queue_item)
 
         return True
 
-    def log(self, level, message):
+    def _log(self, level, message):
         """Log to regular logfile and save for return for PP script log."""
         log.log(level, message)
         self.log += message + "\n"

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -1,32 +1,24 @@
 # coding=utf-8
-# Author: Tyler Fenby <tylerfenby@gmail.com>
-#
-# This file is part of Medusa.
-#
-# Medusa is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Medusa is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
 
+import logging
+
+from medusa import app, logger
+from medusa.helper.exceptions import FailedPostProcessingFailedException
+from medusa.logger.adapters.style import BraceAdapter
+from medusa.name_parser.parser import InvalidNameException, InvalidShowException, NameParser
+from medusa.search.queue import FailedQueueItem
 from medusa.show import naming
-from . import app, logger
-from .helper.exceptions import FailedPostProcessingFailedException
-from .name_parser.parser import InvalidNameException, InvalidShowException, NameParser
-from .search.queue import FailedQueueItem
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
 
 
 class FailedProcessor(object):
     """Take appropriate action when a download fails to complete."""
 
     def __init__(self, dirName, nzbName):
-        """
+        """Initialize the class.
+
         :param dirName: Full path to the folder of the failed download
         :param nzbName: Full name of the nzb file that failed
         """
@@ -37,11 +29,11 @@ class FailedProcessor(object):
 
     def process(self):
         """
-        Do the actual work
+        Do the actual work.
 
         :return: True
         """
-        self._log(u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
+        self._log(u'Failed download detected: ({nzb}, {dir})', {'nzb': self.nzb_name, 'dir': self.dir_name})
 
         releaseName = naming.determine_release_name(self.dir_name, self.nzb_name)
         if not releaseName:
@@ -77,5 +69,5 @@ class FailedProcessor(object):
 
     def _log(self, message, level=logger.INFO):
         """Log to regular logfile and save for return for PP script log."""
-        logger.log(message, level)
+        log.log(level, message)
         self.log += message + "\n"

--- a/medusa/issue_submitter.py
+++ b/medusa/issue_submitter.py
@@ -3,20 +3,27 @@
 from __future__ import unicode_literals
 
 import difflib
+
 import locale
+
 import logging
+
 import platform
+
 import sys
+
 from datetime import datetime, timedelta
 
 from github import InputFileContent
 from github.GithubException import GithubException, RateLimitExceededException
 
-from . import app, db
-from .classes import ErrorViewer
-from .github_client import authenticate, get_github_repo, token_authenticate
+from medusa import app, db
+from medusa.classes import ErrorViewer
+from medusa.github_client import authenticate, get_github_repo, token_authenticate
+from medusa.logger.adapters.style import BraceAdapter
 
-logger = logging.getLogger(__name__)
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
 
 
 class IssueSubmitter(object):
@@ -151,22 +158,22 @@ class IssueSubmitter(object):
         """
         if app.GIT_AUTH_TYPE == 0:
             if not app.DEBUG or not app.GIT_USERNAME or not app.GIT_PASSWORD:
-                logger.warning(IssueSubmitter.INVALID_CONFIG)
+                log.warning(IssueSubmitter.INVALID_CONFIG)
                 return [(IssueSubmitter.INVALID_CONFIG, None)]
         else:
             if not app.DEBUG or not app.GIT_TOKEN:
-                logger.warning(IssueSubmitter.INVALID_CONFIG)
+                log.warning(IssueSubmitter.INVALID_CONFIG)
                 return [(IssueSubmitter.INVALID_CONFIG, None)]
         if not ErrorViewer.errors:
-            logger.info(IssueSubmitter.NO_ISSUES)
+            log.info(IssueSubmitter.NO_ISSUES)
             return [(IssueSubmitter.NO_ISSUES, None)]
 
         if not app.DEVELOPER and version_checker.need_update():
-            logger.warning(IssueSubmitter.UNSUPPORTED_VERSION)
+            log.warning(IssueSubmitter.UNSUPPORTED_VERSION)
             return [(IssueSubmitter.UNSUPPORTED_VERSION, None)]
 
         if self.running:
-            logger.warning(IssueSubmitter.ALREADY_RUNNING)
+            log.warning(IssueSubmitter.ALREADY_RUNNING)
             return [(IssueSubmitter.ALREADY_RUNNING, None)]
 
         self.running = True
@@ -184,10 +191,10 @@ class IssueSubmitter(object):
 
             return IssueSubmitter.submit_issues(github, github_repo, loglines, similar_issues)
         except RateLimitExceededException:
-            logger.warning(IssueSubmitter.RATE_LIMIT)
+            log.warning(IssueSubmitter.RATE_LIMIT)
             return [(IssueSubmitter.RATE_LIMIT, None)]
         except (GithubException, IOError):
-            logger.warning(IssueSubmitter.GITHUB_EXCEPTION)
+            log.warning(IssueSubmitter.GITHUB_EXCEPTION)
             return [(IssueSubmitter.GITHUB_EXCEPTION, None)]
         finally:
             self.running = False
@@ -216,18 +223,18 @@ class IssueSubmitter(object):
             if similar_issue:
                 if similar_issue.raw_data['locked']:
                     submitter_result = IssueSubmitter.EXISTING_ISSUE_LOCKED.format(number=similar_issue.number)
-                    logger.warning(submitter_result)
+                    log.warning(submitter_result)
                 else:
                     similar_issue.create_comment(message)
                     issue_id = similar_issue.number
                     submitter_result = IssueSubmitter.COMMENTED_EXISTING_ISSUE.format(number=issue_id)
-                    logger.info(submitter_result)
+                    log.info(submitter_result)
                     ErrorViewer.remove(logline)
             else:
                 issue = github_repo.create_issue('{prefix}{title}'.format(prefix=IssueSubmitter.TITLE_PREFIX, title=logline.issue_title), message)
                 issue_id = issue.number
                 submitter_result = IssueSubmitter.ISSUE_CREATED.format(number=issue_id)
-                logger.info(submitter_result)
+                log.info(submitter_result)
                 ErrorViewer.remove(logline)
             results.append((submitter_result, issue_id))
 

--- a/medusa/scheduler.py
+++ b/medusa/scheduler.py
@@ -1,27 +1,18 @@
 # coding=utf-8
-# Author: Nic Wolfe <nic@wolfeden.ca>
-
-#
-# This file is part of Medusa.
-#
-# Medusa is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Medusa is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Medusa. If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+
+import logging
+
 import threading
+
 import time
 
-from . import exception_handler, logger
+from medusa import exception_handler
+from medusa.logger.adapters.style import BraceAdapter
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
 
 
 class Scheduler(threading.Thread):
@@ -48,7 +39,8 @@ class Scheduler(threading.Thread):
 
     def timeLeft(self):
         """
-        Check how long we have until we run again
+        Check how long we have until we run again.
+
         :return: timedelta
         """
         if self.isAlive():
@@ -72,9 +64,7 @@ class Scheduler(threading.Thread):
         return False
 
     def run(self):
-        """
-        Runs the thread
-        """
+        """Run the thread."""
         try:
             while not self.stop.is_set():
                 if self.enable:
@@ -99,7 +89,7 @@ class Scheduler(threading.Thread):
                     if should_run:
                         self.lastRun = current_time
                         if not self.silent:
-                            logger.log(u"Starting new thread: " + self.name, logger.DEBUG)
+                            log.debug(u'Starting new thread: {name}', {'name': self.name})
                         self.action.run(self.force)
 
                     if self.force:


### PR DESCRIPTION
small files
I have enough of log changes lol.
A regex replace would be better

I use this but it not always work, specially when logger.INFO is missing:
```regex
(?:\.format)(?:\s)*(?:\()(?:(.*?)(?:=)(.*?))(?:(?:,\s*)(.*?)(?:=)(.*))?(?:\)(?:,\s*)logger\.(?:INFO|DEBUG|WARNING)\))
```
replace with:
`, {'$1': $2, '$3': $4, '$5': $6})`