### PR TITLE
Improved the overall UI, by overflowing the tables with a scrollbar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2555,7 +2555,7 @@ a.whitelink {
 }
 
 /* BacklogOverview */
-div#status-summary {
+#status-summary {
     padding-top: 10px;
     padding-bottom: 2px;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4289,7 +4289,7 @@ CSS helper classes
 /* =======================================================================
  Scroll to top
 ========================================================================== */
-.scroll-top-wrapper {
+.scroll-wrapper {
     position: fixed;
     opacity: 0;
     visibility: hidden;
@@ -4332,3 +4332,37 @@ CSS helper classes
     display: block;
 }
 */
+
+/* =======================================================================
+ overflow for horizontal scrolling, without breaking ui.
+========================================================================== */
+
+.full-screen-scroll {
+    clear: none;
+}
+
+.scroll-wrap {
+    overflow-x: auto;
+}
+
+div#imageContainer {
+    position: fixed;
+    bottom: 50px;
+    right: 100px;
+}
+
+.scroll-wrapper.show {
+    visibility: visible;
+    cursor: pointer;
+    opacity: 1;
+}
+
+.scroll-wrapper.left {
+    position: fixed;
+    right: 150px;
+}
+
+.scroll-wrapper.right {
+    position: fixed;
+    right: 90px;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1788,7 +1788,6 @@ schedule.mako
     padding: 2px 5px;
     font-size: 13px;
     font-weight: bold;
-    border-radius: 5px;
 }
 
 .listing-default {
@@ -2553,6 +2552,12 @@ td.tableright {
 
 a.whitelink {
     color: rgb(255, 255, 255);
+}
+
+/* BacklogOverview */
+div#status-summary {
+    padding-top: 10px;
+    padding-bottom: 2px;
 }
 
 /* =======================================================================
@@ -4334,22 +4339,9 @@ CSS helper classes
 */
 
 /* =======================================================================
- overflow for horizontal scrolling, without breaking ui.
+ overflow buttons for scrolling left and right.
+ For horizontal scrolling, without breaking the ui.
 ========================================================================== */
-
-.full-screen-scroll {
-    clear: none;
-}
-
-.scroll-wrap {
-    overflow-x: auto;
-}
-
-div#imageContainer {
-    position: fixed;
-    bottom: 50px;
-    right: 100px;
-}
 
 .scroll-wrapper.show {
     visibility: visible;

--- a/static/js/common/init.js
+++ b/static/js/common/init.js
@@ -24,20 +24,22 @@ MEDUSA.common.init = function() {
         return offset;
     }
 
-    let initHorizontalScroll = function() {
-        let scrollDiv = $('div.horizontal-scroll');
-        if (!scrollDiv) {
+    /**
+     * Make an attempt to detect if there are currently scroll bars visible for divs with the horizontal-scroll class.
+     *
+     * If scroll bars are visible the fixed left and right buttons become visible on that page.
+     */
+    const initHorizontalScroll = function() {
+        const scrollDiv = $('div.horizontal-scroll').get();
+        if (scrollDiv.length === 0) {
             return;
         }
 
-        let scrollbarVisible = false;
-        $.each(scrollDiv, function(index, el) {
-            if (el.scrollWidth > el.clientWidth) {
-                scrollbarVisible = true;
-            }
-        });
+        let scrollbarVisible = scrollDiv.map(function(el) {
+            return (el.scrollWidth > el.clientWidth);
+        }).indexOf(true);
 
-        if (scrollbarVisible) {
+        if (scrollbarVisible >= 0) {
             $('.scroll-wrapper.left').addClass('show');
             $('.scroll-wrapper.right').addClass('show');
         } else {
@@ -58,14 +60,14 @@ MEDUSA.common.init = function() {
         $('html, body').animate({scrollTop: $(dest).offset().top}, 500, 'linear');
     }
 
-    $('#scroll-left').click(function(e) {
+    $('#scroll-left').on('click', function(e) {
         e.preventDefault();
         $('div.horizontal-scroll').animate({
             scrollLeft: '-=153'
         }, 1000, 'easeOutQuad');
     });
 
-    $('#scroll-right').click(function(e) {
+    $('#scroll-right').on('click', function(e) {
         e.preventDefault();
         $('div.horizontal-scroll').animate({
             scrollLeft: '+=153'

--- a/static/js/common/init.js
+++ b/static/js/common/init.js
@@ -26,7 +26,7 @@ MEDUSA.common.init = function() {
     }
 
     let initHorizontalScroll = function() {
-        let scrollDiv = $('div.scroll-wrap');
+        let scrollDiv = $('div.horizontal-scroll');
         if (!scrollDiv) {
             return
         }
@@ -61,14 +61,14 @@ MEDUSA.common.init = function() {
 
     $('#scroll-left').click(function (e) {
         e.preventDefault();
-        $('.scroll-wrap').animate({
+        $('div.horizontal-scroll').animate({
             scrollLeft: '-=153'
         }, 1000, 'easeOutQuad');
     });
 
     $('#scroll-right').click(function (e) {
         e.preventDefault();
-        $('.scroll-wrap').animate({
+        $('div.horizontal-scroll').animate({
             scrollLeft: '+=153'
         }, 1000, 'easeOutQuad');
     });

--- a/static/js/common/init.js
+++ b/static/js/common/init.js
@@ -50,7 +50,7 @@ MEDUSA.common.init = function() {
 
     initHorizontalScroll();
 
-    $(window).resize(function() {
+    $(window).on('resize', function() {
         $('.backstretch').css('top', backstretchOffset());
         initHorizontalScroll();
     });

--- a/static/js/common/init.js
+++ b/static/js/common/init.js
@@ -1,6 +1,7 @@
 MEDUSA.common.init = function() {
     // Import underscore.string using it's mixin export.
     _.mixin(s.exports());
+    let self = this;
 
     // Background Fanart Functions
     if (MEDUSA.config.fanartBackground) {
@@ -24,8 +25,33 @@ MEDUSA.common.init = function() {
         return offset;
     }
 
+    let initHorizontalScroll = function() {
+        let scrollDiv = $('div.scroll-wrap');
+        if (!scrollDiv) {
+            return
+        }
+
+        let scrollbarVisible = false;
+        $.each(scrollDiv, function(index, el) {
+            if (el.scrollWidth > el.clientWidth) {
+                scrollbarVisible = true;
+            }
+        });
+
+        if (scrollbarVisible) {
+            $('.scroll-wrapper.left').addClass('show');
+            $('.scroll-wrapper.right').addClass('show');
+        } else {
+            $('.scroll-wrapper.left').removeClass('show');
+            $('.scroll-wrapper.right').removeClass('show');
+        }
+    };
+
+    initHorizontalScroll();
+
     $(window).resize(function() {
         $('.backstretch').css('top', backstretchOffset());
+        initHorizontalScroll();
     });
 
     // Scroll Functions
@@ -33,15 +59,29 @@ MEDUSA.common.init = function() {
         $('html, body').animate({scrollTop: $(dest).offset().top}, 500, 'linear');
     }
 
+    $('#scroll-left').click(function (e) {
+        e.preventDefault();
+        $('.scroll-wrap').animate({
+            scrollLeft: '-=153'
+        }, 1000, 'easeOutQuad');
+    });
+
+    $('#scroll-right').click(function (e) {
+        e.preventDefault();
+        $('.scroll-wrap').animate({
+            scrollLeft: '+=153'
+        }, 1000, 'easeOutQuad');
+    });
+
     $(document).on('scroll', function() {
         if ($(window).scrollTop() > 100) {
-            $('.scroll-top-wrapper').addClass('show');
+            $('.scroll-wrapper.top').addClass('show');
         } else {
-            $('.scroll-top-wrapper').removeClass('show');
+            $('.scroll-wrapper.top').removeClass('show');
         }
     });
 
-    $('.scroll-top-wrapper').on('click', function() {
+    $('.scroll-wrapper.top').on('click', function() {
         scrollTo($('body'));
     });
 

--- a/static/js/common/init.js
+++ b/static/js/common/init.js
@@ -1,7 +1,6 @@
 MEDUSA.common.init = function() {
     // Import underscore.string using it's mixin export.
     _.mixin(s.exports());
-    let self = this;
 
     // Background Fanart Functions
     if (MEDUSA.config.fanartBackground) {
@@ -28,7 +27,7 @@ MEDUSA.common.init = function() {
     let initHorizontalScroll = function() {
         let scrollDiv = $('div.horizontal-scroll');
         if (!scrollDiv) {
-            return
+            return;
         }
 
         let scrollbarVisible = false;
@@ -59,14 +58,14 @@ MEDUSA.common.init = function() {
         $('html, body').animate({scrollTop: $(dest).offset().top}, 500, 'linear');
     }
 
-    $('#scroll-left').click(function (e) {
+    $('#scroll-left').click(function(e) {
         e.preventDefault();
         $('div.horizontal-scroll').animate({
             scrollLeft: '-=153'
         }, 1000, 'easeOutQuad');
     });
 
-    $('#scroll-right').click(function (e) {
+    $('#scroll-right').click(function(e) {
         e.preventDefault();
         $('div.horizontal-scroll').animate({
             scrollLeft: '+=153'

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -29,289 +29,285 @@
 <%include file="/partials/showheader.mako"/>
 
 <div class="row">
-    <div class="col-md-12">
-    <div class="full-screen-scroll">
-        <div class="scroll-wrap">
-            <table id="${'animeTable' if show.is_anime else 'showTable'}" class="${'displayShowTableFanArt tablesorterFanArt' if app.FANART_BACKGROUND else 'displayShowTable'} display_show" cellspacing="0" border="0" cellpadding="0">
-                <% cur_season = -1 %>
-                <% odd = 0 %>
+    <div class="col-md-12 horizontal-scroll">
+        <table id="${'animeTable' if show.is_anime else 'showTable'}" class="${'displayShowTableFanArt tablesorterFanArt' if app.FANART_BACKGROUND else 'displayShowTable'} display_show" cellspacing="0" border="0" cellpadding="0">
+            <% cur_season = -1 %>
+            <% odd = 0 %>
+            <% epCount = 0 %>
+            <% epSize = 0 %>
+            <% epList = [] %>
+
+            % for epResult in sql_results:
+                <%
+                epStr = str(epResult["season"]) + "x" + str(epResult["episode"])
+                if not epStr in ep_cats:
+                    continue
+                if not app.DISPLAY_SHOW_SPECIALS and int(epResult["season"]) == 0:
+                    continue
+                scene = False
+                scene_anime = False
+                if not show.air_by_date and not show.is_sports and not show.is_anime and show.is_scene:
+                    scene = True
+                elif not show.air_by_date and not show.is_sports and show.is_anime and show.is_scene:
+                    scene_anime = True
+                (dfltSeas, dfltEpis, dfltAbsolute) = (0, 0, 0)
+                if (epResult["season"], epResult["episode"]) in xem_numbering:
+                    (dfltSeas, dfltEpis) = xem_numbering[(epResult["season"], epResult["episode"])]
+                if epResult["absolute_number"] in xem_absolute_numbering:
+                    dfltAbsolute = xem_absolute_numbering[epResult["absolute_number"]]
+                if epResult["absolute_number"] in scene_absolute_numbering:
+                    scAbsolute = scene_absolute_numbering[epResult["absolute_number"]]
+                    dfltAbsNumbering = False
+                else:
+                    scAbsolute = dfltAbsolute
+                    dfltAbsNumbering = True
+                if (epResult["season"], epResult["episode"]) in scene_numbering:
+                    (scSeas, scEpis) = scene_numbering[(epResult["season"], epResult["episode"])]
+                    dfltEpNumbering = False
+                else:
+                    (scSeas, scEpis) = (dfltSeas, dfltEpis)
+                    dfltEpNumbering = True
+                epLoc = epResult["location"]
+                if epLoc and show._location and epLoc.lower().startswith(show._location.lower()):
+                    epLoc = epLoc[len(show._location)+1:]
+                %>
+                % if int(epResult["season"]) != cur_season:
+                    % if cur_season == -1:
+            <thead>
+                <tr class="seasoncols" style="display:none;">
+                        <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck"/></th>
+                        <th data-sorter="false" class="col-metadata">NFO</th>
+                        <th data-sorter="false" class="col-metadata">TBN</th>
+                        <th data-sorter="false" class="col-ep">Episode</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(show.is_anime)]}>Absolute</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
+                        <th data-sorter="false" class="col-name">Name</th>
+                        <th data-sorter="false" class="col-name columnSelector-false">File Name</th>
+                        <th data-sorter="false" class="col-ep columnSelector-false">Size</th>
+                        <th data-sorter="false" class="col-airdate">Airdate</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.DOWNLOAD_URL)]}>Download</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.USE_SUBTITLES)]}>Subtitles</th>
+                        <th data-sorter="false" class="col-status">Status</th>
+                        <th data-sorter="false" class="col-search">Search</th>
+                </tr>
+            </thead>
+            <tbody class="tablesorter-no-sort">
+                <tr>
+                    <th class="row-seasonheader ${'displayShowTable' if app.FANART_BACKGROUND else 'displayShowTableFanArt'}" colspan="15" style="vertical-align: bottom; width: auto;">
+                        <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}
+                        % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
+                        <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                        % endif
+                        </h3>
+                        <div class="season-scene-exception" data-season=${str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}></div>
+                        <div class="pull-right"> <!-- column select and hide/show episodes -->
+                            % if not app.DISPLAY_ALL_SEASONS:
+                                <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Hide Episodes</button>
+                            % endif
+                            <button id="popover" type="button" class="btn pull-right">Select Columns <b class="caret"></b></button>
+                        </div> <!-- end column select and hide/show episodes -->
+                    </th>
+                </tr>
+            </tbody>
+            <tbody class="tablesorter-no-sort">
+                <tr id="season-${epResult["season"]}-cols" class="seasoncols">
+                    <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+                    <th class="col-metadata">NFO</th>
+                    <th class="col-metadata">TBN</th>
+                    <th class="col-ep">Episode</th>
+                    <th class="col-ep">Absolute</th>
+                    <th class="col-ep">Scene</th>
+                    <th class="col-ep">Scene Absolute</th>
+                    <th class="col-name hidden-xs">Name</th>
+                    <th class="col-name hidden-xs">File Name</th>
+                    <th class="col-ep">Size</th>
+                    <th class="col-airdate">Airdate</th>
+                    <th class="col-ep">Download</th>
+                    <th class="col-ep">Subtitles</th>
+                    <th class="col-status">Status</th>
+                    <th class="col-search">Search</th>
+                </tr>
+                    % else:
+                <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
+                    <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
+                </tr>
                 <% epCount = 0 %>
                 <% epSize = 0 %>
                 <% epList = [] %>
-
-                % for epResult in sql_results:
-                    <%
-                    epStr = str(epResult["season"]) + "x" + str(epResult["episode"])
-                    if not epStr in ep_cats:
-                        continue
-                    if not app.DISPLAY_SHOW_SPECIALS and int(epResult["season"]) == 0:
-                        continue
-                    scene = False
-                    scene_anime = False
-                    if not show.air_by_date and not show.is_sports and not show.is_anime and show.is_scene:
-                        scene = True
-                    elif not show.air_by_date and not show.is_sports and show.is_anime and show.is_scene:
-                        scene_anime = True
-                    (dfltSeas, dfltEpis, dfltAbsolute) = (0, 0, 0)
-                    if (epResult["season"], epResult["episode"]) in xem_numbering:
-                        (dfltSeas, dfltEpis) = xem_numbering[(epResult["season"], epResult["episode"])]
-                    if epResult["absolute_number"] in xem_absolute_numbering:
-                        dfltAbsolute = xem_absolute_numbering[epResult["absolute_number"]]
-                    if epResult["absolute_number"] in scene_absolute_numbering:
-                        scAbsolute = scene_absolute_numbering[epResult["absolute_number"]]
-                        dfltAbsNumbering = False
-                    else:
-                        scAbsolute = dfltAbsolute
-                        dfltAbsNumbering = True
-                    if (epResult["season"], epResult["episode"]) in scene_numbering:
-                        (scSeas, scEpis) = scene_numbering[(epResult["season"], epResult["episode"])]
-                        dfltEpNumbering = False
-                    else:
-                        (scSeas, scEpis) = (dfltSeas, dfltEpis)
-                        dfltEpNumbering = True
-                    epLoc = epResult["location"]
-                    if epLoc and show._location and epLoc.lower().startswith(show._location.lower()):
-                        epLoc = epLoc[len(show._location)+1:]
-                    %>
-                    % if int(epResult["season"]) != cur_season:
-                        % if cur_season == -1:
-                <thead>
-                    <tr class="seasoncols" style="display:none;">
-                            <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck"/></th>
-                            <th data-sorter="false" class="col-metadata">NFO</th>
-                            <th data-sorter="false" class="col-metadata">TBN</th>
-                            <th data-sorter="false" class="col-ep">Episode</th>
-                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(show.is_anime)]}>Absolute</th>
-                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
-                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
-                            <th data-sorter="false" class="col-name">Name</th>
-                            <th data-sorter="false" class="col-name columnSelector-false">File Name</th>
-                            <th data-sorter="false" class="col-ep columnSelector-false">Size</th>
-                            <th data-sorter="false" class="col-airdate">Airdate</th>
-                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.DOWNLOAD_URL)]}>Download</th>
-                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.USE_SUBTITLES)]}>Subtitles</th>
-                            <th data-sorter="false" class="col-status">Status</th>
-                            <th data-sorter="false" class="col-search">Search</th>
-                    </tr>
-                </thead>
-                <tbody class="tablesorter-no-sort">
-                    <tr>
-                        <th class="row-seasonheader ${'displayShowTable' if app.FANART_BACKGROUND else 'displayShowTableFanArt'}" colspan="15" style="vertical-align: bottom; width: auto;">
-                            <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}
-                            % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
-                            <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                            % endif
-                            </h3>
-                            <div class="season-scene-exception" data-season=${str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}></div>
-                            <div class="pull-right"> <!-- column select and hide/show episodes -->
-                                % if not app.DISPLAY_ALL_SEASONS:
-                                    <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Hide Episodes</button>
-                                % endif
-                                <button id="popover" type="button" class="btn pull-right">Select Columns <b class="caret"></b></button>
-                            </div> <!-- end column select and hide/show episodes -->
-                        </th>
-                    </tr>
-                </tbody>
-                <tbody class="tablesorter-no-sort">
-                    <tr id="season-${epResult["season"]}-cols" class="seasoncols">
-                        <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
-                        <th class="col-metadata">NFO</th>
-                        <th class="col-metadata">TBN</th>
-                        <th class="col-ep">Episode</th>
-                        <th class="col-ep">Absolute</th>
-                        <th class="col-ep">Scene</th>
-                        <th class="col-ep">Scene Absolute</th>
-                        <th class="col-name hidden-xs">Name</th>
-                        <th class="col-name hidden-xs">File Name</th>
-                        <th class="col-ep">Size</th>
-                        <th class="col-airdate">Airdate</th>
-                        <th class="col-ep">Download</th>
-                        <th class="col-ep">Subtitles</th>
-                        <th class="col-status">Status</th>
-                        <th class="col-search">Search</th>
-                    </tr>
-                        % else:
-                    <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
-                        <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
-                    </tr>
-                    <% epCount = 0 %>
-                    <% epSize = 0 %>
-                    <% epList = [] %>
-                </tbody>
-                <tbody class="tablesorter-no-sort">
-                    <tr>
-                        <th class="row-seasonheader ${'displayShowTableFanArt' if app.FANART_BACKGROUND else 'displayShowTable'}" colspan="15" style="vertical-align: bottom; width: auto;">
-                            <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) else "Specials"}
-                            % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
-                            <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                            % endif
-                            </h3>
-                            <div class="season-scene-exception" data-season=${str(epResult["season"])}></div>
-                            <div class="pull-right"> <!-- hide/show episodes -->
-                                % if not app.DISPLAY_ALL_SEASONS:
-                                    <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Show Episodes</button>
-                                % endif
-                            </div> <!-- end hide/show episodes -->
-                        </th>
-                    </tr>
-                </tbody>
-                <tbody class="tablesorter-no-sort">
-                    <tr id="season-${epResult["season"]}-cols" class="seasoncols ${'' if app.DISPLAY_ALL_SEASONS else 'shadow'}">
-                        <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
-                        <th class="col-metadata">NFO</th>
-                        <th class="col-metadata">TBN</th>
-                        <th class="col-ep">Episode</th>
-                        <th class="col-ep">Absolute</th>
-                        <th class="col-ep">Scene</th>
-                        <th class="col-ep">Scene Absolute</th>
-                        <th class="col-name hidden-xs">Name</th>
-                        <th class="col-name hidden-xs">File Name</th>
-                        <th class="col-ep">Size</th>
-                        <th class="col-airdate">Airdate</th>
-                        <th class="col-ep">Download</th>
-                        <th class="col-ep">Subtitles</th>
-                        <th class="col-status">Status</th>
-                        <th class="col-search">Search</th>
-                    </tr>
+            </tbody>
+            <tbody class="tablesorter-no-sort">
+                <tr>
+                    <th class="row-seasonheader ${'displayShowTableFanArt' if app.FANART_BACKGROUND else 'displayShowTable'}" colspan="15" style="vertical-align: bottom; width: auto;">
+                        <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) else "Specials"}
+                        % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
+                        <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
                         % endif
-                </tbody>
-                    % if not app.DISPLAY_ALL_SEASONS:
-                    <tbody class="toggle collapse${("", " in")[cur_season == -1]}" id="collapseSeason-${epResult['season']}">
-                    % else:
-                    <tbody>
+                        </h3>
+                        <div class="season-scene-exception" data-season=${str(epResult["season"])}></div>
+                        <div class="pull-right"> <!-- hide/show episodes -->
+                            % if not app.DISPLAY_ALL_SEASONS:
+                                <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Show Episodes</button>
+                            % endif
+                        </div> <!-- end hide/show episodes -->
+                    </th>
+                </tr>
+            </tbody>
+            <tbody class="tablesorter-no-sort">
+                <tr id="season-${epResult["season"]}-cols" class="seasoncols ${'' if app.DISPLAY_ALL_SEASONS else 'shadow'}">
+                    <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+                    <th class="col-metadata">NFO</th>
+                    <th class="col-metadata">TBN</th>
+                    <th class="col-ep">Episode</th>
+                    <th class="col-ep">Absolute</th>
+                    <th class="col-ep">Scene</th>
+                    <th class="col-ep">Scene Absolute</th>
+                    <th class="col-name hidden-xs">Name</th>
+                    <th class="col-name hidden-xs">File Name</th>
+                    <th class="col-ep">Size</th>
+                    <th class="col-airdate">Airdate</th>
+                    <th class="col-ep">Download</th>
+                    <th class="col-ep">Subtitles</th>
+                    <th class="col-status">Status</th>
+                    <th class="col-search">Search</th>
+                </tr>
                     % endif
-                    <% cur_season = int(epResult["season"]) %>
-                    % endif
-                    <tr class="${Overview.overviewStrings[ep_cats[epStr]]} season-${cur_season} seasonstyle" id="${'S' + str(epResult["season"]) + 'E' + str(epResult["episode"])}">
-                        <td class="col-checkbox triggerhighlight">
-                            % if int(epResult["status"]) != UNAIRED:
-                                <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}" />
-                            % endif
-                        </td>
-                        <td align="center" class="triggerhighlight"><img src="images/${("nfo-no.gif", "nfo.gif")[epResult["hasnfo"]]}" alt="${("N", "Y")[epResult["hasnfo"]]}" width="23" height="11" /></td>
-                        <td align="center" class="triggerhighlight"><img src="images/${("tbn-no.gif", "tbn.gif")[epResult["hastbn"]]}" alt="${("N", "Y")[epResult["hastbn"]]}" width="23" height="11" /></td>
-                        <td align="center" class="triggerhighlight">
-                        <%
-                            text = str(epResult['episode'])
-                            if epLoc != '' and epLoc is not None:
-                                text = '<span title="' + epLoc + '" class="addQTip">' + text + "</span>"
-                                epCount += 1
-                                if not epLoc in epList:
-                                    epSize += epResult["file_size"]
-                                    epList.append(epLoc)
-                        %>
-                            ${text}
-                        </td>
-                        <td align="center" class="triggerhighlight">${epResult["absolute_number"]}</td>
-                        <td align="center" class="triggerhighlight">
-                            <input type="text" placeholder="${str(dfltSeas) + 'x' + str(dfltEpis)}" size="6" maxlength="8"
-                                class="sceneSeasonXEpisode form-control input-scene" data-for-season="${epResult["season"]}" data-for-episode="${epResult["episode"]}"
-                                id="sceneSeasonXEpisode_${show.indexerid}_${str(epResult["season"])}_${str(epResult["episode"])}"
-                                title="Change this value if scene numbering differs from the indexer episode numbering. Generally used for non-anime shows."
-                                % if dfltEpNumbering:
-                                    value=""
-                                % else:
-                                    value="${str(scSeas)}x${str(scEpis)}"
-                                % endif
-                                    style="padding: 0; text-align: center; max-width: 60px;"/>
-                        </td>
-                        <td align="center" class="triggerhighlight">
-                            <input type="text" placeholder="${str(dfltAbsolute)}" size="6" maxlength="8"
-                                class="sceneAbsolute form-control input-scene" data-for-absolute="${epResult["absolute_number"]}"
-                                id="sceneAbsolute_${show.indexerid}${"_"+str(epResult["absolute_number"])}"
-                                title="Change this value if scene absolute numbering differs from the indexer absolute numbering. Generally used for anime shows."
-                                % if dfltAbsNumbering:
-                                    value=""
-                                % else:
-                                    value="${str(scAbsolute)}"
-                                % endif
-                                    style="padding: 0; text-align: center; max-width: 60px;"/>
-                        </td>
-                        <td class="col-name hidden-xs triggerhighlight">
-                        % if epResult["description"] != "" and epResult["description"] is not None:
-                            <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.indexer_slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
-                        % else:
-                            <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
-                        % endif
-                        ${epResult["name"]}
-                        </td>
-                        <td class="col-name hidden-xs triggerhighlight">${epLoc if Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED] else ''}</td>
-                        <td class="col-ep triggerhighlight">
-                            % if epResult["file_size"] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                                ${pretty_file_size(epResult["file_size"])}
-                            % endif
-                        </td>
-                        <td class="col-airdate triggerhighlight">
-                            % if int(epResult['airdate']) != 1:
-                                ## Lets do this exactly like ComingEpisodes and History
-                                ## Avoid issues with dateutil's _isdst on Windows but still provide air dates
-                                <% airDate = datetime.datetime.fromordinal(epResult['airdate']) %>
-                                % if airDate.year >= 1970 or show.network:
-                                    <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
-                                % endif
-                                <time datetime="${airDate.isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(airDate)}</time>
-                            % else:
-                                Never
-                            % endif
-                        </td>
-                        <td class="triggerhighlight">
-                            % if app.DOWNLOAD_URL and epResult['location'] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                                <%
-                                    filename = epResult['location']
-                                    for rootDir in app.ROOT_DIRS.split('|'):
-                                        if rootDir.startswith('/'):
-                                            filename = filename.replace(rootDir, "")
-                                    filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
-                                %>
-                                <a href="${filename}">Download</a>
-                            % endif
-                        </td>
-                        <td class="col-subtitles triggerhighlight" align="center">
-                        % for flag in (epResult["subtitles"] or '').split(','):
-                            % if flag.strip() and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                                % if flag != 'und':
-                                    <a class=epRedownloadSubtitle href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult['season']}&amp;episode=${epResult['episode']}&amp;lang=${flag}">
-                                        <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${flag}" onError="this.onerror=null;this.src='images/flags/unknown.png';"/>
-                                    </a>
-                                % else:
-                                    <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
-                                % endif
-                            % endif
-                        % endfor
-                        </td>
-                            <% cur_status, cur_quality = Quality.split_composite_status(int(epResult["status"])) %>
-                            % if cur_quality != Quality.NONE:
-                                <td class="col-status triggerhighlight">${statusStrings[cur_status]} ${renderQualityPill(cur_quality)}</td>
-                            % else:
-                                <td class="col-status triggerhighlight">${statusStrings[cur_status]}</td>
-                            % endif
-                        <td class="col-search triggerhighlight">
-                            % if int(epResult["season"]) != 0:
-                                % if (int(epResult["status"]) in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.DOWNLOADED ) and app.USE_FAILED_DOWNLOADS:
-                                    <a class="epRetry" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/retryEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
-                                % else:
-                                    <a class="epSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/searchEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
-                                % endif
-                                <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                            % else:
-                                <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                            % endif
-                            % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"]:
-                                <a class="epSubtitlesSearch" href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
-                            % endif
-                        </td>
-                    </tr>
-                % endfor
-                % if sql_results:
-                    <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
-                        <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
-                    </tr>
+            </tbody>
+                % if not app.DISPLAY_ALL_SEASONS:
+                <tbody class="toggle collapse${("", " in")[cur_season == -1]}" id="collapseSeason-${epResult['season']}">
+                % else:
+                <tbody>
                 % endif
-                </tbody>
-                <tbody class="tablesorter-no-sort"><tr><th class="row-seasonheader" colspan=15></th></tr></tbody>
-            </table>
-            </div> <!-- end scroll-wrap -->
-        </div> <!-- end full-screen-scroll -->
+                <% cur_season = int(epResult["season"]) %>
+                % endif
+                <tr class="${Overview.overviewStrings[ep_cats[epStr]]} season-${cur_season} seasonstyle" id="${'S' + str(epResult["season"]) + 'E' + str(epResult["episode"])}">
+                    <td class="col-checkbox triggerhighlight">
+                        % if int(epResult["status"]) != UNAIRED:
+                            <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}" />
+                        % endif
+                    </td>
+                    <td align="center" class="triggerhighlight"><img src="images/${("nfo-no.gif", "nfo.gif")[epResult["hasnfo"]]}" alt="${("N", "Y")[epResult["hasnfo"]]}" width="23" height="11" /></td>
+                    <td align="center" class="triggerhighlight"><img src="images/${("tbn-no.gif", "tbn.gif")[epResult["hastbn"]]}" alt="${("N", "Y")[epResult["hastbn"]]}" width="23" height="11" /></td>
+                    <td align="center" class="triggerhighlight">
+                    <%
+                        text = str(epResult['episode'])
+                        if epLoc != '' and epLoc is not None:
+                            text = '<span title="' + epLoc + '" class="addQTip">' + text + "</span>"
+                            epCount += 1
+                            if not epLoc in epList:
+                                epSize += epResult["file_size"]
+                                epList.append(epLoc)
+                    %>
+                        ${text}
+                    </td>
+                    <td align="center" class="triggerhighlight">${epResult["absolute_number"]}</td>
+                    <td align="center" class="triggerhighlight">
+                        <input type="text" placeholder="${str(dfltSeas) + 'x' + str(dfltEpis)}" size="6" maxlength="8"
+                            class="sceneSeasonXEpisode form-control input-scene" data-for-season="${epResult["season"]}" data-for-episode="${epResult["episode"]}"
+                            id="sceneSeasonXEpisode_${show.indexerid}_${str(epResult["season"])}_${str(epResult["episode"])}"
+                            title="Change this value if scene numbering differs from the indexer episode numbering. Generally used for non-anime shows."
+                            % if dfltEpNumbering:
+                                value=""
+                            % else:
+                                value="${str(scSeas)}x${str(scEpis)}"
+                            % endif
+                                style="padding: 0; text-align: center; max-width: 60px;"/>
+                    </td>
+                    <td align="center" class="triggerhighlight">
+                        <input type="text" placeholder="${str(dfltAbsolute)}" size="6" maxlength="8"
+                            class="sceneAbsolute form-control input-scene" data-for-absolute="${epResult["absolute_number"]}"
+                            id="sceneAbsolute_${show.indexerid}${"_"+str(epResult["absolute_number"])}"
+                            title="Change this value if scene absolute numbering differs from the indexer absolute numbering. Generally used for anime shows."
+                            % if dfltAbsNumbering:
+                                value=""
+                            % else:
+                                value="${str(scAbsolute)}"
+                            % endif
+                                style="padding: 0; text-align: center; max-width: 60px;"/>
+                    </td>
+                    <td class="col-name hidden-xs triggerhighlight">
+                    % if epResult["description"] != "" and epResult["description"] is not None:
+                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.indexer_slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
+                    % else:
+                        <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
+                    % endif
+                    ${epResult["name"]}
+                    </td>
+                    <td class="col-name hidden-xs triggerhighlight">${epLoc if Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED] else ''}</td>
+                    <td class="col-ep triggerhighlight">
+                        % if epResult["file_size"] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                            ${pretty_file_size(epResult["file_size"])}
+                        % endif
+                    </td>
+                    <td class="col-airdate triggerhighlight">
+                        % if int(epResult['airdate']) != 1:
+                            ## Lets do this exactly like ComingEpisodes and History
+                            ## Avoid issues with dateutil's _isdst on Windows but still provide air dates
+                            <% airDate = datetime.datetime.fromordinal(epResult['airdate']) %>
+                            % if airDate.year >= 1970 or show.network:
+                                <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
+                            % endif
+                            <time datetime="${airDate.isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(airDate)}</time>
+                        % else:
+                            Never
+                        % endif
+                    </td>
+                    <td class="triggerhighlight">
+                        % if app.DOWNLOAD_URL and epResult['location'] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                            <%
+                                filename = epResult['location']
+                                for rootDir in app.ROOT_DIRS.split('|'):
+                                    if rootDir.startswith('/'):
+                                        filename = filename.replace(rootDir, "")
+                                filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
+                            %>
+                            <a href="${filename}">Download</a>
+                        % endif
+                    </td>
+                    <td class="col-subtitles triggerhighlight" align="center">
+                    % for flag in (epResult["subtitles"] or '').split(','):
+                        % if flag.strip() and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                            % if flag != 'und':
+                                <a class=epRedownloadSubtitle href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult['season']}&amp;episode=${epResult['episode']}&amp;lang=${flag}">
+                                    <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${flag}" onError="this.onerror=null;this.src='images/flags/unknown.png';"/>
+                                </a>
+                            % else:
+                                <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                            % endif
+                        % endif
+                    % endfor
+                    </td>
+                        <% cur_status, cur_quality = Quality.split_composite_status(int(epResult["status"])) %>
+                        % if cur_quality != Quality.NONE:
+                            <td class="col-status triggerhighlight">${statusStrings[cur_status]} ${renderQualityPill(cur_quality)}</td>
+                        % else:
+                            <td class="col-status triggerhighlight">${statusStrings[cur_status]}</td>
+                        % endif
+                    <td class="col-search triggerhighlight">
+                        % if int(epResult["season"]) != 0:
+                            % if (int(epResult["status"]) in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.DOWNLOADED ) and app.USE_FAILED_DOWNLOADS:
+                                <a class="epRetry" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/retryEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
+                            % else:
+                                <a class="epSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/searchEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
+                            % endif
+                            <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                        % else:
+                            <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                        % endif
+                        % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"]:
+                            <a class="epSubtitlesSearch" href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+                        % endif
+                    </td>
+                </tr>
+            % endfor
+            % if sql_results:
+                <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
+                    <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
+                </tr>
+            % endif
+            </tbody>
+            <tbody class="tablesorter-no-sort"><tr><th class="row-seasonheader" colspan=15></th></tr></tbody>
+        </table>
     </div> <!-- end of col -->
 </div> <!-- row -->
 

--- a/views/displayShow.mako
+++ b/views/displayShow.mako
@@ -30,362 +30,365 @@
 
 <div class="row">
     <div class="col-md-12">
-        <table id="${'animeTable' if show.is_anime else 'showTable'}" class="${'displayShowTableFanArt tablesorterFanArt' if app.FANART_BACKGROUND else 'displayShowTable'} display_show" cellspacing="0" border="0" cellpadding="0">
-            <% cur_season = -1 %>
-            <% odd = 0 %>
-            <% epCount = 0 %>
-            <% epSize = 0 %>
-            <% epList = [] %>
-
-            % for epResult in sql_results:
-                <%
-                epStr = str(epResult["season"]) + "x" + str(epResult["episode"])
-                if not epStr in ep_cats:
-                    continue
-                if not app.DISPLAY_SHOW_SPECIALS and int(epResult["season"]) == 0:
-                    continue
-                scene = False
-                scene_anime = False
-                if not show.air_by_date and not show.is_sports and not show.is_anime and show.is_scene:
-                    scene = True
-                elif not show.air_by_date and not show.is_sports and show.is_anime and show.is_scene:
-                    scene_anime = True
-                (dfltSeas, dfltEpis, dfltAbsolute) = (0, 0, 0)
-                if (epResult["season"], epResult["episode"]) in xem_numbering:
-                    (dfltSeas, dfltEpis) = xem_numbering[(epResult["season"], epResult["episode"])]
-                if epResult["absolute_number"] in xem_absolute_numbering:
-                    dfltAbsolute = xem_absolute_numbering[epResult["absolute_number"]]
-                if epResult["absolute_number"] in scene_absolute_numbering:
-                    scAbsolute = scene_absolute_numbering[epResult["absolute_number"]]
-                    dfltAbsNumbering = False
-                else:
-                    scAbsolute = dfltAbsolute
-                    dfltAbsNumbering = True
-                if (epResult["season"], epResult["episode"]) in scene_numbering:
-                    (scSeas, scEpis) = scene_numbering[(epResult["season"], epResult["episode"])]
-                    dfltEpNumbering = False
-                else:
-                    (scSeas, scEpis) = (dfltSeas, dfltEpis)
-                    dfltEpNumbering = True
-                epLoc = epResult["location"]
-                if epLoc and show._location and epLoc.lower().startswith(show._location.lower()):
-                    epLoc = epLoc[len(show._location)+1:]
-                %>
-                % if int(epResult["season"]) != cur_season:
-                    % if cur_season == -1:
-            <thead>
-                <tr class="seasoncols" style="display:none;">
-                        <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck"/></th>
-                        <th data-sorter="false" class="col-metadata">NFO</th>
-                        <th data-sorter="false" class="col-metadata">TBN</th>
-                        <th data-sorter="false" class="col-ep">Episode</th>
-                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(show.is_anime)]}>Absolute</th>
-                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
-                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
-                        <th data-sorter="false" class="col-name">Name</th>
-                        <th data-sorter="false" class="col-name columnSelector-false">File Name</th>
-                        <th data-sorter="false" class="col-ep columnSelector-false">Size</th>
-                        <th data-sorter="false" class="col-airdate">Airdate</th>
-                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.DOWNLOAD_URL)]}>Download</th>
-                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.USE_SUBTITLES)]}>Subtitles</th>
-                        <th data-sorter="false" class="col-status">Status</th>
-                        <th data-sorter="false" class="col-search">Search</th>
-                </tr>
-            </thead>
-            <tbody class="tablesorter-no-sort">
-                <tr>
-                    <th class="row-seasonheader ${'displayShowTable' if app.FANART_BACKGROUND else 'displayShowTableFanArt'}" colspan="15" style="vertical-align: bottom; width: auto;">
-                        <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}
-                        % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
-                        <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                        % endif
-                        </h3>
-                        <div class="season-scene-exception" data-season=${str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}></div>
-                        <div class="pull-right"> <!-- column select and hide/show episodes -->
-                            % if not app.DISPLAY_ALL_SEASONS:
-                                <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Hide Episodes</button>
-                            % endif
-                            <button id="popover" type="button" class="btn pull-right">Select Columns <b class="caret"></b></button>
-                        </div> <!-- end column select and hide/show episodes -->
-                    </th>
-                </tr>
-            </tbody>
-            <tbody class="tablesorter-no-sort">
-                <tr id="season-${epResult["season"]}-cols" class="seasoncols">
-                    <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
-                    <th class="col-metadata">NFO</th>
-                    <th class="col-metadata">TBN</th>
-                    <th class="col-ep">Episode</th>
-                    <th class="col-ep">Absolute</th>
-                    <th class="col-ep">Scene</th>
-                    <th class="col-ep">Scene Absolute</th>
-                    <th class="col-name hidden-xs">Name</th>
-                    <th class="col-name hidden-xs">File Name</th>
-                    <th class="col-ep">Size</th>
-                    <th class="col-airdate">Airdate</th>
-                    <th class="col-ep">Download</th>
-                    <th class="col-ep">Subtitles</th>
-                    <th class="col-status">Status</th>
-                    <th class="col-search">Search</th>
-                </tr>
-                    % else:
-                <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
-                    <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
-                </tr>
+    <div class="full-screen-scroll">
+        <div class="scroll-wrap">
+            <table id="${'animeTable' if show.is_anime else 'showTable'}" class="${'displayShowTableFanArt tablesorterFanArt' if app.FANART_BACKGROUND else 'displayShowTable'} display_show" cellspacing="0" border="0" cellpadding="0">
+                <% cur_season = -1 %>
+                <% odd = 0 %>
                 <% epCount = 0 %>
                 <% epSize = 0 %>
                 <% epList = [] %>
-            </tbody>
-            <tbody class="tablesorter-no-sort">
-                <tr>
-                    <th class="row-seasonheader ${'displayShowTableFanArt' if app.FANART_BACKGROUND else 'displayShowTable'}" colspan="15" style="vertical-align: bottom; width: auto;">
-                        <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) else "Specials"}
-                        % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
-                        <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                        % endif
-                        </h3>
-                        <div class="season-scene-exception" data-season=${str(epResult["season"])}></div>
-                        <div class="pull-right"> <!-- hide/show episodes -->
-                            % if not app.DISPLAY_ALL_SEASONS:
-                                <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Show Episodes</button>
-                            % endif
-                        </div> <!-- end hide/show episodes -->
-                    </th>
-                </tr>
-            </tbody>
-            <tbody class="tablesorter-no-sort">
-                <tr id="season-${epResult["season"]}-cols" class="seasoncols ${'' if app.DISPLAY_ALL_SEASONS else 'shadow'}">
-                    <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
-                    <th class="col-metadata">NFO</th>
-                    <th class="col-metadata">TBN</th>
-                    <th class="col-ep">Episode</th>
-                    <th class="col-ep">Absolute</th>
-                    <th class="col-ep">Scene</th>
-                    <th class="col-ep">Scene Absolute</th>
-                    <th class="col-name hidden-xs">Name</th>
-                    <th class="col-name hidden-xs">File Name</th>
-                    <th class="col-ep">Size</th>
-                    <th class="col-airdate">Airdate</th>
-                    <th class="col-ep">Download</th>
-                    <th class="col-ep">Subtitles</th>
-                    <th class="col-status">Status</th>
-                    <th class="col-search">Search</th>
-                </tr>
-                    % endif
-            </tbody>
-                % if not app.DISPLAY_ALL_SEASONS:
-                <tbody class="toggle collapse${("", " in")[cur_season == -1]}" id="collapseSeason-${epResult['season']}">
-                % else:
-                <tbody>
-                % endif
-                <% cur_season = int(epResult["season"]) %>
-                % endif
-                <tr class="${Overview.overviewStrings[ep_cats[epStr]]} season-${cur_season} seasonstyle" id="${'S' + str(epResult["season"]) + 'E' + str(epResult["episode"])}">
-                    <td class="col-checkbox triggerhighlight">
-                        % if int(epResult["status"]) != UNAIRED:
-                            <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}" />
-                        % endif
-                    </td>
-                    <td align="center" class="triggerhighlight"><img src="images/${("nfo-no.gif", "nfo.gif")[epResult["hasnfo"]]}" alt="${("N", "Y")[epResult["hasnfo"]]}" width="23" height="11" /></td>
-                    <td align="center" class="triggerhighlight"><img src="images/${("tbn-no.gif", "tbn.gif")[epResult["hastbn"]]}" alt="${("N", "Y")[epResult["hastbn"]]}" width="23" height="11" /></td>
-                    <td align="center" class="triggerhighlight">
+
+                % for epResult in sql_results:
                     <%
