### PR TITLE
Skip propers for wrong season/result

### DIFF
--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -159,6 +159,14 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 log.info('Skipping non-proper: {name}', {'name': cur_proper.name})
                 continue
 
+            if not cur_proper.show.episodes.get(cur_proper.parse_result.season_number) or \
+                    any([ep for ep in cur_proper.parse_result.episode_numbers
+                         if not cur_proper.show.episodes[cur_proper.parse_result.season_number].get(ep)]):
+                log.info('Skipping proper for wrong season/episode: {name}', {'name': cur_proper.name})
+                if cur_proper.name not in processed_propers_names:
+                    self.processed_propers.append({'name': cur_proper.name, 'date': cur_proper.date})
+                continue
+
             log.debug('Proper tags for {proper}: {tags}', {
                 'proper': cur_proper.name,
                 'tags': cur_proper.parse_result.proper_tags

--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -163,8 +163,6 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                     any([ep for ep in cur_proper.parse_result.episode_numbers
                          if not cur_proper.show.episodes[cur_proper.parse_result.season_number].get(ep)]):
                 log.info('Skipping proper for wrong season/episode: {name}', {'name': cur_proper.name})
-                if cur_proper.name not in processed_propers_names:
-                    self.processed_propers.append({'name': cur_proper.name, 'date': cur_proper.date})
                 continue
 
             log.debug('Proper tags for {proper}: {tags}', {


### PR DESCRIPTION
cur_proper.show.episodes is the episode we are searching for.
cur_proper.parse_result is the possible proper parsed result

```
FINDPROPERS :: [Speedcd] :: [4c2ace8] Search string: Show S07E06 PROPER
FINDPROPERS :: [4c2ace8] Skipping proper for wrong season/episode: Show.S06E02.PROPER.HDTV.x264-BATV
FINDPROPERS :: [4c2ace8] Skipping proper for wrong season/episode: Show.S05E04.PROPER.720p.HDTV.x264-0SEC
```