### PR TITLE
Don't search subtitles for archived episodes

### DIFF
--- a/medusa/server/web/manage/handler.py
+++ b/medusa/server/web/manage/handler.py
@@ -163,7 +163,7 @@ class Manage(Home, WebRoot):
             b'FROM tv_episodes '
             b'WHERE showid = ? '
             b'AND season != 0 '
-            b'AND (status LIKE \'%4\' OR status LIKE \'%6\') '
+            b'AND status LIKE \'%4\' '
             b'AND location != \'\'',
             [int(indexer_id)]
         )
@@ -204,7 +204,7 @@ class Manage(Home, WebRoot):
             b'SELECT show_name, tv_shows.indexer_id as indexer_id, tv_episodes.subtitles subtitles '
             b'FROM tv_episodes, tv_shows '
             b'WHERE tv_shows.subtitles = 1 '
-            b'AND (tv_episodes.status LIKE \'%4\' OR tv_episodes.status LIKE \'%6\') '
+            b'AND tv_episodes.status LIKE \'%4\' '
             b'AND tv_episodes.season != 0 '
             b'AND tv_episodes.location != \'\' '
             b'AND tv_episodes.showid = tv_shows.indexer_id '
@@ -258,7 +258,7 @@ class Manage(Home, WebRoot):
                 all_eps_results = main_db_con.select(
                     b'SELECT season, episode '
                     b'FROM tv_episodes '
-                    b'WHERE (status LIKE \'%4\' OR status LIKE \'%6\') '
+                    b'WHERE status LIKE \'%4\' '
                     b'AND season != 0 '
                     b'AND showid = ? '
                     b'AND location != \'\'',

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -975,7 +975,7 @@ class SubtitlesFinder(object):
                 "WHERE "
                 "s.subtitles = 1 "
                 "AND s.paused = 0 "
-                "AND (e.status LIKE '%4' OR e.status LIKE '%6') "
+                "AND e.status LIKE '%4' "
                 "AND e.season > 0 "
                 "AND e.location != '' "
                 "AND age {} 30 "

--- a/views/config_subtitles.mako
+++ b/views/config_subtitles.mako
@@ -47,7 +47,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <span class="component-title">Search Subtitles</span>
                                 <span class="component-desc">
                                     <input type="checkbox" class="enabler" ${' checked="checked"' if app.USE_SUBTITLES else ''} id="use_subtitles" name="use_subtitles">
-                                            <p>Search subtitles for episodes with DOWNLOADED status</p>
+                                    <p>Search subtitles for episodes with DOWNLOADED status</p>
                                 </span>
                             </label>
                         </div>

--- a/views/config_subtitles.mako
+++ b/views/config_subtitles.mako
@@ -47,6 +47,7 @@ $('#subtitles_dir').fileBrowser({ title: 'Select Subtitles Download Directory' }
                                 <span class="component-title">Search Subtitles</span>
                                 <span class="component-desc">
                                     <input type="checkbox" class="enabler" ${' checked="checked"' if app.USE_SUBTITLES else ''} id="use_subtitles" name="use_subtitles">
+                                            <p>Search subtitles for episodes with DOWNLOADED status</p>
                                 </span>
                             </label>
                         </div>


### PR DESCRIPTION
Archived status is generally used to mark a episode as downloaded and watched, so it doesn't need subtitles

@duramato all good?

![image](https://user-images.githubusercontent.com/2620870/32723470-b2fdde38-c854-11e7-9ff3-66e026ad3021.png)

Related to: https://github.com/pymedusa/Medusa/issues/3248