-                        text = str(epResult['episode'])
-                        if epLoc != '' and epLoc is not None:
-                            text = '<span title="' + epLoc + '" class="addQTip">' + text + "</span>"
-                            epCount += 1
-                            if not epLoc in epList:
-                                epSize += epResult["file_size"]
-                                epList.append(epLoc)
+                    epStr = str(epResult["season"]) + "x" + str(epResult["episode"])
+                    if not epStr in ep_cats:
+                        continue
+                    if not app.DISPLAY_SHOW_SPECIALS and int(epResult["season"]) == 0:
+                        continue
+                    scene = False
+                    scene_anime = False
+                    if not show.air_by_date and not show.is_sports and not show.is_anime and show.is_scene:
+                        scene = True
+                    elif not show.air_by_date and not show.is_sports and show.is_anime and show.is_scene:
+                        scene_anime = True
+                    (dfltSeas, dfltEpis, dfltAbsolute) = (0, 0, 0)
+                    if (epResult["season"], epResult["episode"]) in xem_numbering:
+                        (dfltSeas, dfltEpis) = xem_numbering[(epResult["season"], epResult["episode"])]
+                    if epResult["absolute_number"] in xem_absolute_numbering:
+                        dfltAbsolute = xem_absolute_numbering[epResult["absolute_number"]]
+                    if epResult["absolute_number"] in scene_absolute_numbering:
+                        scAbsolute = scene_absolute_numbering[epResult["absolute_number"]]
+                        dfltAbsNumbering = False
+                    else:
+                        scAbsolute = dfltAbsolute
+                        dfltAbsNumbering = True
+                    if (epResult["season"], epResult["episode"]) in scene_numbering:
+                        (scSeas, scEpis) = scene_numbering[(epResult["season"], epResult["episode"])]
+                        dfltEpNumbering = False
+                    else:
+                        (scSeas, scEpis) = (dfltSeas, dfltEpis)
+                        dfltEpNumbering = True
+                    epLoc = epResult["location"]
+                    if epLoc and show._location and epLoc.lower().startswith(show._location.lower()):
+                        epLoc = epLoc[len(show._location)+1:]
                     %>
