### PR TITLE
Fix PP renaming subtitle to .srt.srt

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -367,10 +367,11 @@ class PostProcessor(object):
             new_extension = 'nfo-orig'
 
         elif is_subtitle(filepath):
-            sub_code = filepath.rsplit('.', 2)
+            split_path = filepath.rsplit('.', 2)
             # len != 3 means we have a subtitle without language
-            if len(sub_code) == 3:
-                code = sub_code[1].lower().replace('_', '-')
+            if len(split_path) == 3:
+                sub_code = split_path[1]
+                code = sub_code.lower().replace('_', '-')
                 if from_code(code, unknown='') or from_ietf_code(code, unknown=''):
                     # TODO remove this hardcoded language
                     if code == 'pt-br':

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -367,14 +367,16 @@ class PostProcessor(object):
             new_extension = 'nfo-orig'
 
         elif is_subtitle(filepath):
-            sub_code = filepath.rsplit('.', 2)[1]
-            code = sub_code.lower().replace('_', '-')
-            if from_code(code, unknown='') or from_ietf_code(code, unknown=''):
-                # TODO remove this hardcoded language
-                if code == 'pt-br':
-                    code = 'pt-BR'
-                new_extension = code + '.' + extension
-                extension = sub_code + '.' + extension
+            sub_code = filepath.rsplit('.', 2)
+            # len != 3 means we have a subtitle without language
+            if len(sub_code) == 3:
+                code = sub_code[1].lower().replace('_', '-')
+                if from_code(code, unknown='') or from_ietf_code(code, unknown=''):
+                    # TODO remove this hardcoded language
+                    if code == 'pt-br':
+                        code = 'pt-BR'
+                    new_extension = code + '.' + extension
+                    extension = sub_code + '.' + extension
 
         # rename file with new basename
         if new_basename:

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -209,11 +209,9 @@ def from_ietf_code(code, unknown='und'):
     :rtype: babelfish.Language
     """
     try:
-        ietf_code = Language.fromietf(code)
+        return Language.fromietf(code)
     except (LanguageReverseError, ValueError):
         return Language(unknown) if unknown else None
-    else:
-        return ietf_code if ietf_code.country else None
 
 
 def from_country_code_to_name(code):

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -209,9 +209,11 @@ def from_ietf_code(code, unknown='und'):
     :rtype: babelfish.Language
     """
     try:
-        return Language.fromietf(code)
+        ietf_code = Language.fromietf(code)
     except (LanguageReverseError, ValueError):
         return Language(unknown) if unknown else None
+    else:
+        return ietf_code if ietf_code.country else None
 
 
 def from_country_code_to_name(code):

--- a/tests/test_rename_associated_file.py
+++ b/tests/test_rename_associated_file.py
@@ -87,6 +87,12 @@ import pytest
         'filepath': 'downloads/tv/riko.or.marty.s03e05.1080p.web-dl.mkv',
         'expected': 'media/shows/riko or marty/season 3/Riko or Marty S03E05 Episode Name.mkv'
     },
+    {  # p13: Space before subtitle extension
+        'new_path': 'media/shows/gomorra/season 3/',
+        'new_basename': 'Gomorra S03E15 Episode Name',
+        'filepath': 'downloads/tv/Gomorra S03 E11 - x264 .srt',
+        'expected': 'media/shows/gomorra/season 3/Gomorra S03E15 Episode Name.srt'
+    },
 ])
 def test_rename_associated_file(p, create_dir, monkeypatch):
     """Test rename_associated_file."""


### PR DESCRIPTION
Fixes https://github.com/pymedusa/Medusa/issues/3489
@medariox when calling from_ietf_code with `srt`, it returns an alpha3 code with `srt` in Language object but no country information 

IMO if no country, so the Language object is not a valid language, so we should not use it. 
Let me know what do you think

This issue was introduced recently as moving a SRT with no language wasn't a issue since I first started to used subtitles in Medusa/SR
