### PR TITLE
Join categories list into a comma separated list.

### DIFF
--- a/medusa/helpers/utils.py
+++ b/medusa/helpers/utils.py
@@ -25,4 +25,4 @@ def generate(it):
 
 def split_and_strip(value, sep=','):
     """Split a value based on the passed separator, and remove whitespace for each individual value."""
-    return [_.strip() for _ in value.split(sep)] if isinstance(value, string_types) else value
+    return [_.strip() for _ in value.split(sep) if value != ''] if isinstance(value, string_types) else value

--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -100,7 +100,7 @@ class NewznabProvider(NZBProvider):
             't': 'search',
             'limit': 100,
             'offset': 0,
-            'cat': self.cat_ids,
+            'cat': ','.join(self.cat_ids),
             'maxage': app.USENET_RETENTION
         }
 


### PR DESCRIPTION
If passing the cats as a list to requests.get(), it will add them like: `cats=5000&cats=5020&cats=5030`.
This will result in the backend matching if the searched show matches all of the passed cats, not if it's in one of them.

passing it comma separated like: `cats=5000,5020,5030` potentially gives more results.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
