### PR TITLE
Fix double slash in rtorrent-python. Should fix #3084

### DIFF
--- a/lib/rtorrent/lib/xmlrpc/requests_transport.py
+++ b/lib/rtorrent/lib/xmlrpc/requests_transport.py
@@ -110,9 +110,9 @@ class RequestsTransport(xmlrpc_client.Transport):
         # Need to be done because the schema(http or https) is lost in
         # xmlrpc.Transport's init.
         if self._use_https:
-            url = "https://{host}/{handler}".format(host=host, handler=handler)
+            url = "https://{host}{handler}".format(host=host, handler=handler)
         else:
-            url = "http://{host}/{handler}".format(host=host, handler=handler)
+            url = "http://{host}{handler}".format(host=host, handler=handler)
 
         # TODO Construct kwargs query instead
         try:


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
