### PR TITLE
Fix newznab and torznab attributes not being parsed

### DIFF
--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -187,7 +187,12 @@ class NewznabProvider(NZBProvider):
                                 item_size = size_regex.group() if size_regex else -1
                             else:
                                 item_size = item.size.get_text(strip=True) if item.size else -1
-                                for attr in item('newznab:attr') + item('torznab:attr'):
+                                # Use regex to find name-spaced tags
+                                # see BeautifulSoup4 bug 1720605
+                                # https://bugs.launchpad.net/beautifulsoup/+bug/1720605
+                                newznab_attrs = item(re.compile('newznab:attr'))
+                                torznab_attrs = item(re.compile('torznab:attr'))
+                                for attr in newznab_attrs + torznab_attrs:
                                     item_size = attr['value'] if attr['name'] == 'size' else item_size
                                     seeders = try_int(attr['value']) if attr['name'] == 'seeders' else seeders
                                     peers = try_int(attr['value']) if attr['name'] == 'peers' else None


### PR DESCRIPTION
`newznab` and `torznab` namespaced tags are not parsed properly by BeautifulSoup 4 v4.6.0
Using a regex to find tags works until the bug is fixed.
https://bugs.launchpad.net/beautifulsoup/+bug/1720605