### PR TITLE
Added pubdate parsing for iptorrents.

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -593,7 +593,7 @@ class GenericProvider(object):
 
                     # The parse method does not support decimals used with the month, months, year or years granularities.
                     if matched_granularity and matched_granularity in ('month', 'months', 'year', 'years'):
-                        matched_time = int(float(matched_time.strip()))
+                        matched_time = int(round(float(matched_time.strip())))
 
                     seconds = parse('{0} {1}'.format(matched_time, matched_granularity))
                 return datetime.now(tz.tzlocal()) - timedelta(seconds=seconds)

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -587,8 +587,15 @@ class GenericProvider(object):
                 if pubdate.lower() in now_alias:
                     seconds = 0
                 else:
-                    match = re.search(r'(?P<time>\d+\W*\w+)', pubdate)
-                    seconds = parse(match.group('time'))
+                    match = re.search(r'(?P<time>[\d.]+\W*)(?P<granularity>\w+)', pubdate)
+                    matched_time = match.group('time')
+                    matched_granularity = match.group('granularity')
+
+                    # The parse method does not support decimals used with the month, months, year or years granularities.
+                    if matched_granularity and matched_granularity in ('month', 'months', 'year', 'years'):
+                        matched_time = int(float(matched_time.strip()))
+
+                    seconds = parse('{0} {1}'.format(matched_time, matched_granularity))
                 return datetime.now(tz.tzlocal()) - timedelta(seconds=seconds)
 
             dt = parser.parse(pubdate, dayfirst=df, yearfirst=yf, fuzzy=True)

--- a/medusa/providers/torrent/html/iptorrents.py
+++ b/medusa/providers/torrent/html/iptorrents.py
@@ -132,13 +132,16 @@ class IPTorrentsProvider(TorrentProvider):
                     torrent_size = row('td')[5].text
                     size = convert_size(torrent_size) or -1
 
+                    pubdate_raw = row('td')[1].find('div').get_text().split('|')[-1].strip()
+                    pubdate = self.parse_pubdate(pubdate_raw, human_time=True)
+
                     item = {
                         'title': title,
                         'link': download_url,
                         'size': size,
                         'seeders': seeders,
                         'leechers': leechers,
-                        'pubdate': None,
+                        'pubdate': pubdate,
                     }
                     if mode != 'RSS':
                         log.debug('Found result: {0} with {1} seeders and {2} leechers',

--- a/tests/providers/test_generic_provider.py
+++ b/tests/providers/test_generic_provider.py
@@ -88,6 +88,28 @@ sut = GenericProvider('FakeProvider')
         'dayfirst': True,
         'yearfirst': True
     },
+    {  # p15: iptorrents test human date with decimal.
+        'pubdate': '4.8 minutes ago',
+        'expected': 288,
+        'human_time': True
+    },
+    {  # p16: iptorrents test human date with decimal.
+        'pubdate': '4.2 weeks ago',
+        'expected': 2540160,
+        'human_time': True
+    },
+    {  # p17: iptorrents test human date with decimal.
+       # The parse method does not support decimals for the months granularity.
+        'pubdate': '1.0 months ago',
+        'expected': 2592000,
+        'human_time': True
+    },
+    {  # p18: iptorrents test human date with decimal.
+       # The parse method does not support decimals for the years granularity.
+        'pubdate': '5.2 years ago',
+        'expected': 157680000,
+        'human_time': True
+    },
 ])
 def test_parse_pubdate(p):
     # Given

--- a/tests/providers/test_generic_provider.py
+++ b/tests/providers/test_generic_provider.py
@@ -104,9 +104,15 @@ sut = GenericProvider('FakeProvider')
         'expected': 2592000,
         'human_time': True
     },
-    {  # p18: iptorrents test human date with decimal.
+    {  # p18: iptorrents test human date with decimal. (round down)
        # The parse method does not support decimals for the years granularity.
         'pubdate': '5.2 years ago',
+        'expected': 157680000,
+        'human_time': True
+    },
+    {  # p19: iptorrents test human date with decimal. (round up)
+       # The parse method does not support decimals for the years granularity.
+        'pubdate': '4.8 years ago',
         'expected': 157680000,
         'human_time': True
     },


### PR DESCRIPTION
* Needed to enhance the parse_pubdate method a little. The parse method does not support passing decimals like 1.0 months, 4.2 years.
For for these granularity i'm casting them to int.
* Added tests.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fix #3402 