### PR TITLE
Revert "Transmision Retry session"

### DIFF
--- a/medusa/clients/torrent/transmission_client.py
+++ b/medusa/clients/torrent/transmission_client.py
@@ -19,9 +19,8 @@ from medusa.helpers import (
 )
 from medusa.logger.adapters.style import BraceAdapter
 
-from requests.adapters import HTTPAdapter
 from requests.compat import urljoin
-from requests.packages.urllib3.util.retry import Retry
+
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
@@ -44,24 +43,6 @@ class TransmissionAPI(GenericClient):
 
         self.rpcurl = self.rpcurl.strip('/')
         self.url = urljoin(self.host, self.rpcurl + '/rpc')
-
-        # Adds retry when '409 - Conflict' status code
-        # https://github.com/transmission/transmission/issues/231#issuecomment-296385711
-        retry_count = 3
-
-        # POST needs to be whitelisted as it's not default
-        # urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#urllib3.util.retry.Retry.DEFAULT_METHOD_WHITELIST
-        method_whitelist = Retry.DEFAULT_METHOD_WHITELIST.union({'POST'})
-
-        retry = Retry(total=retry_count,
-                      read=retry_count,
-                      connect=retry_count,
-                      backoff_factor=0.3,
-                      status_forcelist=(409,),
-                      method_whitelist=method_whitelist)
-        adapter = HTTPAdapter(max_retries=retry)
-        self.session.mount('http://', adapter)
-        self.session.mount('https://', adapter)
 
     def check_response(self):
         """Check if response is a valid json and its a success one."""


### PR DESCRIPTION
Need to revert as today Transmission has an issue that we don't send the x-TrasmissionSessionID in header and it returns 409 because of that. So that need to be fixed before adding the retry to fix the actual 409 issue
@p0psicles 