### PR TITLE
Enhance EliteTracker

### DIFF
--- a/medusa/providers/torrent/html/elitetracker.py
+++ b/medusa/providers/torrent/html/elitetracker.py
@@ -161,18 +161,20 @@ class EliteTrackerProvider(TorrentProvider):
                     torrent_size = torrent('td')[labels.index('Taille')].get_text(strip=True)
                     size = convert_size(torrent_size) or -1
 
+                    # Get Pubdate if it is available. Sometimes only PRE is displayed.
+                    pubdate_raw = torrent('td')[labels.index('Nom')].find_all('div')[-1].get_text(strip=True)
+                    pubdate = None
+                    if 'PRE' not in pubdate_raw:
+                        pubdate = self.parse_pubdate(pubdate_raw, dayfirst=True)
+
                     item = {
                         'title': title,
                         'link': download_url,
                         'size': size,
                         'seeders': seeders,
                         'leechers': leechers,
+                        'pubdate': pubdate
                     }
-
-                    # Get Pubdate if it is available. Sometimes only PRE is displayed.
-                    pubdate_raw = torrent('td')[labels.index('Nom')].find_all('div')[-1].get_text(strip=True)
-                    if 'PRE' not in pubdate_raw:
-                        item['pubdate'] = self.parse_pubdate(pubdate_raw, dayfirst=True)
 
                     if mode != 'RSS':
                         log.debug('Found result: {0} with {1} seeders and {2} leechers',

--- a/medusa/providers/torrent/html/elitetracker.py
+++ b/medusa/providers/torrent/html/elitetracker.py
@@ -96,6 +96,7 @@ class EliteTrackerProvider(TorrentProvider):
                               {'search': search_string})
 
                 search_params['keywords'] = search_string
+                search_params['category'] = 30
                 response = self.session.get(self.urls['search'], params=search_params)
                 if not response or not response.text:
                     log.debug('No data returned from provider')
@@ -160,17 +161,19 @@ class EliteTrackerProvider(TorrentProvider):
                     torrent_size = torrent('td')[labels.index('Taille')].get_text(strip=True)
                     size = convert_size(torrent_size) or -1
 
-                    pubdate_raw = torrent('td')[labels.index('Nom')].find_all('div')[-1].get_text(strip=True)
-                    pubdate = self.parse_pubdate(pubdate_raw, dayfirst=True)
-
                     item = {
                         'title': title,
                         'link': download_url,
                         'size': size,
                         'seeders': seeders,
                         'leechers': leechers,
-                        'pubdate': pubdate,
                     }
+
+                    # Get Pubdate if it is available. Sometimes only PRE is displayed.
+                    pubdate_raw = torrent('td')[labels.index('Nom')].find_all('div')[-1].get_text(strip=True)
+                    if 'PRE' not in pubdate_raw:
+                        item['pubdate'] = self.parse_pubdate(pubdate_raw, dayfirst=True)
+
                     if mode != 'RSS':
                         log.debug('Found result: {0} with {1} seeders and {2} leechers',
                                   title, seeders, leechers)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

The goal of this PR is to:
* Limit search to the relevant category (ie TV Shows)
* Prevent an issue when pubdate is not available but only PRE date is, which we don't want (see attached)

![2017-10-28_170504](https://user-images.githubusercontent.com/959078/32138532-308b4174-bc02-11e7-8249-28cd4dec686b.png)

Causing the following error

```
2017-10-28 22:36:19 ERROR    SEARCHQUEUE-DAILY-SEARCH :: [EliteTracker] :: [b16e0e5] Failed parsing publishing date: PRE:16 Années, 10 Mois, 3 Semaines, 5 Jours, 7 Heures, 13 Minutes, 25 Secondes
Traceback (most recent call last):
  File "/home/www/medusa/medusa/providers/generic_provider.py", line 566, in parse_pubdate
    dt = parser.parse(pubdate, dayfirst=df, yearfirst=yf, fuzzy=True)
  File "/home/www/medusa/ext/dateutil/parser.py", line 1182, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/www/medusa/ext/dateutil/parser.py", line 559, in parse
    raise ValueError("Unknown string format")
ValueError: Unknown string format
```
