### PR TITLE
Fix Language convertion error when bad naming

### DIFF
--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -26,7 +26,7 @@ import re
 import subprocess
 import time
 
-from babelfish import Country, Language, LanguageReverseError, language_converters
+from babelfish import Country, Language, LanguageConvertError, LanguageReverseError, language_converters
 
 from dogpile.cache.api import NO_VALUE
 
@@ -792,8 +792,13 @@ def delete_unwanted_subtitles(dirpath, filename):
 
     code = filename.rsplit('.', 2)[1].lower().replace('_', '-')
     language = from_code(code, unknown='') or from_ietf_code(code)
+    found_language = None
+    try:
+        found_language = language.opensubtitles
+    except LanguageConvertError:
+        logger.info(u"Unable to convert language code '%s' for: %s", code, filename)
 
-    if language.opensubtitles not in app.SUBTITLES_LANGUAGES:
+    if found_language and found_language not in app.SUBTITLES_LANGUAGES:
         try:
             os.remove(os.path.join(dirpath, filename))
         except OSError as error:


### PR DESCRIPTION
I reproduced the issue by adding a language or `srt` to a srt file

FINDSUBTITLES :: [4c2ace8] Unable to convert language code 'srt' for: Show.S01E10.1080p.WEB.H264-STRiFE.srt.srt

Fixes: https://github.com/pymedusa/Medusa/issues/3441