### PR TITLE
Incorrect language code for `Chinese Simplified, People's Republic of China`

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -70,7 +70,7 @@ LANGUAGE_TAGS = {
     'pt-br': 'pt-BR',
     'pt-pt': 'pt-PT',
     'es-mx': 'es-MX',
-    'zh-cn': 'zh-CH',
+    'zh-cn': 'zh-CN',
     'zh-tw': 'zh-TW',
 }
 


### PR DESCRIPTION
Language code for `Chinese Simplified, People's Republic of China` is `zh-CN` not `zh-CH`.
