### PR TITLE
HOTFIX - medusa fails to start with recent python 2.7.14 version (openwrt, synology)

### DIFF
--- a/medusa/init/filesystem.py
+++ b/medusa/init/filesystem.py
@@ -8,6 +8,8 @@ import shutil
 import sys
 import tarfile
 
+# unused import but needs to be monkeypatched here
+import tempfile
 import certifi
 
 from six import binary_type, text_type

--- a/medusa/init/filesystem.py
+++ b/medusa/init/filesystem.py
@@ -8,8 +8,7 @@ import shutil
 import sys
 import tarfile
 
-# unused import but needs to be monkeypatched here
-import tempfile
+import tempfile # noqa # pylint: disable=unused-import
 import certifi
 
 from six import binary_type, text_type


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
No, because hotfix for master.
See https://github.com/pymedusa/Medusa/pull/3619 for the develop version.

Tested by me on x64 entware
Tested by Kilay on Synology [here](https://github.com/SynoCommunity/spksrc/issues/3111#issuecomment-358290028)