-                        ${text}
-                    </td>
-                    <td align="center" class="triggerhighlight">${epResult["absolute_number"]}</td>
-                    <td align="center" class="triggerhighlight">
-                        <input type="text" placeholder="${str(dfltSeas) + 'x' + str(dfltEpis)}" size="6" maxlength="8"
-                            class="sceneSeasonXEpisode form-control input-scene" data-for-season="${epResult["season"]}" data-for-episode="${epResult["episode"]}"
-                            id="sceneSeasonXEpisode_${show.indexerid}_${str(epResult["season"])}_${str(epResult["episode"])}"
-                            title="Change this value if scene numbering differs from the indexer episode numbering. Generally used for non-anime shows."
-                            % if dfltEpNumbering:
-                                value=""
-                            % else:
-                                value="${str(scSeas)}x${str(scEpis)}"
+                    % if int(epResult["season"]) != cur_season:
+                        % if cur_season == -1:
+                <thead>
+                    <tr class="seasoncols" style="display:none;">
+                            <th data-sorter="false" data-priority="critical" class="col-checkbox"><input type="checkbox" class="seasonCheck"/></th>
+                            <th data-sorter="false" class="col-metadata">NFO</th>
+                            <th data-sorter="false" class="col-metadata">TBN</th>
+                            <th data-sorter="false" class="col-ep">Episode</th>
+                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(show.is_anime)]}>Absolute</th>
+                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
+                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
+                            <th data-sorter="false" class="col-name">Name</th>
+                            <th data-sorter="false" class="col-name columnSelector-false">File Name</th>
+                            <th data-sorter="false" class="col-ep columnSelector-false">Size</th>
+                            <th data-sorter="false" class="col-airdate">Airdate</th>
+                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.DOWNLOAD_URL)]}>Download</th>
+                            <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(app.USE_SUBTITLES)]}>Subtitles</th>
+                            <th data-sorter="false" class="col-status">Status</th>
+                            <th data-sorter="false" class="col-search">Search</th>
+                    </tr>
+                </thead>
+                <tbody class="tablesorter-no-sort">
+                    <tr>
+                        <th class="row-seasonheader ${'displayShowTable' if app.FANART_BACKGROUND else 'displayShowTableFanArt'}" colspan="15" style="vertical-align: bottom; width: auto;">
+                            <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}
+                            % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
+                            <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
                             % endif
