### PR TITLE
Transmission: Fix remove torrents by idle timeout

### DIFF
--- a/medusa/clients/torrent/deluge_client.py
+++ b/medusa/clients/torrent/deluge_client.py
@@ -14,6 +14,7 @@ from medusa.helpers import (
     is_already_processed_media,
     is_info_hash_in_history,
     is_info_hash_processed,
+    is_media_file,
 )
 from medusa.logger.adapters.style import BraceAdapter
 from requests.exceptions import RequestException
@@ -37,6 +38,8 @@ def read_torrent_status(torrent_data):
         for i in details['files']:
             # Check if media was processed
             # OR check hash in case of RARed torrents
+            if not is_media_file(i['path']):
+                continue
             if is_already_processed_media(i['path']) or is_info_hash_processed(info_hash):
                 to_remove = True
 

--- a/medusa/clients/torrent/transmission_client.py
+++ b/medusa/clients/torrent/transmission_client.py
@@ -17,6 +17,7 @@ from medusa.helpers import (
     is_already_processed_media,
     is_info_hash_in_history,
     is_info_hash_processed,
+    is_media_file,
 )
 from medusa.logger.adapters.style import BraceAdapter
 
@@ -294,6 +295,8 @@ class TransmissionAPI(GenericClient):
             for i in torrent['files']:
                 # Check if media was processed
                 # OR check hash in case of RARed torrents
+                if not is_media_file(i['name']):
+                    continue
                 if is_already_processed_media(i['name']) or is_info_hash_processed(str(torrent['hashString'])):
                     to_remove = True
 

--- a/medusa/clients/torrent/transmission_client.py
+++ b/medusa/clients/torrent/transmission_client.py
@@ -314,7 +314,7 @@ class TransmissionAPI(GenericClient):
                 if torrent['percentDone'] == 1:
                     # Check if torrent is stopped because of idle timeout
                     seed_timeouted = False
-                    if torrent['activityDate'] > 0 and torrent['seedIdleLimit'] > 0 and torrent['seedIdleLimit'] > 0:
+                    if torrent['activityDate'] > 0 and torrent['seedIdleLimit'] > 0:
                         last_activity_date = datetime.fromtimestamp(torrent['activityDate'])
                         seed_timeouted = (datetime.now() - timedelta(
                             minutes=torrent['seedIdleLimit'])) > last_activity_date

--- a/medusa/clients/torrent/transmission_client.py
+++ b/medusa/clients/torrent/transmission_client.py
@@ -316,13 +316,13 @@ class TransmissionAPI(GenericClient):
                 status = 'stopped'
                 if torrent['percentDone'] == 1:
                     # Check if torrent is stopped because of idle timeout
-                    seed_timeouted = False
+                    seed_timed_out = False
                     if torrent['activityDate'] > 0 and torrent['seedIdleLimit'] > 0:
                         last_activity_date = datetime.fromtimestamp(torrent['activityDate'])
-                        seed_timeouted = (datetime.now() - timedelta(
+                        seed_timed_out = (datetime.now() - timedelta(
                             minutes=torrent['seedIdleLimit'])) > last_activity_date
 
-                    if torrent.get('isFinished') or seed_timeouted:
+                    if torrent.get('isFinished') or seed_timed_out:
                         status = 'completed'
             elif torrent['status'] == 6:
                 status = 'seeding'

--- a/medusa/helpers/__init__.py
+++ b/medusa/helpers/__init__.py
@@ -1790,8 +1790,6 @@ def get_broken_providers():
 
 def is_already_processed_media(full_filename):
     """Check if resource was already processed."""
-    if not is_media_file(str(full_filename)):
-        return False
     main_db_con = db.DBConnection()
     history_result = main_db_con.select('SELECT action FROM history '
                                         "WHERE action LIKE '%04' "


### PR DESCRIPTION
`isFinished` is not set to True when idle timeout (torrent is stopend seeding when inactive for N minutes)
Got the wrong information from #transmission IRC

@duramato also fixes https://github.com/pymedusa/Medusa/issues/3146

TORRENTCHECKER :: [bc468f4] Torrent completed and reached minimum ratio: [0.467/3.000] or seed idle limit: [10080 min]. Removing it: [Show.S03E10.MULTi.1080p.WEB.x264-CiELOS]


Had to change the is_media_file check because when it wasn't a media file, the is_info_hash_processed is called. But it shouldn't