### PR TITLE
NMA: proper handle status code

### DIFF
--- a/medusa/notifiers/nma.py
+++ b/medusa/notifiers/nma.py
@@ -22,7 +22,7 @@ class Notifier(object):
     def notify_snatch(self, ep_name, is_proper):
         if app.NMA_NOTIFY_ONSNATCH:
             self._sendNMA(nma_api=None, nma_priority=None,
-                          event=common.notifyStrings[(common.NOTIFY_SNATCH,common.NOTIFY_SNATCH_PROPER)[is_proper]],
+                          event=common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]],
                           message=ep_name)
 
     def notify_download(self, ep_name):

--- a/medusa/notifiers/nma.py
+++ b/medusa/notifiers/nma.py
@@ -84,6 +84,6 @@ class Notifier(object):
         elif response_status_code == u'400':
             log.error(u'{0} Data supplied is in the wrong format, invalid length or null', log_message)
         else:
-            log.warning(u'{0} Status code: {0}', response_status_code)
+            log.warning(u'{0} Status code: {1}', log_message, response_status_code)
         return False
 

--- a/medusa/notifiers/nma.py
+++ b/medusa/notifiers/nma.py
@@ -3,8 +3,11 @@
 import logging
 
 from medusa import app, common
+from medusa.helper.common import http_code_description
 from medusa.logger.adapters.style import BraceAdapter
+
 from pynma import pynma
+
 from six import text_type
 
 log = BraceAdapter(logging.getLogger(__name__))
@@ -18,7 +21,8 @@ class Notifier(object):
 
     def notify_snatch(self, ep_name, is_proper):
         if app.NMA_NOTIFY_ONSNATCH:
-            self._sendNMA(nma_api=None, nma_priority=None, event=common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]],
+            self._sendNMA(nma_api=None, nma_priority=None,
+                          event=common.notifyStrings[(common.NOTIFY_SNATCH,common.NOTIFY_SNATCH_PROPER)[is_proper]],
                           message=ep_name)
 
     def notify_download(self, ep_name):
@@ -84,6 +88,5 @@ class Notifier(object):
         elif response_status_code == u'400':
             log.error(u'{0} Data supplied is in the wrong format, invalid length or null', log_message)
         else:
-            log.warning(u'{0} Status code: {1}', log_message, response_status_code)
+            log.warning(u'{0} Error: {1}', log_message, http_code_description(response_status_code))
         return False
-

--- a/medusa/notifiers/nma.py
+++ b/medusa/notifiers/nma.py
@@ -71,9 +71,19 @@ class Notifier(object):
                   event, message, nma_priority, batch)
         response = p.push(application=title, event=event, description=message, priority=nma_priority, batch_mode=batch)
 
-        if not response[','.join(nma_api)][u'code'] == u'200':
-            log.warning(u'NMA: Could not send notification to NotifyMyAndroid')
-            return False
-        else:
+        response_status_code = response[','.join(nma_api)][u'code']
+        log_message = u'NMA: Could not send notification to NotifyMyAndroid.'
+
+        if response_status_code == u'200':
             log.info(u'NMA: Notification sent to NotifyMyAndroid')
             return True
+        elif response_status_code == u'402':
+            log.info(u'{0} Maximum number of API calls per hour exceeded', log_message)
+        elif response_status_code == u'401':
+            log.warning(u'{0} The apikey provided is not valid', log_message)
+        elif response_status_code == u'400':
+            log.error(u'{0} Data supplied is in the wrong format, invalid length or null', log_message)
+        else:
+            log.warning(u'{0} Status code: {0}', response_status_code)
+        return False
+


### PR DESCRIPTION
@duramato

Seems really inconsistent.
Testing multiple times sometimes it works and sometimes it doesn't

```
Thread-29 :: [4c2ace8] NMA: Could not send notification to NotifyMyAndroid. Maximum number of API calls per hour exceeded
Thread-28 :: [4c2ace8] NMA: Notification sent to NotifyMyAndroid
Thread-29 :: [4c2ace8] NMA: Could not send notification to NotifyMyAndroid. Maximum number of API calls per hour exceeded
Thread-28 :: [4c2ace8] NMA: Could not send notification to NotifyMyAndroid. Maximum number of API calls per hour exceeded
Thread-29 :: [4c2ace8] NMA: Notification sent to NotifyMyAndroid
```