-                                style="padding: 0; text-align: center; max-width: 60px;"/>
-                    </td>
-                    <td align="center" class="triggerhighlight">
-                        <input type="text" placeholder="${str(dfltAbsolute)}" size="6" maxlength="8"
-                            class="sceneAbsolute form-control input-scene" data-for-absolute="${epResult["absolute_number"]}"
-                            id="sceneAbsolute_${show.indexerid}${"_"+str(epResult["absolute_number"])}"
-                            title="Change this value if scene absolute numbering differs from the indexer absolute numbering. Generally used for anime shows."
-                            % if dfltAbsNumbering:
-                                value=""
-                            % else:
-                                value="${str(scAbsolute)}"
+                            </h3>
+                            <div class="season-scene-exception" data-season=${str(epResult["season"]) if int(epResult["season"]) > 0 else "Specials"}></div>
+                            <div class="pull-right"> <!-- column select and hide/show episodes -->
+                                % if not app.DISPLAY_ALL_SEASONS:
+                                    <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Hide Episodes</button>
+                                % endif
+                                <button id="popover" type="button" class="btn pull-right">Select Columns <b class="caret"></b></button>
+                            </div> <!-- end column select and hide/show episodes -->
+                        </th>
+                    </tr>
+                </tbody>
+                <tbody class="tablesorter-no-sort">
+                    <tr id="season-${epResult["season"]}-cols" class="seasoncols">
+                        <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+                        <th class="col-metadata">NFO</th>
+                        <th class="col-metadata">TBN</th>
+                        <th class="col-ep">Episode</th>
+                        <th class="col-ep">Absolute</th>
+                        <th class="col-ep">Scene</th>
+                        <th class="col-ep">Scene Absolute</th>
+                        <th class="col-name hidden-xs">Name</th>
+                        <th class="col-name hidden-xs">File Name</th>
+                        <th class="col-ep">Size</th>
+                        <th class="col-airdate">Airdate</th>
+                        <th class="col-ep">Download</th>
+                        <th class="col-ep">Subtitles</th>
+                        <th class="col-status">Status</th>
+                        <th class="col-search">Search</th>
+                    </tr>
+                        % else:
+                    <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
+                        <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
+                    </tr>
+                    <% epCount = 0 %>
+                    <% epSize = 0 %>
+                    <% epList = [] %>
+                </tbody>
+                <tbody class="tablesorter-no-sort">
+                    <tr>
+                        <th class="row-seasonheader ${'displayShowTableFanArt' if app.FANART_BACKGROUND else 'displayShowTable'}" colspan="15" style="vertical-align: bottom; width: auto;">
+                            <h3 style="display: inline;"><a name="season-${epResult["season"]}"></a>${"Season " + str(epResult["season"]) if int(epResult["season"]) else "Specials"}
+                            % if not any([i for i in sql_results if epResult['season'] == i['season'] and int(i['status']) == 1]):
+                            <a class="epManualSearch" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=1&amp;manual_search_type=season"><img data-ep-manual-search src="images/manualsearch${'-white' if app.THEME_NAME == 'dark' else ''}.png" width="16" height="16" alt="search" title="Manual Search" /></a>
                             % endif
-                                style="padding: 0; text-align: center; max-width: 60px;"/>
-                    </td>
-                    <td class="col-name hidden-xs triggerhighlight">
-                    % if epResult["description"] != "" and epResult["description"] is not None:
-                        <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.indexer_slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
+                            </h3>
+                            <div class="season-scene-exception" data-season=${str(epResult["season"])}></div>
+                            <div class="pull-right"> <!-- hide/show episodes -->
+                                % if not app.DISPLAY_ALL_SEASONS:
+                                    <button id="showseason-${epResult['season']}" type="button" class="btn pull-right" data-toggle="collapse" data-target="#collapseSeason-${epResult['season']}">Show Episodes</button>
+                                % endif
+                            </div> <!-- end hide/show episodes -->
+                        </th>
+                    </tr>
+                </tbody>
+                <tbody class="tablesorter-no-sort">
+                    <tr id="season-${epResult["season"]}-cols" class="seasoncols ${'' if app.DISPLAY_ALL_SEASONS else 'shadow'}">
+                        <th class="col-checkbox"><input type="checkbox" class="seasonCheck" id="${epResult["season"]}" /></th>
+                        <th class="col-metadata">NFO</th>
+                        <th class="col-metadata">TBN</th>
+                        <th class="col-ep">Episode</th>
+                        <th class="col-ep">Absolute</th>
+                        <th class="col-ep">Scene</th>
+                        <th class="col-ep">Scene Absolute</th>
+                        <th class="col-name hidden-xs">Name</th>
+                        <th class="col-name hidden-xs">File Name</th>
+                        <th class="col-ep">Size</th>
+                        <th class="col-airdate">Airdate</th>
+                        <th class="col-ep">Download</th>
+                        <th class="col-ep">Subtitles</th>
+                        <th class="col-status">Status</th>
+                        <th class="col-search">Search</th>
+                    </tr>
+                        % endif
+                </tbody>
+                    % if not app.DISPLAY_ALL_SEASONS:
+                    <tbody class="toggle collapse${("", " in")[cur_season == -1]}" id="collapseSeason-${epResult['season']}">
                     % else:
-                        <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
+                    <tbody>
                     % endif
-                    ${epResult["name"]}
-                    </td>
-                    <td class="col-name hidden-xs triggerhighlight">${epLoc if Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED] else ''}</td>
-                    <td class="col-ep triggerhighlight">
-                        % if epResult["file_size"] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                            ${pretty_file_size(epResult["file_size"])}
-                        % endif
-                    </td>
-                    <td class="col-airdate triggerhighlight">
-                        % if int(epResult['airdate']) != 1:
-                            ## Lets do this exactly like ComingEpisodes and History
-                            ## Avoid issues with dateutil's _isdst on Windows but still provide air dates
-                            <% airDate = datetime.datetime.fromordinal(epResult['airdate']) %>
-                            % if airDate.year >= 1970 or show.network:
-                                <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
+                    <% cur_season = int(epResult["season"]) %>
+                    % endif
+                    <tr class="${Overview.overviewStrings[ep_cats[epStr]]} season-${cur_season} seasonstyle" id="${'S' + str(epResult["season"]) + 'E' + str(epResult["episode"])}">
+                        <td class="col-checkbox triggerhighlight">
+                            % if int(epResult["status"]) != UNAIRED:
+                                <input type="checkbox" class="epCheck" id="${str(epResult["season"])+'x'+str(epResult["episode"])}" name="${str(epResult["season"]) +"x"+str(epResult["episode"])}" />
                             % endif
-                            <time datetime="${airDate.isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(airDate)}</time>
+                        </td>
+                        <td align="center" class="triggerhighlight"><img src="images/${("nfo-no.gif", "nfo.gif")[epResult["hasnfo"]]}" alt="${("N", "Y")[epResult["hasnfo"]]}" width="23" height="11" /></td>
+                        <td align="center" class="triggerhighlight"><img src="images/${("tbn-no.gif", "tbn.gif")[epResult["hastbn"]]}" alt="${("N", "Y")[epResult["hastbn"]]}" width="23" height="11" /></td>
+                        <td align="center" class="triggerhighlight">
+                        <%
+                            text = str(epResult['episode'])
+                            if epLoc != '' and epLoc is not None:
+                                text = '<span title="' + epLoc + '" class="addQTip">' + text + "</span>"
+                                epCount += 1
+                                if not epLoc in epList:
+                                    epSize += epResult["file_size"]
+                                    epList.append(epLoc)
+                        %>
+                            ${text}
+                        </td>
+                        <td align="center" class="triggerhighlight">${epResult["absolute_number"]}</td>
+                        <td align="center" class="triggerhighlight">
+                            <input type="text" placeholder="${str(dfltSeas) + 'x' + str(dfltEpis)}" size="6" maxlength="8"
+                                class="sceneSeasonXEpisode form-control input-scene" data-for-season="${epResult["season"]}" data-for-episode="${epResult["episode"]}"
+                                id="sceneSeasonXEpisode_${show.indexerid}_${str(epResult["season"])}_${str(epResult["episode"])}"
+                                title="Change this value if scene numbering differs from the indexer episode numbering. Generally used for non-anime shows."
+                                % if dfltEpNumbering:
+                                    value=""
+                                % else:
+                                    value="${str(scSeas)}x${str(scEpis)}"
+                                % endif
+                                    style="padding: 0; text-align: center; max-width: 60px;"/>
+                        </td>
+                        <td align="center" class="triggerhighlight">
+                            <input type="text" placeholder="${str(dfltAbsolute)}" size="6" maxlength="8"
+                                class="sceneAbsolute form-control input-scene" data-for-absolute="${epResult["absolute_number"]}"
+                                id="sceneAbsolute_${show.indexerid}${"_"+str(epResult["absolute_number"])}"
+                                title="Change this value if scene absolute numbering differs from the indexer absolute numbering. Generally used for anime shows."
+                                % if dfltAbsNumbering:
+                                    value=""
+                                % else:
+                                    value="${str(scAbsolute)}"
+                                % endif
+                                    style="padding: 0; text-align: center; max-width: 60px;"/>
+                        </td>
+                        <td class="col-name hidden-xs triggerhighlight">
+                        % if epResult["description"] != "" and epResult["description"] is not None:
+                            <img src="images/info32.png" width="16" height="16" class="plotInfo" alt="" id="plot_info_${show.indexer_slug}_${str(epResult["season"])}_${str(epResult["episode"])}" />
                         % else:
