### PR TITLE
Fix associated files not being deleted on replace. Fixes #3157

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -326,13 +326,8 @@ class PostProcessor(object):
             file_list = files
 
         # also delete associated files, works only for 1 file
-        if associated_files and len(files) == 1:
-            file_list += self.list_associated_files(files[0], subfolders=True)
-
-        if not file_list:
-            self.log(u'There were no files associated with {0}, not deleting anything'.format
-                     (files), logger.DEBUG)
-            return
+        if associated_files and len(file_list) == 1:
+            file_list += self.list_associated_files(file_list[0], subfolders=True)
 
         for cur_file in file_list:
             if os.path.isfile(cur_file):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

```files``` was mistakenly being used instead of ```file_list```. I also removed the ```if not file_list:``` check, as it could never happen.