### PR TITLE
Fix EliteTracker empty result

### DIFF
--- a/medusa/providers/torrent/html/elitetracker.py
+++ b/medusa/providers/torrent/html/elitetracker.py
@@ -124,7 +124,7 @@ class EliteTrackerProvider(TorrentProvider):
             torrent_rows = torrent_table('tr') if torrent_table else []
 
             # Continue only if at least one release is found
-            if len(torrent_rows) < 2:
+            if torrent_rows[1].get_text(strip=True) == 'Aucun Resultat':
                 log.debug('Data returned from provider does not contain any torrents')
                 return items
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Currently if no result is found the following error occurs:

```
2017-11-19 01:49:03 ERROR    SEARCHQUEUE-BACKLOG-270915 :: [EliteTracker] :: [b16e0e5] Failed parsing provider. Traceback: 'Traceback (most recent call last):\n  File "/home/www/medusa/medusa/providers/torrent/html/elitetracker.py", line 138, in parse\n    title = torrent.find(class_=\'tooltip-content\').div.get_text(strip=True)\nAttributeError: \'NoneType\' object has no attribute \'div\'\n'
Traceback (most recent call last):
  File "/home/www/medusa/medusa/providers/torrent/html/elitetracker.py", line 138, in parse
    title = torrent.find(class_='tooltip-content').div.get_text(strip=True)
AttributeError: 'NoneType' object has no attribute 'div'
```

The current check of len < 2 doesn't work and neither does increasing or decreasing it because a single result has a len of 2 or more and no result also has a len of 2, the 2nd element being "Aucun resultat" (No Result)