-                            Never
+                            <img src="images/info32.png" width="16" height="16" class="plotInfoNone" alt="" />
                         % endif
-                    </td>
-                    <td class="triggerhighlight">
-                        % if app.DOWNLOAD_URL and epResult['location'] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                            <%
-                                filename = epResult['location']
-                                for rootDir in app.ROOT_DIRS.split('|'):
-                                    if rootDir.startswith('/'):
-                                        filename = filename.replace(rootDir, "")
-                                filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
-                            %>
-                            <a href="${filename}">Download</a>
-                        % endif
-                    </td>
-                    <td class="col-subtitles triggerhighlight" align="center">
-                    % for flag in (epResult["subtitles"] or '').split(','):
-                        % if flag.strip() and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
-                            % if flag != 'und':
-                                <a class=epRedownloadSubtitle href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult['season']}&amp;episode=${epResult['episode']}&amp;lang=${flag}">
-                                    <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${flag}" onError="this.onerror=null;this.src='images/flags/unknown.png';"/>
-                                </a>
+                        ${epResult["name"]}
+                        </td>
+                        <td class="col-name hidden-xs triggerhighlight">${epLoc if Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED] else ''}</td>
+                        <td class="col-ep triggerhighlight">
+                            % if epResult["file_size"] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                                ${pretty_file_size(epResult["file_size"])}
+                            % endif
+                        </td>
+                        <td class="col-airdate triggerhighlight">
+                            % if int(epResult['airdate']) != 1:
+                                ## Lets do this exactly like ComingEpisodes and History
+                                ## Avoid issues with dateutil's _isdst on Windows but still provide air dates
+                                <% airDate = datetime.datetime.fromordinal(epResult['airdate']) %>
+                                % if airDate.year >= 1970 or show.network:
+                                    <% airDate = sbdatetime.sbdatetime.convert_to_setting(network_timezones.parse_date_time(epResult['airdate'], show.airs, show.network)) %>
+                                % endif
+                                <time datetime="${airDate.isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(airDate)}</time>
                             % else:
-                                <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                                Never
                             % endif
-                        % endif
-                    % endfor
-                    </td>
-                        <% cur_status, cur_quality = Quality.split_composite_status(int(epResult["status"])) %>
-                        % if cur_quality != Quality.NONE:
-                            <td class="col-status triggerhighlight">${statusStrings[cur_status]} ${renderQualityPill(cur_quality)}</td>
-                        % else:
-                            <td class="col-status triggerhighlight">${statusStrings[cur_status]}</td>
-                        % endif
-                    <td class="col-search triggerhighlight">
-                        % if int(epResult["season"]) != 0:
-                            % if (int(epResult["status"]) in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.DOWNLOADED ) and app.USE_FAILED_DOWNLOADS:
-                                <a class="epRetry" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/retryEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
+                        </td>
+                        <td class="triggerhighlight">
+                            % if app.DOWNLOAD_URL and epResult['location'] and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                                <%
+                                    filename = epResult['location']
+                                    for rootDir in app.ROOT_DIRS.split('|'):
+                                        if rootDir.startswith('/'):
+                                            filename = filename.replace(rootDir, "")
+                                    filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
+                                %>
+                                <a href="${filename}">Download</a>
+                            % endif
+                        </td>
+                        <td class="col-subtitles triggerhighlight" align="center">
+                        % for flag in (epResult["subtitles"] or '').split(','):
+                            % if flag.strip() and Quality.split_composite_status(int(epResult['status'])).status in [DOWNLOADED, ARCHIVED]:
+                                % if flag != 'und':
+                                    <a class=epRedownloadSubtitle href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult['season']}&amp;episode=${epResult['episode']}&amp;lang=${flag}">
+                                        <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${flag}" onError="this.onerror=null;this.src='images/flags/unknown.png';"/>
+                                    </a>
+                                % else:
+                                    <img src="images/subtitles/flags/${flag}.png" width="16" height="11" alt="${subtitles.name_from_code(flag)}" onError="this.onerror=null;this.src='images/flags/unknown.png';" />
+                                % endif
+                            % endif
+                        % endfor
+                        </td>
+                            <% cur_status, cur_quality = Quality.split_composite_status(int(epResult["status"])) %>
+                            % if cur_quality != Quality.NONE:
+                                <td class="col-status triggerhighlight">${statusStrings[cur_status]} ${renderQualityPill(cur_quality)}</td>
                             % else:
-                                <a class="epSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/searchEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
+                                <td class="col-status triggerhighlight">${statusStrings[cur_status]}</td>
                             % endif
-                            <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                        % else:
-                            <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                        % endif
-                        % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"]:
-                            <a class="epSubtitlesSearch" href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
-                        % endif
-                    </td>
-                </tr>
-            % endfor
-            % if sql_results:
-                <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
-                    <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
-                </tr>
-            % endif
-            </tbody>
-            <tbody class="tablesorter-no-sort"><tr><th class="row-seasonheader" colspan=15></th></tr></tbody>
-        </table>
+                        <td class="col-search triggerhighlight">
+                            % if int(epResult["season"]) != 0:
+                                % if (int(epResult["status"]) in Quality.SNATCHED + Quality.SNATCHED_PROPER + Quality.SNATCHED_BEST + Quality.DOWNLOADED ) and app.USE_FAILED_DOWNLOADS:
+                                    <a class="epRetry" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/retryEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" height="16" alt="retry" title="Retry Download" /></a>
+                                % else:
+                                    <a class="epSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/searchEpisode?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
+                                % endif
+                                <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                            % else:
+                                <a class="epManualSearch" id="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" name="${str(show.indexerid)}x${str(epResult["season"])}x${str(epResult["episode"])}" href="home/snatchSelection?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                            % endif
+                            % if int(epResult["status"]) not in Quality.SNATCHED + Quality.SNATCHED_PROPER and app.USE_SUBTITLES and show.subtitles and epResult["location"]:
+                                <a class="epSubtitlesSearch" href="home/searchEpisodeSubtitles?show=${show.indexerid}&amp;season=${epResult["season"]}&amp;episode=${epResult["episode"]}"><img src="images/closed_captioning.png" height="16" alt="search subtitles" title="Search Subtitles" /></a>
+                            % endif
+                        </td>
+                    </tr>
+                % endfor
+                % if sql_results:
+                    <tr id="season-${epResult["season"]}-footer" class="seasoncols border-bottom shadow">
+                        <th class="col-footer" colspan=15 align=left>Season contains ${epCount} episodes with total filesize: ${pretty_file_size(epSize)}</th>
+                    </tr>
+                % endif
+                </tbody>
+                <tbody class="tablesorter-no-sort"><tr><th class="row-seasonheader" colspan=15></th></tr></tbody>
+            </table>
+            </div> <!-- end scroll-wrap -->
+        </div> <!-- end full-screen-scroll -->
     </div> <!-- end of col -->
 </div> <!-- row -->
 
+<!--Begin - Bootstrap Modals-->
+<div id="forcedSearchModalFailed" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Forced Search</h4>
+            </div>
+            <div class="modal-body">
+                <p>Do you want to mark this episode as failed?</p>
+                <p class="text-warning"><small>The episode release name will be added to the failed history, preventing it to be downloaded again.</small></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="forcedSearchModalQuality" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Forced Search</h4>
+            </div>
+            <div class="modal-body">
+                <p>Do you want to include the current episode quality in the search?</p>
+                <p class="text-warning"><small>Choosing No will ignore any releases with the same episode quality as the one currently downloaded/snatched.</small></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="confirmSubtitleReDownloadModal" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Re-download subtitle</h4>
+            </div>
+            <div class="modal-body">
+                <p>Do you want to re-download the subtitle for this language?</p>
+                <p class="text-warning"><small>It will overwrite your current subtitle</small></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div id="askmanualSubtitleSearchModal" class="modal fade">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+                <h4 class="modal-title">Subtitle search</h4>
+            </div>
+            <div class="modal-body">
+                <p>Do you want to manually pick subtitles or let us choose it for you?</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-info" data-dismiss="modal">Auto</button>
+                <button type="button" class="btn btn-success" data-dismiss="modal">Manual</button>
+            </div>
+        </div>
+    </div>
+</div>
 
-
-
-        <!--Begin - Bootstrap Modals-->
-        <div id="forcedSearchModalFailed" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title">Forced Search</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>Do you want to mark this episode as failed?</p>
-                        <p class="text-warning"><small>The episode release name will be added to the failed history, preventing it to be downloaded again.</small></p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
-                        <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div id="forcedSearchModalQuality" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title">Forced Search</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>Do you want to include the current episode quality in the search?</p>
-                        <p class="text-warning"><small>Choosing No will ignore any releases with the same episode quality as the one currently downloaded/snatched.</small></p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
-                        <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div id="confirmSubtitleReDownloadModal" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title">Re-download subtitle</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>Do you want to re-download the subtitle for this language?</p>
-                        <p class="text-warning"><small>It will overwrite your current subtitle</small></p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-danger" data-dismiss="modal">No</button>
-                        <button type="button" class="btn btn-success" data-dismiss="modal">Yes</button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div id="askmanualSubtitleSearchModal" class="modal fade">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                        <h4 class="modal-title">Subtitle search</h4>
-                    </div>
-                    <div class="modal-body">
-                        <p>Do you want to manually pick subtitles or let us choose it for you?</p>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-info" data-dismiss="modal">Auto</button>
-                        <button type="button" class="btn btn-success" data-dismiss="modal">Manual</button>
-                    </div>
-                </div>
-            </div>
-        </div>
 <%include file="subtitle_modal.mako"/>
 <!--End - Bootstrap Modal-->
 </%block>
+

--- a/views/manage.mako
+++ b/views/manage.mako
@@ -9,107 +9,117 @@
 </%block>
 <%block name="content">
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
+
 <form name="massUpdateForm" method="post" action="manage/massUpdate">
