### PR TITLE
Import tempfile early on to ensure it is monkey patched

### DIFF
--- a/medusa/init/filesystem.py
+++ b/medusa/init/filesystem.py
@@ -8,6 +8,8 @@ import shutil
 import sys
 import tarfile
 
+# unused import but needs to be monkeypatched here
+import tempfile
 import certifi
 
 from six import binary_type, text_type

--- a/medusa/init/filesystem.py
+++ b/medusa/init/filesystem.py
@@ -8,8 +8,7 @@ import shutil
 import sys
 import tarfile
 
-# unused import but needs to be monkeypatched here
-import tempfile
+import tempfile # noqa # pylint: disable=unused-import
 import certifi
 
 from six import binary_type, text_type


### PR DESCRIPTION
- [ x ] PR is based on the DEVELOP branch
- [ x ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ x ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fixes openwrt / entware / synology issues with monkeypatching.

Deeper explanation: after printing the `f, args, type(args[0]), args[0].__type__` in the `patch_output` wrapper. 
```
<built-in function unlink> (u'/tmp/JhfhpO',) <type 'unicode'> <type 'unicode'>
<built-in function unlink> (<closed file '<fdopen>', mode 'w+b' at 0x244f600>, u'/tmp/tmpwipQTM') <type 'instance'> tempfile._TemporaryFileWrapper
<built-in function unlink> (<closed file '<fdopen>', mode 'w+b' at 0x2455850>, u'/tmp/tmpMSDo2T') <type 'instance'> tempfile._TemporaryFileWrapper
<built-in function unlink> (<closed file '<fdopen>', mode 'w+b' at 0x6a0f3c0>, u'/tmp/tmpW40zBz') <type 'instance'> tempfile._TemporaryFileWrapper
```
I suspected garbage collection issues with the cleanup with tempfiles. When I tried to drop these args, I saw that simply importing the tempfile module was sufficient (no need to drop them even).

Fixes https://github.com/pymedusa/Medusa/issues/3613, https://github.com/pymedusa/Medusa/issues/3618 and its first appearance in https://github.com/pymedusa/Medusa/issues/3567.