### PR TITLE
Add missing mappings for YggTorrent, fixes #3427

### DIFF
--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -45,6 +45,8 @@ class YggtorrentProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.translation = {
+            'seconde': 'second',
+            'secondes': 'seconds',
             'minute': 'minute',
             'minutes': 'minutes',
             'heure': 'hour',
@@ -53,6 +55,7 @@ class YggtorrentProvider(TorrentProvider):
             'jours': 'days',
             'mois': 'month',
             'an': 'year',
+            'ans': 'years',
             'années': 'years'
         }
 

--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -147,7 +147,6 @@ class YggtorrentProvider(TorrentProvider):
                         translated = self.translation.get(pubdate_match.group(2))
                         if not translated:
                             log.exception('No translation mapping available for value: {0}', pubdate_match.group(2))
-                            continue
                         else:
                             pubdate_raw = '{0} {1}'.format(pubdate_match.group(1), translated)
                             pubdate = self.parse_pubdate(pubdate_raw, human_time=True)

--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -45,6 +45,8 @@ class YggtorrentProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.translation = {
+            'minute': 'minute',
+            'minutes': 'minutes',
             'heure': 'hour',
             'heures': 'hours',
             'jour': 'day',

--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -55,8 +55,8 @@ class YggtorrentProvider(TorrentProvider):
             'jours': 'days',
             'mois': 'month',
             'an': 'year',
-            'ans': 'years',
             'année': 'year',
+            'ans': 'years',
             'années': 'years'
         }
 

--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -56,6 +56,7 @@ class YggtorrentProvider(TorrentProvider):
             'mois': 'month',
             'an': 'year',
             'ans': 'years',
+            'année': 'year',
             'années': 'years'
         }
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

I thought they were not needed since they are not to be translated but apparently they are.

Once again, I think this should be a soft warning, not a hard error preventing the snatch...

Also could we do a hotfix for this one? Otherwise I guess we'll see at least 10 tickets about this until next release.