-<table style="width: 100%;" class="home-header">
-    <tr>
-        <td nowrap>
-            % if not header is UNDEFINED:
-            <h1 class="header" style="margin: 0;">${header}</h1>
-            % else:
-            <h1 class="title" style="margin: 0;">${title}</h1>
-            % endif
-        </td>
-        <td align="right">
-            <div>
-                <input class="btn btn-inline submitMassEdit" type="button" value="Edit Selected" />
-                <input class="btn btn-inline submitMassUpdate" type="button" value="Submit" />
-                <span class="show-option">
-                    <button id="popover" type="button" class="btn btn-inline">Select Columns <b class="caret"></b></button>
-                </span>
-                <span class="show-option">
-                    <button type="button" class="resetsorting btn btn-inline">Clear Filter(s)</button>
-                </span>
-            </div>
-        </td>
-    </tr>
-</table>
-<table id="massUpdateTable" class="tablesorter" cellspacing="1" border="0" cellpadding="0">
-    <thead>
-        <tr>
-            <th class="col-checkbox">Edit<br><input type="checkbox" class="bulkCheck" id="editCheck" /></th>
-            <th class="nowrap" style="text-align: left;">Show Name</th>
-            <th class="col-quality">Quality</th>
-            <th class="col-legend">Sports</th>
-            <th class="col-legend">Scene</th>
-            <th class="col-legend">Anime</th>
-            <th class="col-legend">Season folders</th>
-            <th class="col-legend">DVD Order</th>
-            <th class="col-legend">Paused</th>
-            <th class="col-legend">Subtitle</th>
-            <th class="col-legend">Default Ep Status</th>
-            <th class="col-legend">Status</th>
-            <th width="1%">Update<br><input type="checkbox" class="bulkCheck" id="updateCheck" /></th>
-            <th width="1%">Rescan<br><input type="checkbox" class="bulkCheck" id="refreshCheck" /></th>
-            <th width="1%">Rename<br><input type="checkbox" class="bulkCheck" id="renameCheck" /></th>
-        % if app.USE_SUBTITLES:
-            <th width="1%">Search Subtitle<br><input type="checkbox" class="bulkCheck" id="subtitleCheck" /></th>
-        % endif
-            <!-- <th>Force Metadata Regen <input type="checkbox" class="bulkCheck" id="metadataCheck" /></th>//-->
-            <th width="1%">Delete<br><input type="checkbox" class="bulkCheck" id="deleteCheck" /></th>
-            <th width="1%">Remove<br><input type="checkbox" class="bulkCheck" id="removeCheck" /></th>
-        </tr>
-    </thead>
-    <tfoot>
-        <tr>
-            <td rowspan="1" colspan="2" class="align-center alt"><input class="btn pull-left submitMassEdit" type="button" value="Edit Selected" /></td>
-            <td rowspan="1" colspan="${(15, 16)[bool(app.USE_SUBTITLES)]}" class="align-right alt"><input class="btn pull-right submitMassUpdate" type="button" value="Submit" /></td>
-        </tr>
-    </tfoot>
-    <tbody>
-<%
-    my_show_list = app.showList
-    my_show_list.sort(lambda x, y: cmp(x.name, y.name))
-%>
-    % for cur_show in my_show_list:
-    <%
-        cur_ep = cur_show.next_aired
-        disabled = app.show_queue_scheduler.action.isBeingUpdated(cur_show) or app.show_queue_scheduler.action.isInUpdateQueue(cur_show)
-        curUpdate = "<input type=\"checkbox\" class=\"updateCheck\" id=\"update-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-        disabled = app.show_queue_scheduler.action.isBeingRefreshed(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
-        curRefresh = "<input type=\"checkbox\" class=\"refreshCheck\" id=\"refresh-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-        disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show)
-        curRename = "<input type=\"checkbox\" class=\"renameCheck\" id=\"rename-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-        disabled = not cur_show.subtitles or app.show_queue_scheduler.action.isBeingSubtitled(cur_show) or app.show_queue_scheduler.action.isInSubtitleQueue(cur_show)
-        curSubtitle = "<input type=\"checkbox\" class=\"subtitleCheck\" id=\"subtitle-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-        disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
-        curDelete = "<input type=\"checkbox\" class=\"confirm deleteCheck\" id=\"delete-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-        disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
-        curRemove = "<input type=\"checkbox\" class=\"removeCheck\" id=\"remove-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
-    %>
-    <tr>
-        <td class="triggerhighlight" align="center"><input type="checkbox" class="editCheck" id="edit-${cur_show.indexerid}" /></td>
-        <td class="tvShow triggerhighlight"><a href="home/displayShow?show=${cur_show.indexerid}">${cur_show.name}</a></td>
-        <td class="triggerhighlight" align="center">${renderQualityPill(cur_show.quality, showTitle=True)}</td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_sports) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_scene) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_anime) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[not int(cur_show.flatten_folders) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.dvd_order) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.paused) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.subtitles) == 1]}" width="16" height="16" /></td>
-        <td class="triggerhighlight" align="center">${statusStrings[cur_show.default_ep_status]}</td>
-        <td class="triggerhighlight" align="center">${cur_show.status}</td>
-        <td class="triggerhighlight" align="center">${curUpdate}</td>
-        <td class="triggerhighlight" align="center">${curRefresh}</td>
-        <td class="triggerhighlight" align="center">${curRename}</td>
-        % if app.USE_SUBTITLES:
-        <td class="triggerhighlight" align="center">${curSubtitle}</td>
-        % endif
-        <td class="triggerhighlight" align="center">${curDelete}</td>
-        <td class="triggerhighlight" align="center">${curRemove}</td>
-    </tr>
-% endfor
-</tbody>
-</table>
+    <div class="row wide">
+        <div class="col-md-12">
+            <table style="width: 100%;" class="home-header">
+                <tr>
+                    <td nowrap>
+                        % if not header is UNDEFINED:
+                        <h1 class="header" style="margin: 0;">${header}</h1>
+                        % else:
+                        <h1 class="title" style="margin: 0;">${title}</h1>
+                        % endif
+                    </td>
+                    <td align="right">
+                        <div>
+                            <input class="btn btn-inline submitMassEdit" type="button" value="Edit Selected" />
+                            <input class="btn btn-inline submitMassUpdate" type="button" value="Submit" />
+                            <span class="show-option">
+                                <button id="popover" type="button" class="btn btn-inline">Select Columns <b class="caret"></b></button>
+                            </span>
+                            <span class="show-option">
+                                <button type="button" class="resetsorting btn btn-inline">Clear Filter(s)</button>
+                            </span>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </div>
+    </div>
+
+    <div class="row wide">
+        <div class="col-md-12 horizontal-scroll">
+            <table id="massUpdateTable" class="tablesorter" cellspacing="1" border="0" cellpadding="0">
+                <thead>
+                    <tr>
+                        <th class="col-checkbox">Edit<br><input type="checkbox" class="bulkCheck" id="editCheck" /></th>
+                        <th class="nowrap" style="text-align: left;">Show Name</th>
+                        <th class="col-quality">Quality</th>
+                        <th class="col-legend">Sports</th>
+                        <th class="col-legend">Scene</th>
+                        <th class="col-legend">Anime</th>
+                        <th class="col-legend">Season folders</th>
+                        <th class="col-legend">DVD Order</th>
+                        <th class="col-legend">Paused</th>
+                        <th class="col-legend">Subtitle</th>
+                        <th class="col-legend">Default Ep Status</th>
+                        <th class="col-legend">Status</th>
+                        <th width="1%">Update<br><input type="checkbox" class="bulkCheck" id="updateCheck" /></th>
+                        <th width="1%">Rescan<br><input type="checkbox" class="bulkCheck" id="refreshCheck" /></th>
+                        <th width="1%">Rename<br><input type="checkbox" class="bulkCheck" id="renameCheck" /></th>
+                    % if app.USE_SUBTITLES:
+                        <th width="1%">Search Subtitle<br><input type="checkbox" class="bulkCheck" id="subtitleCheck" /></th>
+                    % endif
+                        <!-- <th>Force Metadata Regen <input type="checkbox" class="bulkCheck" id="metadataCheck" /></th>//-->
+                        <th width="1%">Delete<br><input type="checkbox" class="bulkCheck" id="deleteCheck" /></th>
+                        <th width="1%">Remove<br><input type="checkbox" class="bulkCheck" id="removeCheck" /></th>
+                    </tr>
+                </thead>
+                <tfoot>
+                    <tr>
+                        <td rowspan="1" colspan="2" class="align-center alt"><input class="btn pull-left submitMassEdit" type="button" value="Edit Selected" /></td>
+                        <td rowspan="1" colspan="${(15, 16)[bool(app.USE_SUBTITLES)]}" class="align-right alt"><input class="btn pull-right submitMassUpdate" type="button" value="Submit" /></td>
+                    </tr>
+                </tfoot>
+                <tbody>
+            <%
+                my_show_list = app.showList
+                my_show_list.sort(lambda x, y: cmp(x.name, y.name))
+            %>
+                % for cur_show in my_show_list:
+                <%
+                    cur_ep = cur_show.next_aired
+                    disabled = app.show_queue_scheduler.action.isBeingUpdated(cur_show) or app.show_queue_scheduler.action.isInUpdateQueue(cur_show)
+                    curUpdate = "<input type=\"checkbox\" class=\"updateCheck\" id=\"update-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                    disabled = app.show_queue_scheduler.action.isBeingRefreshed(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
+                    curRefresh = "<input type=\"checkbox\" class=\"refreshCheck\" id=\"refresh-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                    disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show)
+                    curRename = "<input type=\"checkbox\" class=\"renameCheck\" id=\"rename-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                    disabled = not cur_show.subtitles or app.show_queue_scheduler.action.isBeingSubtitled(cur_show) or app.show_queue_scheduler.action.isInSubtitleQueue(cur_show)
+                    curSubtitle = "<input type=\"checkbox\" class=\"subtitleCheck\" id=\"subtitle-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                    disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
+                    curDelete = "<input type=\"checkbox\" class=\"confirm deleteCheck\" id=\"delete-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                    disabled = app.show_queue_scheduler.action.isBeingRenamed(cur_show) or app.show_queue_scheduler.action.isInRenameQueue(cur_show) or app.show_queue_scheduler.action.isInRefreshQueue(cur_show)
+                    curRemove = "<input type=\"checkbox\" class=\"removeCheck\" id=\"remove-" + str(cur_show.indexerid) + "\" " + ("", "disabled=\"disabled\" ")[disabled] + "/>"
+                %>
+                <tr>
+                    <td class="triggerhighlight" align="center"><input type="checkbox" class="editCheck" id="edit-${cur_show.indexerid}" /></td>
+                    <td class="tvShow triggerhighlight"><a href="home/displayShow?show=${cur_show.indexerid}">${cur_show.name}</a></td>
+                    <td class="triggerhighlight" align="center">${renderQualityPill(cur_show.quality, showTitle=True)}</td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_sports) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_scene) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.is_anime) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[not int(cur_show.flatten_folders) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.dvd_order) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.paused) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center"><img src="images/${('no16.png" alt="N', 'yes16.png" alt="Y')[int(cur_show.subtitles) == 1]}" width="16" height="16" /></td>
+                    <td class="triggerhighlight" align="center">${statusStrings[cur_show.default_ep_status]}</td>
+                    <td class="triggerhighlight" align="center">${cur_show.status}</td>
+                    <td class="triggerhighlight" align="center">${curUpdate}</td>
+                    <td class="triggerhighlight" align="center">${curRefresh}</td>
+                    <td class="triggerhighlight" align="center">${curRename}</td>
+                    % if app.USE_SUBTITLES:
+                    <td class="triggerhighlight" align="center">${curSubtitle}</td>
+                    % endif
+                    <td class="triggerhighlight" align="center">${curDelete}</td>
+                    <td class="triggerhighlight" align="center">${curRemove}</td>
+                </tr>
+            % endfor
+            </tbody>
+            </table>
+        </div>
+    </div>
 </form>
 </%block>

--- a/views/manage_backlogOverview.mako
+++ b/views/manage_backlogOverview.mako
@@ -10,17 +10,20 @@
 </%block>
 <%block name="content">
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
-<div class="clearfix"></div><!-- div.clearfix //-->
-</div>
-<div class="clearfix"></div>
-<div id="content-col" class="col-lg-10 col-lg-offset-1 col-md-10 col-md-offset-1 col-sm-12 col-xs-12">
-    <div class="row col-md-12">
+
+<div class="row">
+<div id="content-col" class="col-md-12">
+    <div class="col-md-12">
     % if not header is UNDEFINED:
         <h1 class="header">${header}</h1>
     % else:
         <h1 class="title">${title}</h1>
     % endif
     </div>
+</div>
+
+<div class="row">
+    <div class="col-md-12">
 <%
     totalWanted = totalQual = 0
     backLogShows = sorted([x for x in app.showList if x.paused == 0 and showCounts[x.indexerid][Overview.QUAL] + showCounts[x.indexerid][Overview.WANTED]], key=lambda x: x.name)
@@ -28,34 +31,31 @@
         totalWanted += showCounts[cur_show.indexerid][Overview.WANTED]
         totalQual += showCounts[cur_show.indexerid][Overview.QUAL]
 %>
-    <div class="clearfix"></div>
-    <div class="row col-md-12">
-        <div class="col-md-12">
-            <div class="show-option pull-left">Jump to Show:
-                <select id="pickShow" class="form-control-inline input-sm-custom">
-                % for cur_show in backLogShows:
-                    <option value="${cur_show.indexerid}">${cur_show.name}</option>
-                % endfor
-                </select>
-            </div>
-            <div class="show-option pull-left">Period:
-                <select id="backlog_period" class="form-control-inline input-sm-custom">
-                    <option value="all" ${'selected="selected"' if app.BACKLOG_PERIOD == 'all' else ''}>All</option>
-                    <option value="one_day" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_day' else ''}>Last 24h</option>
-                    <option value="three_days" ${'selected="selected"' if app.BACKLOG_PERIOD == 'three_days' else ''}>Last 3 days</option>
-                    <option value="one_week" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_week' else ''}>Last 7 days</option>
-                    <option value="one_month" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_month' else ''}>Last 30 days</option>
-                </select>
-            </div>
-            <div class="show-option pull-left">Status:
-                <select id="backlog_status" class="form-control-inline input-sm-custom">
-                    <option value="all" ${'selected="selected"' if app.BACKLOG_STATUS == 'all' else ''}>All</option>
-                    <option value="quality" ${'selected="selected"' if app.BACKLOG_STATUS == 'quality' else ''}>Quality</option>
-                    <option value="wanted" ${'selected="selected"' if app.BACKLOG_STATUS == 'wanted' else ''}>Wanted</option>
-                </select>
-            </div>
+        <div class="show-option pull-left">Jump to Show:
+            <select id="pickShow" class="form-control-inline input-sm-custom">
+            % for cur_show in backLogShows:
+                <option value="${cur_show.indexerid}">${cur_show.name}</option>
+            % endfor
+            </select>
         </div>
-        <div class="col-md-6 pull-right">
+        <div class="show-option pull-left">Period:
+            <select id="backlog_period" class="form-control-inline input-sm-custom">
+                <option value="all" ${'selected="selected"' if app.BACKLOG_PERIOD == 'all' else ''}>All</option>
+                <option value="one_day" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_day' else ''}>Last 24h</option>
+                <option value="three_days" ${'selected="selected"' if app.BACKLOG_PERIOD == 'three_days' else ''}>Last 3 days</option>
+                <option value="one_week" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_week' else ''}>Last 7 days</option>
+                <option value="one_month" ${'selected="selected"' if app.BACKLOG_PERIOD == 'one_month' else ''}>Last 30 days</option>
+            </select>
+        </div>
+        <div class="show-option pull-left">Status:
+            <select id="backlog_status" class="form-control-inline input-sm-custom">
+                <option value="all" ${'selected="selected"' if app.BACKLOG_STATUS == 'all' else ''}>All</option>
+                <option value="quality" ${'selected="selected"' if app.BACKLOG_STATUS == 'quality' else ''}>Quality</option>
+                <option value="wanted" ${'selected="selected"' if app.BACKLOG_STATUS == 'wanted' else ''}>Wanted</option>
+            </select>
+        </div>
+
+        <div id="status-summary" class="pull-right">
             <div class="h2footer pull-right">
                 % if totalWanted > 0:
                 <span class="listing-key wanted">Wanted: <b>${totalWanted}</b></span>
@@ -64,102 +64,104 @@
                 <span class="listing-key qual">Quality: <b>${totalQual}</b></span>
                 % endif
             </div>
