### PR TITLE
don't use absolute episode numbering to season/ep transformation, whe…

### DIFF
--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -167,6 +167,7 @@ class NameParser(object):
             log.debug('Scene numbering enabled series {name} is anime',
                       {'name': result.show.name})
             scene_season = scene_exceptions.get_scene_exception_by_name(result.series_name)[1]
+
             for absolute_episode in result.ab_episode_numbers:
                 a = absolute_episode
 
@@ -175,12 +176,24 @@ class NameParser(object):
                                                                        result.show.indexer, absolute_episode,
                                                                        True, scene_season)
 
-                # Translate the absolute episode number, back to the indexers season and episode.
-                (season, episode) = helpers.get_all_episodes_from_absolute_number(result.show, [a])
-                log.debug(
-                    'Scene numbering enabled series {name} using indexer for absolute {absolute}: {ep}',
-                    {'name': result.show.name, 'absolute': a, 'ep': episode_num(season, episode, 'absolute')}
-                )
+                # Apparentle we got a scene_season using the season scene exceptions. If we also do not have a season
+                # parsed, guessit made a 'mistake' and it should have set the season with the value.
+                if result.season_number is None and scene_season:
+                    season = scene_season
+                    episode = [a]
+                    log.debug(
+                        'Detected a scene_season without a season number, asuming the episode is the scene_absolute.'
+                        'For series {name} using scene season {scene_season} and scene_absolute {scene_absolute}: {ep}',
+                        {'name': result.show.name, 'scene_season': scene_season,
+                         'scene_absolute': a, 'ep': episode_num(season, episode, 'absolute')}
+                    )
+                else:
+                    # Translate the absolute episode number, back to the indexers season and episode.
+                    (season, episode) = helpers.get_all_episodes_from_absolute_number(result.show, [a])
+                    log.debug(
+                        'Scene numbering enabled series {name} using indexer for absolute {absolute}: {ep}',
+                        {'name': result.show.name, 'absolute': a, 'ep': episode_num(season, episode, 'absolute')}
+                    )
 
                 new_absolute_numbers.append(a)
                 new_episode_numbers.extend(episode)

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -166,7 +166,7 @@ class NameParser(object):
         elif result.show.is_anime and result.is_anime:
             log.debug('Scene numbering enabled series {name} is anime',
                       {'name': result.show.name})
-            scene_season = scene_exceptions.get_scene_exception_by_name(result.series_name)[1]
+            scene_season = scene_exceptions.get_scene_exceptions_by_name(result.series_name)[0][1]
 
             for absolute_episode in result.ab_episode_numbers:
                 a = absolute_episode
@@ -176,16 +176,17 @@ class NameParser(object):
                                                                        result.show.indexer, absolute_episode,
                                                                        True, scene_season)
 
-                # Apparentle we got a scene_season using the season scene exceptions. If we also do not have a season
+                # Apparently we got a scene_season using the season scene exceptions. If we also do not have a season
                 # parsed, guessit made a 'mistake' and it should have set the season with the value.
-                if result.season_number is None and scene_season:
+                # This is required for titles like: '[HorribleSubs].Kekkai.Sensen.&.Beyond.-.01.[1080p].mkv'
+                if result.season_number is None and scene_season > 0:
                     season = scene_season
                     episode = [a]
                     log.debug(
-                        'Detected a scene_season without a season number, asuming the episode is the scene_absolute.'
-                        'For series {name} using scene season {scene_season} and scene_absolute {scene_absolute}: {ep}',
-                        {'name': result.show.name, 'scene_season': scene_season,
-                         'scene_absolute': a, 'ep': episode_num(season, episode, 'absolute')}
+                        'Detected a season scene exception [{series_name} -> {scene_season}] without a '
+                        'season number in the title, '
+                        'assuming the episode # [{scene_absolute}] is the scene_absolute #.',
+                        {'series_name': result.series_name, 'scene_season': scene_season, 'scene_absolute': a}
                     )
                 else:
                     # Translate the absolute episode number, back to the indexers season and episode.

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -171,11 +171,6 @@ class NameParser(object):
             for absolute_episode in result.ab_episode_numbers:
                 a = absolute_episode
 
-                if result.show.is_scene:
-                    a = scene_numbering.get_indexer_absolute_numbering(result.show.indexerid,
-                                                                       result.show.indexer, absolute_episode,
-                                                                       True, scene_season)
-
                 # Apparently we got a scene_season using the season scene exceptions. If we also do not have a season
                 # parsed, guessit made a 'mistake' and it should have set the season with the value.
                 # This is required for titles like: '[HorribleSubs].Kekkai.Sensen.&.Beyond.-.01.[1080p].mkv'
@@ -189,6 +184,11 @@ class NameParser(object):
                         {'series_name': result.series_name, 'scene_season': scene_season, 'scene_absolute': a}
                     )
                 else:
+                    if result.show.is_scene:
+                        a = scene_numbering.get_indexer_absolute_numbering(result.show.indexerid,
+                                                                           result.show.indexer, absolute_episode,
+                                                                           True, scene_season)
+
                     # Translate the absolute episode number, back to the indexers season and episode.
                     (season, episode) = helpers.get_all_episodes_from_absolute_number(result.show, [a])
                     log.debug(

--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -202,7 +202,7 @@ def set_scene_numbering(indexer_id, indexer, season=None, episode=None,  # pylin
 
     main_db_con = db.DBConnection()
     # Season/episode can be 0 so can't check "if season"
-    if season is not None and episode is not None:
+    if season is not None and episode is not None and absolute_number is None:
         main_db_con.action(
             "INSERT OR IGNORE INTO scene_numbering (indexer, indexer_id, season, episode) VALUES (?,?,?,?)",
             [indexer, indexer_id, season, episode])
@@ -211,7 +211,7 @@ def set_scene_numbering(indexer_id, indexer, season=None, episode=None,  # pylin
             "UPDATE scene_numbering SET scene_season = ?, scene_episode = ? WHERE indexer = ? and indexer_id = ? and season = ? and episode = ?",
             [sceneSeason, sceneEpisode, indexer, indexer_id, season, episode])
     # absolute_number can be 0 so can't check "if absolute_number"
-    elif absolute_number is not None:
+    else:
         main_db_con.action(
             "INSERT OR IGNORE INTO scene_numbering (indexer, indexer_id, absolute_number) VALUES (?,?,?)",
             [indexer, indexer_id, absolute_number])


### PR DESCRIPTION
…n scene_season is detected.

This can happen for anime titles which map to a season scene name.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Potential fix for #3152 

Wil fix searches for releases:
* `[HorribleSubs].Kekkai.Sensen.&.Beyond.-.01.[1080p].mkv`
* `Shokugeki.no.Soma.S3.-.01.[1080p].mkv` (food wars)
