### PR TITLE
Feature/broken union

### DIFF
--- a/medusa/providers/torrent/html/speedcd.py
+++ b/medusa/providers/torrent/html/speedcd.py
@@ -180,7 +180,7 @@ class SpeedCDProvider(TorrentProvider):
             'password': self.password,
         }
 
-        if not (self.urls['login_post'] and self.login_url()):
+        if not self.urls['login_post'] and not self.login_url():
             log.debug('Unable to get login URL')
             return False
 


### PR DESCRIPTION
First it did: 
 `if not self.urls['login_post'] and not self.login_url():` 
then I "improved" to:
`if not (self.urls['login_post'] and not self.login_url()):` 

but second one is not the same as `self.login_url` is not called.
Had to revert. Why is that?
@p0psicles 