-        </div>
-    </div>
-    <div class="clearfix"></div>
-    <div class="row col-md-12">
-        <table class="defaultTable" cellspacing="0" border="0" cellpadding="0">
-        % for cur_show in backLogShows:
-            % if not showCounts[cur_show.indexerid][Overview.WANTED] + showCounts[cur_show.indexerid][Overview.QUAL]:
-                <% continue %>
-            % endif
-            <tr class="seasonheader"><td colspan="5">&nbsp;</td></tr>
-            <tr class="seasonheader" id="show-${cur_show.indexerid}">
-                <td class="row-seasonheader" colspan="5" style="vertical-align: bottom; width: auto;">
-                    <div class="col-md-12">
-                        <div class="col-md-6 left-30">
-                            <h3 style="display: inline;"><a href="home/displayShow?show=${cur_show.indexerid}">${cur_show.name}</a></h3>
-                             % if cur_show.quality in qualityPresets:
-                                &nbsp;&nbsp;&nbsp;&nbsp;<i>Quality:</i>&nbsp;&nbsp;${renderQualityPill(cur_show.quality)}
-                             % endif
-                        </div>
-                        <div class="col-md-6 pull-right right-30">
-                            <div class="top-5 bottom-5 pull-right">
-                                % if showCounts[cur_show.indexerid][Overview.WANTED] > 0:
-                                <span class="listing-key wanted">Wanted: <b>${showCounts[cur_show.indexerid][Overview.WANTED]}</b></span>
-                                % endif
-                                % if showCounts[cur_show.indexerid][Overview.QUAL] > 0:
-                                <span class="listing-key qual">Quality: <b>${showCounts[cur_show.indexerid][Overview.QUAL]}</b></span>
-                                % endif
-                                <a class="btn btn-inline forceBacklog" href="manage/backlogShow?indexer_id=${cur_show.indexerid}"><i class="icon-play-circle icon-white"></i> Force Backlog</a>
-                                <a class="btn btn-inline editShow" href="manage/editShow?show=${cur_show.indexerid}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
+        </div> <!-- status-summary -->
+    </div> <!-- end of col -->
+</div> <!-- end of row -->
+
+    <div class="row">
+        <div class="col-md-12 horizontal-scroll">
+            <table class="defaultTable" cellspacing="0" border="0" cellpadding="0">
+            % for cur_show in backLogShows:
+                % if not showCounts[cur_show.indexerid][Overview.WANTED] + showCounts[cur_show.indexerid][Overview.QUAL]:
+                    <% continue %>
+                % endif
+                <tr class="seasonheader" id="show-${cur_show.indexerid}">
+                    <td class="row-seasonheader" colspan="5" style="vertical-align: bottom; width: auto;">
+                        <div class="col-md-12">
+                            <div class="col-md-6 left-30">
+                                <h3 style="display: inline;"><a href="home/displayShow?show=${cur_show.indexerid}">${cur_show.name}</a></h3>
+                                 % if cur_show.quality in qualityPresets:
+                                    &nbsp;&nbsp;&nbsp;&nbsp;<i>Quality:</i>&nbsp;&nbsp;${renderQualityPill(cur_show.quality)}
+                                 % endif
+                            </div>
+                            <div class="col-md-6 pull-right right-30">
+                                <div class="top-5 bottom-5 pull-right">
+                                    % if showCounts[cur_show.indexerid][Overview.WANTED] > 0:
+                                    <span class="listing-key wanted">Wanted: <b>${showCounts[cur_show.indexerid][Overview.WANTED]}</b></span>
+                                    % endif
+                                    % if showCounts[cur_show.indexerid][Overview.QUAL] > 0:
+                                    <span class="listing-key qual">Quality: <b>${showCounts[cur_show.indexerid][Overview.QUAL]}</b></span>
+                                    % endif
+                                    <a class="btn btn-inline forceBacklog" href="manage/backlogShow?indexer_id=${cur_show.indexerid}"><i class="icon-play-circle icon-white"></i> Force Backlog</a>
+                                    <a class="btn btn-inline editShow" href="manage/editShow?show=${cur_show.indexerid}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
+                                </div>
                             </div>
                         </div>
-                    </div>
-                </td>
-            </tr>
-            % if not cur_show.quality in qualityPresets:
-            <% allowed_qualities, preferred_qualities = Quality.split_quality(int(cur_show.quality)) %>
-            <tr>
-                <td colspan="5" class="backlog-quality">
-                    <div class="col-md-12 left-30">
-                    % if allowed_qualities:
-                        <div class="col-md-12 align-left">
-                           <i>Allowed:</i>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ${' '.join([capture(renderQualityPill, x) for x in sorted(allowed_qualities)])}${'<br>' if preferred_qualities else ''}
-                        </div>
-                    % endif
-                    % if preferred_qualities:
-                        <div class="col-md-12 align-left">
-                           <i>Preferred:</i>&nbsp;&nbsp; ${' '.join([capture(renderQualityPill, x) for x in sorted(preferred_qualities)])}
-                       </div>
-                    % endif
-                    </div>
-                </td>
-            </tr>
-            % endif
-            <tr class="seasoncols">
-                <th>Episode</th>
-                <th>Status / Quality</th>
-                <th>Episode Title</th>
-                <th class="nowrap">Airdate</th>
-                <th>Actions</th>
-            </tr>
-            % for cur_result in showSQLResults[cur_show.indexerid]:
-                <%
-                    old_status, old_quality = Quality.split_composite_status(cur_result['status'])
-                    archived_status = Quality.composite_status(ARCHIVED, old_quality)
-                %>
-                <tr class="seasonstyle ${Overview.overviewStrings[showCats[cur_show.indexerid][cur_result["episode_string"]]]}">
-                    <td class="tableleft" align="center">${cur_result["episode_string"]}</td>
-                    <td class="col-status">
-                        % if old_quality != Quality.NONE:
-                            ${statusStrings[old_status]} ${renderQualityPill(old_quality)}
-                        % else:
-                            ${statusStrings[old_status]}
-                        % endif
-                    </td>
-                    <td class="tableright" align="center" class="nowrap">
-                        ${cur_result["name"]}
-                    </td>
-                    <td>
-                        <% show = cur_show %>
-                        % if cur_result['airdate']:
-                            <time datetime="${cur_result['airdate'].isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(cur_result['airdate'])}</time>
-                        % else:
-                            Never
-                        % endif
-                    </td>
-                    <td class="col-search">
-                        <a class="epSearch" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/searchEpisode?show=${cur_show.indexerid}&amp;season=${cur_result['season']}&amp;episode=${cur_result['episode']}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
-                        <a class="epManualSearch" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/snatchSelection?show=${cur_show.indexerid}&amp;season=${cur_result['season']}&amp;episode=${cur_result['episode']}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
-                        % if old_status == DOWNLOADED:
-                            <a class="epArchive" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/setStatus?show=${cur_show.indexerid}&eps=${cur_result['season']}x${cur_result['episode']}&status=${archived_status}&direct=1"><img data-ep-archive src="images/archive.png" width="16" height="16" alt="search" title="Archive episode" /></a>
-                        % endif
                     </td>
                 </tr>
+                % if not cur_show.quality in qualityPresets:
+                <% allowed_qualities, preferred_qualities = Quality.split_quality(int(cur_show.quality)) %>
+                <tr>
+                    <td colspan="5" class="backlog-quality">
+                        <div class="col-md-12 left-30">
+                        % if allowed_qualities:
+                            <div class="col-md-12 align-left">
+                               <i>Allowed:</i>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; ${' '.join([capture(renderQualityPill, x) for x in sorted(allowed_qualities)])}${'<br>' if preferred_qualities else ''}
+                            </div>
+                        % endif
+                        % if preferred_qualities:
+                            <div class="col-md-12 align-left">
+                               <i>Preferred:</i>&nbsp;&nbsp; ${' '.join([capture(renderQualityPill, x) for x in sorted(preferred_qualities)])}
+                           </div>
+                        % endif
+                        </div>
+                    </td>
+                </tr>
+                % endif
+                <tr class="seasoncols">
+                    <th>Episode</th>
+                    <th>Status / Quality</th>
+                    <th>Episode Title</th>
+                    <th class="nowrap">Airdate</th>
+                    <th>Actions</th>
+                </tr>
+                % for cur_result in showSQLResults[cur_show.indexerid]:
+                    <%
+                        old_status, old_quality = Quality.split_composite_status(cur_result['status'])
+                        archived_status = Quality.composite_status(ARCHIVED, old_quality)
+                    %>
+                    <tr class="seasonstyle ${Overview.overviewStrings[showCats[cur_show.indexerid][cur_result["episode_string"]]]}">
+                        <td class="tableleft" align="center">${cur_result["episode_string"]}</td>
+                        <td class="col-status">
+                            % if old_quality != Quality.NONE:
+                                ${statusStrings[old_status]} ${renderQualityPill(old_quality)}
+                            % else:
+                                ${statusStrings[old_status]}
+                            % endif
+                        </td>
+                        <td class="tableright" align="center" class="nowrap">
+                            ${cur_result["name"]}
+                        </td>
+                        <td>
+                            <% show = cur_show %>
+                            % if cur_result['airdate']:
+                                <time datetime="${cur_result['airdate'].isoformat('T')}" class="date">${sbdatetime.sbdatetime.sbfdatetime(cur_result['airdate'])}</time>
+                            % else:
+                                Never
+                            % endif
+                        </td>
+                        <td class="col-search">
+                            <a class="epSearch" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/searchEpisode?show=${cur_show.indexerid}&amp;season=${cur_result['season']}&amp;episode=${cur_result['episode']}"><img data-ep-search src="images/search16.png" width="16" height="16" alt="search" title="Forced Search" /></a>
+                            <a class="epManualSearch" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/snatchSelection?show=${cur_show.indexerid}&amp;season=${cur_result['season']}&amp;episode=${cur_result['episode']}"><img data-ep-manual-search src="images/manualsearch.png" width="16" height="16" alt="search" title="Manual Search" /></a>
+                            % if old_status == DOWNLOADED:
+                                <a class="epArchive" id="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" name="${str(cur_show.indexerid)}x${str(cur_result['season'])}x${str(cur_result['episode'])}" href="home/setStatus?show=${cur_show.indexerid}&eps=${cur_result['season']}x${cur_result['episode']}&status=${archived_status}&direct=1"><img data-ep-archive src="images/archive.png" width="16" height="16" alt="search" title="Archive episode" /></a>
+                            % endif
+                        </td>
+                    </tr>
+                % endfor
             % endfor
-        % endfor
-        </table>
-    </div>
+            </table>
+        </div> <!-- end of col-12 -->
+    </div> <!-- end of row -->
 </div>
 </%block>

--- a/views/manage_massEdit.mako
+++ b/views/manage_massEdit.mako
@@ -17,228 +17,234 @@
 <script type="text/javascript" src="js/quality-chooser.js?${sbPID}"></script>
 <script type="text/javascript" src="js/mass-edit.js?${sbPID}"></script>
 </%block>
+
 <%block name="content">
-<div id="config">
-    <div id="config-content">
-        <form action="manage/massEditSubmit" method="post">
-            <input type="hidden" name="toEdit" value="${showList}" />
-            <div id="config-components">
-                ## @TODO: Fix this stupid hack
-                <script>document.write('<ul><li><a href="' + document.location.href + '#core-component-group1">Main</a></li></ul>');</script>
-                <div id="core-component-group1">
-                    <div class="component-group">
-                        <h3>Main Settings</h3>
-                        <em class="note">NOTE: Changing any settings marked with (<span class="separator">*</span>) will force a refresh of the selected shows.</em><br>
-                        <br>
-                        <fieldset class="component-group-list">
-                        <div class="field-pair">
-                            <label for="shows">
-                                <span class="component-title">Selected Shows</span>
-                                <span class="component-desc">
-                                    <span style="font-size: 14px;">${', '.join(sorted(showNames))}</span><br>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_root_dir_0">
-                                <span class="component-title">Root Directories (<span class="separator">*</span>)</span>
-                                <span class="component-desc">
-                                    <table class="defaultTable" cellspacing="1" cellpadding="0" border="0">
-                                        <thead>
-                                            <tr>
-                                                <th class="nowrap tablesorter-header">Current</th>
-                                                <th class="nowrap tablesorter-header">New</th>
-                                                <th class="nowrap tablesorter-header" style="width: 140px;">-</th>
-                                            </tr>
-                                        </thead>
-                                        <tbody>
-                                        % for cur_dir in root_dir_list:
-                                            <% cur_index = root_dir_list.index(cur_dir) %>
-                                            <tr class="listing-default">
-                                                <td align="center">${cur_dir}</td>
-                                                <td align="center" id="display_new_root_dir_${cur_index}">${cur_dir}</td>
-                                                <td>
-                                                    <a href="#" class="btn edit_root_dir" class="edit_root_dir" id="edit_root_dir_${cur_index}">Edit</a>
-                                                    <a href="#" class="btn delete_root_dir" class="delete_root_dir" id="delete_root_dir_${cur_index}">Delete</a>
-                                                    <input type="hidden" name="orig_root_dir_${cur_index}" value="${cur_dir}" />
-                                                    <input type="text" style="display: none;" name="new_root_dir_${cur_index}" id="new_root_dir_${cur_index}" class="new_root_dir" value="${cur_dir}"/>
-                                                </td>
-                                            </tr>
-                                        % endfor
-                                        </tbody>
-                                    </table>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="qualityPreset">
-                                <span class="component-title">Preferred Quality</span>
-                                <span class="component-desc">
-                                    <%
-                                        if quality_value is not None:
-                                            initial_quality = int(quality_value)
-                                        else:
-                                            initial_quality = common.SD
-                                        allowed_qualities, preferred_qualities = common.Quality.split_quality(initial_quality)
-                                    %>
-                                    <select id="qualityPreset" name="quality_preset" class="form-control form-control-inline input-sm">
-                                        <option value="keep">&lt; Keep &gt;</option>
-                                        <% selected = None %>
-                                        <option value="0" ${'selected="selected"' if quality_value is not None and quality_value not in common.qualityPresets else ''}>Custom</option>
-                                        % for curPreset in sorted(common.qualityPresets):
-                                        <option value="${curPreset}" ${'selected="selected"' if quality_value == curPreset else ''}>${common.qualityPresetStrings[curPreset]}</option>
-                                        % endfor
-                                    </select>
-                                    <div id="customQuality" style="padding-left: 0;">
-                                        <div style="padding-right: 40px; text-align: left; float: left;">
-                                            <h5>Allowed</h5>
-                                            <% anyQualityList = filter(lambda x: x > common.Quality.NONE, common.Quality.qualityStrings) %>
-                                            <select id="allowed_qualities" name="allowed_qualities" multiple="multiple" size="${len(anyQualityList)}" class="form-control form-control-inline input-sm">
-                                                % for curQuality in sorted(anyQualityList):
-                                                <option value="${curQuality}" ${'selected="selected"' if curQuality in allowed_qualities else ''}>${common.Quality.qualityStrings[curQuality]}</option>
+<div class="row">
+    <div class="col-md-12">
+        <div id="config">
+            <div id="config-content">
+                <form action="manage/massEditSubmit" method="post">
+                    <input type="hidden" name="toEdit" value="${showList}" />
+                    <div id="config-components">
+                        ## @TODO: Fix this stupid hack
+                        <script>document.write('<ul><li><a href="' + document.location.href + '#core-component-group1">Main</a></li></ul>');</script>
+                        <div id="core-component-group1">
+                            <div class="component-group">
+                                <h3>Main Settings</h3>
+                                <em class="note">NOTE: Changing any settings marked with (<span class="separator">*</span>) will force a refresh of the selected shows.</em><br>
+                                <br>
+                                <fieldset class="component-group-list">
+                                <div class="field-pair">
+                                    <label for="shows">
+                                        <span class="component-title">Selected Shows</span>
+                                        <span class="component-desc">
+                                            <span style="font-size: 14px;">${', '.join(sorted(showNames))}</span><br>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_root_dir_0">
+                                        <span class="component-title">Root Directories (<span class="separator">*</span>)</span>
+                                        <span class="component-desc">
+                                            <table class="defaultTable" cellspacing="1" cellpadding="0" border="0">
+                                                <thead>
+                                                    <tr>
+                                                        <th class="nowrap tablesorter-header">Current</th>
+                                                        <th class="nowrap tablesorter-header">New</th>
+                                                        <th class="nowrap tablesorter-header" style="width: 140px;">-</th>
+                                                    </tr>
+                                                </thead>
+                                                <tbody>
+                                                % for cur_dir in root_dir_list:
+                                                    <% cur_index = root_dir_list.index(cur_dir) %>
+                                                    <tr class="listing-default">
+                                                        <td align="center">${cur_dir}</td>
+                                                        <td align="center" id="display_new_root_dir_${cur_index}">${cur_dir}</td>
+                                                        <td>
+                                                            <a href="#" class="btn edit_root_dir" class="edit_root_dir" id="edit_root_dir_${cur_index}">Edit</a>
+                                                            <a href="#" class="btn delete_root_dir" class="delete_root_dir" id="delete_root_dir_${cur_index}">Delete</a>
+                                                            <input type="hidden" name="orig_root_dir_${cur_index}" value="${cur_dir}" />
+                                                            <input type="text" style="display: none;" name="new_root_dir_${cur_index}" id="new_root_dir_${cur_index}" class="new_root_dir" value="${cur_dir}"/>
+                                                        </td>
+                                                    </tr>
+                                                % endfor
+                                                </tbody>
+                                            </table>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="qualityPreset">
+                                        <span class="component-title">Preferred Quality</span>
+                                        <span class="component-desc">
+                                            <%
+                                                if quality_value is not None:
+                                                    initial_quality = int(quality_value)
+                                                else:
+                                                    initial_quality = common.SD
+                                                allowed_qualities, preferred_qualities = common.Quality.split_quality(initial_quality)
+                                            %>
+                                            <select id="qualityPreset" name="quality_preset" class="form-control form-control-inline input-sm">
+                                                <option value="keep">&lt; Keep &gt;</option>
+                                                <% selected = None %>
+                                                <option value="0" ${'selected="selected"' if quality_value is not None and quality_value not in common.qualityPresets else ''}>Custom</option>
+                                                % for curPreset in sorted(common.qualityPresets):
+                                                <option value="${curPreset}" ${'selected="selected"' if quality_value == curPreset else ''}>${common.qualityPresetStrings[curPreset]}</option>
                                                 % endfor
                                             </select>
