### PR TITLE
Fix HeBits title split issue

### DIFF
--- a/medusa/providers/torrent/html/hebits.py
+++ b/medusa/providers/torrent/html/hebits.py
@@ -124,7 +124,12 @@ class HeBitsProvider(TorrentProvider):
             for row in torrent_rows:
                 try:
                     heb_eng_title = row.find('div', class_='bTitle').find(href=re.compile('details\.php')).find('b').get_text()
-                    title = heb_eng_title.split('/')[1].strip()
+                    if '/' in heb_eng_title:
+                        title = heb_eng_title.split('/')[1].strip()
+                    elif '\\' in heb_eng_title:
+                        title = heb_eng_title.split('\\')[1].strip()
+                    else:
+                        continue
 
                     download_id = row.find('div', class_='bTitle').find(href=re.compile('download\.php'))['href']
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Seems that there are some titles that have a backslash ('\\') separator between the English and Hebrew title instead of regular slash ('/'). So I had to add this case to prevent out of bound error. I also added that in case none of those exist, it will skip that result.