### PR TITLE
Adds urllib3.util.retry to MedusaSession

### DIFF
--- a/medusa/session/retry.py
+++ b/medusa/session/retry.py
@@ -1,0 +1,46 @@
+"""Session class retry method."""
+
+import logging
+
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+log = logging.getLogger(__name__)
+log.addHandler(logging.NullHandler())
+
+
+def requests_retry_session(session, retry_session):
+    """Retry session.
+
+    :param retry_session: dict expecting following params: retries, backoff_factor, status
+        retries: number of retries to allow
+        backoff_factor: to apply between attempts after the second try
+        status: a set of HTTP status codes that we should force a retry on.
+
+    Docs: http://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry
+    By default, the retry only fires for these conditions:
+    - Could not get a connection from the pool.
+    - TimeoutError
+    - HTTPException raised (from http.client in Python 3 else httplib)
+    - SocketError
+    - ProtocolError
+
+    Most errors are resolved immediately by a second try without a delay),
+    urllib3 will sleep for {backoff factor} * (2 ^ ({number of total retries} - 1)) seconds
+    https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry
+
+    """
+    session = session or requests.Session()
+    retries = retry_session.get('retries', 3)
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=retry_session.get('backoff_factor', 2),
+        status_forcelist=retry_session.get('status', (500, 502, 503, 504, 509)),
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session

--- a/tests/test_retry_session.py
+++ b/tests/test_retry_session.py
@@ -1,0 +1,21 @@
+# coding=utf-8
+
+"""Test if a retry session works."""
+
+from medusa.session.core import MedusaSession
+
+import pytest
+from requests.exceptions import RetryError
+from six import text_type
+
+
+session = MedusaSession(retry_session={'retries': 1, 'status': (404,)})
+
+url = 'https://cdn.pymedusa.com/retry.txt'
+
+try:
+    response = session.get(url)
+except RetryError as error:
+    assert text_type(error.message.reason) == 'too many 404 error responses'
+else:
+    pytest.fail()


### PR DESCRIPTION
@p0psicles as we talked

TODO:

- [ ] Should be enabled by default ?
- [ ] Enable retry without passing any override param
- [x] ~Add to Transmission to retry on 409 Conflict. Fix https://gist.github.com/duramato/8e17661da07d76788aa49c94d484e421#file-application-log-L8 @duramato~