-                                        </div>
-                                        <div style="text-align: left; float: left;">
-                                            <h5>Preferred</h5>
-                                            <% bestQualityList = filter(lambda x: x >= common.Quality.SDTV, common.Quality.qualityStrings) %>
-                                            <select id="preferred_qualities" name="preferred_qualities" multiple="multiple" size="${len(bestQualityList)}" class="form-control form-control-inline input-sm">
-                                                % for curQuality in sorted(bestQualityList):
-                                                <option value="${curQuality}" ${'selected="selected"' if curQuality in preferred_qualities else ''}>${common.Quality.qualityStrings[curQuality]}</option>
+                                            <div id="customQuality" style="padding-left: 0;">
+                                                <div style="padding-right: 40px; text-align: left; float: left;">
+                                                    <h5>Allowed</h5>
+                                                    <% anyQualityList = filter(lambda x: x > common.Quality.NONE, common.Quality.qualityStrings) %>
+                                                    <select id="allowed_qualities" name="allowed_qualities" multiple="multiple" size="${len(anyQualityList)}" class="form-control form-control-inline input-sm">
+                                                        % for curQuality in sorted(anyQualityList):
+                                                        <option value="${curQuality}" ${'selected="selected"' if curQuality in allowed_qualities else ''}>${common.Quality.qualityStrings[curQuality]}</option>
+                                                        % endfor
+                                                    </select>
+                                                </div>
+                                                <div style="text-align: left; float: left;">
+                                                    <h5>Preferred</h5>
+                                                    <% bestQualityList = filter(lambda x: x >= common.Quality.SDTV, common.Quality.qualityStrings) %>
+                                                    <select id="preferred_qualities" name="preferred_qualities" multiple="multiple" size="${len(bestQualityList)}" class="form-control form-control-inline input-sm">
+                                                        % for curQuality in sorted(bestQualityList):
+                                                        <option value="${curQuality}" ${'selected="selected"' if curQuality in preferred_qualities else ''}>${common.Quality.qualityStrings[curQuality]}</option>
+                                                        % endfor
+                                                    </select>
+                                                </div>
+                                            </div>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_flatten_folders">
+                                        <span class="component-title">Season folders (<span class="separator">*</span>)</span>
+                                        <span class="component-desc">
+                                            <select id="" name="flatten_folders" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if flatten_folders_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if flatten_folders_value == 0 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if flatten_folders_value == 1 else ''}>No</option>
+                                            </select><br>
+                                            Group episodes by season folder (set to "No" to store in a single folder).
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_paused">
+                                        <span class="component-title">Paused</span>
+                                        <span class="component-desc">
+                                            <select id="edit_paused" name="paused" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if paused_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if paused_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if paused_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Pause these shows (Medusa will not download episodes).
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_default_ep_status">
+                                        <span class="component-title">Default Episode Status</span>
+                                        <span class="component-desc">
+                                            <select id="edit_default_ep_status" name="default_ep_status" class="form-control form-control-inline input-sm">
+                                                <option value="keep">&lt; Keep &gt;</option>
+                                                % for cur_status in [WANTED, SKIPPED, IGNORED]:
+                                                <option value="${cur_status}" ${'selected="selected"' if cur_status == default_ep_status_value else ''}>${statusStrings[cur_status]}</option>
                                                 % endfor
-                                            </select>
-                                        </div>
-                                    </div>
-                                </span>
-                            </label>
+                                            </select><br>
+                                            This will set the status for future episodes.
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_scene">
+                                        <span class="component-title">Scene Numbering</span>
+                                        <span class="component-desc">
+                                            <select id="edit_scene" name="scene" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if scene_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if scene_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if scene_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Search by scene numbering (set to "No" to search by indexer numbering).
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_anime">
+                                        <span class="component-title">Anime</span>
+                                        <span class="component-desc">
+                                            <select id="edit_anime" name="anime" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if anime_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if anime_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if anime_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Set if these shows are Anime and episodes are released as Show.265 rather than Show.S02E03
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_sports">
+                                        <span class="component-title">Sports</span>
+                                        <span class="component-desc">
+                                            <select id="edit_sports" name="sports" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if sports_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if sports_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if sports_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Set if these shows are sporting or MMA events released as Show.03.02.2010 rather than Show.S02E03.<br>
+                                            <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_air_by_date">
+                                        <span class="component-title">Air by date</span>
+                                        <span class="component-desc">
+                                            <select id="edit_air_by_date" name="air_by_date" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if air_by_date_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if air_by_date_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if air_by_date_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Set if these shows are released as Show.03.02.2010 rather than Show.S02E03.<br>
+                                            <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_dvd_order">
+                                        <span class="component-title">DVD Order</span>
+                                        <span class="component-desc">
+                                            <select id="edit_dvd_order" name="dvd_order" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if dvd_order_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if dvd_order_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if dvd_order_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            use the DVD order instead of the air order<br>
+                                            <span>A "Force Full Update" is necessary, and if you have existing episodes you need to sort them manually.</span>
+                                        </span>
+                                    </label>
+                                </div>
+                                <div class="field-pair">
+                                    <label for="edit_subtitles">
+                                        <span class="component-title">Subtitles</span>
+                                        <span class="component-desc">
+                                            <select id="edit_subtitles" name="subtitles" class="form-control form-control-inline input-sm">
+                                                <option value="keep" ${'selected="selected"' if subtitles_value is None else ''}>&lt; Keep &gt;</option>
+                                                <option value="enable" ${'selected="selected"' if subtitles_value == 1 else ''}>Yes</option>
+                                                <option value="disable" ${'selected="selected"' if subtitles_value == 0 else ''}>No</option>
+                                            </select><br>
+                                            Search for subtitles.
+                                        </span>
+                                    </label>
+                                </div>
+                                </fieldset>
+                            </div>
                         </div>
-                        <div class="field-pair">
-                            <label for="edit_flatten_folders">
-                                <span class="component-title">Season folders (<span class="separator">*</span>)</span>
-                                <span class="component-desc">
-                                    <select id="" name="flatten_folders" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if flatten_folders_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if flatten_folders_value == 0 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if flatten_folders_value == 1 else ''}>No</option>
-                                    </select><br>
-                                    Group episodes by season folder (set to "No" to store in a single folder).
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_paused">
-                                <span class="component-title">Paused</span>
-                                <span class="component-desc">
-                                    <select id="edit_paused" name="paused" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if paused_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if paused_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if paused_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Pause these shows (Medusa will not download episodes).
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_default_ep_status">
-                                <span class="component-title">Default Episode Status</span>
-                                <span class="component-desc">
-                                    <select id="edit_default_ep_status" name="default_ep_status" class="form-control form-control-inline input-sm">
-                                        <option value="keep">&lt; Keep &gt;</option>
-                                        % for cur_status in [WANTED, SKIPPED, IGNORED]:
-                                        <option value="${cur_status}" ${'selected="selected"' if cur_status == default_ep_status_value else ''}>${statusStrings[cur_status]}</option>
-                                        % endfor
-                                    </select><br>
-                                    This will set the status for future episodes.
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_scene">
-                                <span class="component-title">Scene Numbering</span>
-                                <span class="component-desc">
-                                    <select id="edit_scene" name="scene" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if scene_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if scene_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if scene_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Search by scene numbering (set to "No" to search by indexer numbering).
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_anime">
-                                <span class="component-title">Anime</span>
-                                <span class="component-desc">
-                                    <select id="edit_anime" name="anime" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if anime_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if anime_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if anime_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Set if these shows are Anime and episodes are released as Show.265 rather than Show.S02E03
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_sports">
-                                <span class="component-title">Sports</span>
-                                <span class="component-desc">
-                                    <select id="edit_sports" name="sports" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if sports_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if sports_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if sports_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Set if these shows are sporting or MMA events released as Show.03.02.2010 rather than Show.S02E03.<br>
-                                    <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_air_by_date">
-                                <span class="component-title">Air by date</span>
-                                <span class="component-desc">
-                                    <select id="edit_air_by_date" name="air_by_date" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if air_by_date_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if air_by_date_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if air_by_date_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Set if these shows are released as Show.03.02.2010 rather than Show.S02E03.<br>
-                                    <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_dvd_order">
-                                <span class="component-title">DVD Order</span>
-                                <span class="component-desc">
-                                    <select id="edit_dvd_order" name="dvd_order" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if dvd_order_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if dvd_order_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if dvd_order_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    use the DVD order instead of the air order<br>
-                                    <span>A "Force Full Update" is necessary, and if you have existing episodes you need to sort them manually.</span>
-                                </span>
-                            </label>
-                        </div>
-                        <div class="field-pair">
-                            <label for="edit_subtitles">
-                                <span class="component-title">Subtitles</span>
-                                <span class="component-desc">
-                                    <select id="edit_subtitles" name="subtitles" class="form-control form-control-inline input-sm">
-                                        <option value="keep" ${'selected="selected"' if subtitles_value is None else ''}>&lt; Keep &gt;</option>
-                                        <option value="enable" ${'selected="selected"' if subtitles_value == 1 else ''}>Yes</option>
-                                        <option value="disable" ${'selected="selected"' if subtitles_value == 0 else ''}>No</option>
-                                    </select><br>
-                                    Search for subtitles.
-                                </span>
-                            </label>
-                        </div>
-                        </fieldset>
                     </div>
-                </div>
+                    <input id="submit" type="submit" value="Save Changes" class="btn pull-left config_submitter button">
+                </form>
             </div>
-            <input id="submit" type="submit" value="Save Changes" class="btn pull-left config_submitter button">
-        </form>
-    </div>
-</div>
+        </div>
+    </div> <!-- end of col -->
+</div> <!-- end of row -->
+
 </%block>

--- a/views/partials/footer.mako
+++ b/views/partials/footer.mako
@@ -60,8 +60,21 @@
     </footer>
 % endif
 <!-- END FOOTER -->
-<div class="scroll-top-wrapper ">
+
+<div class="scroll-wrapper top">
 	<span class="scroll-top-inner">
 		<i class="glyphicon glyphicon-circle-arrow-up"></i>
+	</span>
+</div>
+
+<div class="scroll-wrapper left">
+	<span class="scroll-left-inner">
+		<i id="scroll-left" class="glyphicon glyphicon-circle-arrow-left"></i>
+	</span>
+</div>
+
+<div class="scroll-wrapper right">
+	<span class="scroll-right-inner">
+		<i id="scroll-right" class="glyphicon glyphicon-circle-arrow-right"></i>
 	</span>
 </div>

--- a/views/snatchSelection.mako
+++ b/views/snatchSelection.mako
@@ -17,7 +17,7 @@
 <%include file="/partials/showheader.mako"/>
 
 <div class="row">
-    <div class="col-md-12">
+    <div class="col-md-12 horizontal-scroll">
         <div class="clearfix"></div><!-- .clearfix //-->
         <div id="wrapper" data-history-toggle="hide">
             <div id="container">


### PR DESCRIPTION
This will result in only showing a scrollbar for tables that exceed the page viewport.

* Added buttons at the bottom of the page, when a scrollbar is visible, similar to the one that has been implement to scroll all the way up.

Biggest advantage of this is, that we will not have a messed up overal UI, like needing to scroll to the right for the menu button on mobile.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

# TODO:
- [x] Implement for displayShow
- [x] Implement for snatchSelection
- [x] Implement for massUpdate
- [x] Test with multiple tables on a page, that exceed the width.
- [ ] ..

![image](https://user-images.githubusercontent.com/1331394/29315353-2b096d9e-81c3-11e7-8780-154dbd900ced.png)

Maybe I wasn't clear before. But the buttons only _should_ appear when there are scrollbars visible. It's implemented, and works pretty well on screen size changes. There are some small issues to be worked out on screen initialization.

As Fernandog showed me in #3016, we already have class for this, named `horizontal-scroll`.
```css
.horizontal-scroll {
    overflow-x: auto;
}
```

I'll see if I can create something easy applyable and still keep the scroll-left-right buttons.