### PR TITLE
Fix AttributeError: 'NoneType' object has no attribute 'json'

### DIFF
--- a/medusa/scene_numbering.py
+++ b/medusa/scene_numbering.py
@@ -498,7 +498,7 @@ def xem_refresh(indexer_id, indexer, force=False):
             # XEM MAP URL
             url = "http://thexem.de/map/havemap?origin={0}".format(indexerApi(indexer).config['xem_origin'])
             # TODO: Check if this needs exception handling
-            parsedJSON = safe_session.get(url).json()
+            parsedJSON = safe_session.get(url).json() if safe_session.get(url) else None
             if not parsedJSON or 'result' not in parsedJSON or 'success' not in parsedJSON['result'] or 'data' not in parsedJSON or str(indexer_id) not in parsedJSON['data']:
                 logger.log(u'No XEM data for show ID {0} on {1}'.format(indexer_id, indexerApi(indexer).name), logger.DEBUG)
                 return
@@ -507,7 +507,7 @@ def xem_refresh(indexer_id, indexer, force=False):
             url = "http://thexem.de/map/all?id={0}&origin={1}&destination=scene".format(indexer_id, indexerApi(indexer).config['xem_origin'])
 
             # TODO: Check if this needs exception handling.
-            parsedJSON = safe_session.get(url).json()
+            parsedJSON = safe_session.get(url).json() if safe_session.get(url) else None
             if not parsedJSON or 'result' not in parsedJSON or 'success' not in parsedJSON['result']:
                 logger.log(u'No XEM data for show ID {0} on {1}'.format(indexer_id, indexerApi(indexer).name), logger.DEBUG)
                 return


### PR DESCRIPTION
@p0psicles what do you think?


```
2017-11-15 09:57:53 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4c3cff8] Looking up XEM scene mapping for show ID 257248 on TVDBv2
2017-11-15 09:58:23 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4c3cff8] Error requesting url http://thexem.de/map/havemap?origin=tvdb. Error: HTTPConnectionPool(host='thexem.de', port=80): Max retries exceeded with url: /map/havemap?origin=tvdb (Caused by ConnectTimeoutError(<urllib3.connection.HTTPConnection object at 0x65562b90>, 'Connection to thexem.de timed out. (connect timeout=30)'))
2017-11-15 09:58:23 WARNING  SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4c3cff8] Exception while refreshing XEM data for show ID 257248 on TVDBv2: 'NoneType' object has no attribute 'json'
2017-11-15 09:58:24 DEBUG    SEARCHQUEUE-DAILY-SEARCH :: [Rarbg] :: [4c3cff8] Traceback (most recent call last):
  File "/home/osmc/Medusa/medusa/scene_numbering.py", line 501, in xem_refresh
    parsedJSON = safe_session.get(url).json()
AttributeError: 'NoneType' object has no attribute 'json'
```