### PR TITLE
Show anime checkbox when adding existing shows

### DIFF
--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -362,8 +362,8 @@ class HomeAddShows(Home):
         Prints out the page to add existing shows from a root dir
         """
         t = PageTemplate(rh=self, filename='addShows_addExistingShow.mako')
-        return t.render(enable_anime_options=False, title='Existing Show',
-                        header='Existing Show', topmenu='home',
+        return t.render(enable_anime_options=True, blacklist=[], whitelist=[], groups=[],
+                        title='Existing Show', header='Existing Show', topmenu='home',
                         controller='addShows', action='addExistingShow')
 
     def addShowByID(self, indexer_id, show_name=None, indexer="TVDB", which_series=None,

--- a/static/js/add-shows/add-existing-show.js
+++ b/static/js/add-shows/add-existing-show.js
@@ -1,4 +1,7 @@
 MEDUSA.addShows.addExistingShow = function() {
+    // Hide the black/whitelist, because it can only be used for a single anime show
+    $.updateBlackWhiteList(undefined);
+
     $('#tableDiv').on('click', '#checkAll', function() {
         var seasonCheck = this;
         $('.dirCheck').each(function() {

--- a/static/js/add-shows/new-show.js
+++ b/static/js/add-shows/new-show.js
@@ -150,7 +150,7 @@ MEDUSA.addShows.newShow = function() {
 
     $('#addShowButton').click(function() {
         // if they haven't picked a show don't let them submit
-        if (!$('input:radio[name="whichSeries"]:checked').val() && $('input:hidden[name="whichSeries"]').val().length !== 0) {
+        if (!$('input:radio[name="whichSeries"]:checked').val() && $('input:hidden[name="whichSeries"]').val().length == 0) {
             alert('You must choose a show to continue'); // eslint-disable-line no-alert
             return false;
         }

--- a/static/js/add-shows/new-show.js
+++ b/static/js/add-shows/new-show.js
@@ -150,7 +150,7 @@ MEDUSA.addShows.newShow = function() {
 
     $('#addShowButton').click(function() {
         // if they haven't picked a show don't let them submit
-        if (!$('input:radio[name="whichSeries"]:checked').val() && $('input:hidden[name="whichSeries"]').val().length == 0) {
+        if (!$('input:radio[name="whichSeries"]:checked').val() && $('input:hidden[name="whichSeries"]').val().length === 0) {
             alert('You must choose a show to continue'); // eslint-disable-line no-alert
             return false;
         }

--- a/views/addShows_addExistingShow.mako
+++ b/views/addShows_addExistingShow.mako
@@ -17,7 +17,7 @@
         ## @TODO: Fix this stupid hack
         <script>document.write('<ul><li><a href="' + document.location.href + '#core-component-group1">Add Existing Show</a></li></ul>')</script>
         <div id="core-component-group1" class="tab-pane active component-group">
-            <form id="addShowForm" method="post" action="addShows/addNewShow" accept-charset="utf-8">
+            <form id="addShowForm" method="post" action="addShows/addExistingShows" accept-charset="utf-8">
                 <div id="tabs">
                     <ul>
                         <li><a href="${base_url}addShows/existingShows/#tabs-1">Manage Directories</a></li>


### PR DESCRIPTION
Fix for https://github.com/pymedusa/Medusa/issues/3529

This change:
- adds anime option
-  fixes the dialog for 'you must select a show to continue' when adding an exising show with prompt for settings

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
