### PR TITLE
Allow no label to be set for qbittorrent client. Fixes #3211

### DIFF
--- a/medusa/clients/torrent/qbittorrent_client.py
+++ b/medusa/clients/torrent/qbittorrent_client.py
@@ -96,7 +96,7 @@ class QBittorrentAPI(GenericClient):
                 label_key.lower(): label.replace(' ', '_'),
             }
             return self._request(method='post', data=data, cookies=self.session.cookies)
-        return None
+        return True
 
     def _set_torrent_priority(self, result):
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
