### PR TITLE
Don't add artwork_prefix to image if empty string. Fixes #3225

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -355,7 +355,7 @@ class TVDBv2(BaseIndexer):
                 k = k.lower()
 
                 if v is not None:
-                    if k == 'filename':
+                    if v and k == 'filename':
                         v = urljoin(self.config['artwork_prefix'], v)
                     else:
                         v = self._clean_data(v)
@@ -567,7 +567,7 @@ class TVDBv2(BaseIndexer):
         # get series data / add the base_url to the image urls
         for k, v in series_info['series'].items():
             if v is not None:
-                if k in ['banner', 'fanart', 'poster']:
+                if v and k in ['banner', 'fanart', 'poster']:
                     v = self.config['artwork_prefix'] % v
             self._set_show_data(sid, k, v)
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This caused `filename` to not be empty and get_image() would try to download the image anyway, querying a non-existent endpoint.