### PR TITLE
Fix moving torrent feature not working with remote client

### DIFF
--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -631,11 +631,6 @@ class ProcessResult(object):
     @staticmethod
     def move_torrent(info_hash, release_names):
         """Move torrent to a given seeding folder after PP."""
-        if not os.path.isdir(app.TORRENT_SEED_LOCATION):
-            logger.log('Not possible to move torrent after post-processing because seed location is invalid',
-                       logger.WARNING)
-            return False
-
         if release_names:
             # Log 'release' or 'releases'
             s = 's' if len(release_names) > 1 else ''


### PR DESCRIPTION
I can't check `isdir` for a remote location
If folder is not valid Transmission will return an error

Related to https://github.com/pymedusa/Medusa/issues/3295