### PR TITLE
Fix Torrentz2 being to strict on the category

### DIFF
--- a/medusa/providers/torrent/xml/torrentz2.py
+++ b/medusa/providers/torrent/xml/torrentz2.py
@@ -105,7 +105,7 @@ class Torrentz2Provider(TorrentProvider):
 
             for row in torrent_rows:
                 try:
-                    if row.category and 'tv' not in row.category.get_text(strip=True).lower():
+                    if row.category and 'video' not in row.category.get_text(strip=True).lower():
                         continue
 
                     title_raw = row.title.text


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Many releses only have `video` as category, this was overly restricting to only releases categorized as `video tv`.
I also tought of removing the "category" restriction altogether, as getting other results isn't the end of the world, but only `video` seems to be fine as it isn't too broad nor too restrictive.