### PR TITLE
Allow redirects for Torrent9 provider

### DIFF
--- a/medusa/providers/torrent/html/torrent9.py
+++ b/medusa/providers/torrent/html/torrent9.py
@@ -76,7 +76,7 @@ class Torrent9Provider(TorrentProvider):
                 else:
                     search_url = self.urls['daily']
 
-                response = self.session.get(search_url, allow_redirects=False)
+                response = self.session.get(search_url)
                 if not response or not response.text:
                     log.debug('No data returned from provider')
                     continue

--- a/medusa/session/hooks.py
+++ b/medusa/session/hooks.py
@@ -6,9 +6,10 @@ import logging
 
 import cfscrape
 
+from medusa.logger.adapters.style import BraceAdapter
+
 import requests
 from requests.utils import dict_from_cookiejar
-from medusa.logger.adapters.style import BraceAdapter
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

I don't know why it was set to False, but it breaks the provider.