### PR TITLE
Fix start when git_reset_branches config setting is empty

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -420,7 +420,7 @@ class Application(object):
             # git reset on update
             app.GIT_RESET = bool(check_setting_int(app.CFG, 'General', 'git_reset', 1))
             app.GIT_RESET_BRANCHES = check_setting_list(app.CFG, 'General', 'git_reset_branches', app.GIT_RESET_BRANCHES)
-            if app.GIT_RESET_BRANCHES[0] == '':
+            if not app.GIT_RESET_BRANCHES:
                 app.GIT_RESET_BRANCHES = []
 
             # current git branch


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

```
Traceback (most recent call last):
  File "/usr/local/sickbeard-custom/var/SickBeard/SickBeard.py", line 7, in <module>
    main()
  File "/volumeUSB1/usbshare/applications/sickrage/SickBeard/medusa/__main__.py", line 2104, in main
    application.start(sys.argv[1:])
  File "/volumeUSB1/usbshare/applications/sickrage/SickBeard/medusa/__main__.py", line 297, in start
    self.initialize(console_logging=self.console_logging)
  File "/volumeUSB1/usbshare/applications/sickrage/SickBeard/medusa/__main__.py", line 423, in initialize
    if app.GIT_RESET_BRANCHES[0] == '':
IndexError: string index out of range
```