### PR TITLE
Added a new function get_season_scene_exceptions() to retrieve scene …

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -44,7 +44,7 @@ from medusa.name_parser.parser import (
     InvalidShowException,
     NameParser,
 )
-from medusa.scene_exceptions import get_scene_exceptions
+from medusa.scene_exceptions import get_season_scene_exceptions
 from medusa.search import PROPER_SEARCH
 from medusa.session.core import MedusaSafeSession
 from medusa.session.hooks import cloudflare
@@ -639,7 +639,7 @@ class GenericProvider(object):
             elif episode.series.anime:
                 # If the showname is a season scene exception, we want to use the indexer episode number.
                 if (episode.scene_season > 1 and
-                        show_name in get_scene_exceptions(episode.series, episode.scene_season)):
+                        show_name in get_season_scene_exceptions(episode.series, episode.scene_season)):
                     # This is apparently a season exception, let's use the scene_episode instead of absolute
                     ep = episode.scene_episode
                 else:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -95,7 +95,7 @@ def set_last_refresh(source):
 
 
 def get_scene_exceptions(series_obj, season=-1):
-    """Get scene exceptions from exceptions_cache for an indexer id."""
+    """Get scene exceptions from exceptions_cache for a series."""
     exceptions_list = exceptions_cache[(series_obj.indexer, series_obj.series_id)][season]
 
     if season != -1 and not exceptions_list:
@@ -108,10 +108,10 @@ def get_scene_exceptions(series_obj, season=-1):
 
 def get_season_scene_exceptions(series_obj, season=-1):
     """
-    Get season scene exceptions from exceptions_cache for an indexer id.
+    Get season scene exceptions from exceptions_cache for a series.
 
-    Use this method if you expect to get back a season exception, or a series exception. But without any fallback between the to.
-    As opposed to the function get_scene_exceptions.
+    Use this method if you expect to get back a season exception, or a series exception.
+    But without any fallback between the two. As opposed to the function get_scene_exceptions.
     :param series_obj: A Series object.
     :param season: The season to return exceptions for. Or -1 for the series exceptions.
 

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -108,7 +108,7 @@ def get_scene_exceptions(series_obj, season=-1):
 
 def get_season_scene_exceptions(series_obj, season=-1):
     """
-    Get sason scene exceptions from exceptions_cache for an indexer id.
+    Get season scene exceptions from exceptions_cache for an indexer id.
 
     Use this method if you expect to get back a season exception, or a series exception. But without any fallback between the to.
     As opposed to the function get_scene_exceptions.

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -106,6 +106,24 @@ def get_scene_exceptions(series_obj, season=-1):
     return set(exceptions_list)
 
 
+def get_season_scene_exceptions(series_obj, season=-1):
+    """
+    Get sason scene exceptions from exceptions_cache for an indexer id.
+
+    Use this method if you expect to get back a season exception, or a series exception. But without any fallback between the to.
+    As opposed to the function get_scene_exceptions.
+    :param series_obj: A Series object.
+    :param season: The season to return exceptions for. Or -1 for the series exceptions.
+
+    :return: A set of exception names.
+    """
+    exceptions_list = exceptions_cache[(series_obj.indexer, series_obj.series_id)][season]
+
+    # Return a set to avoid duplicates and it makes a copy of the list so the
+    # original doesn't get modified
+    return set(exceptions_list)
+
+
 def get_all_scene_exceptions(series_obj):
     """
     Get all scene exceptions for a show ID.


### PR DESCRIPTION
…exceptions, without falling back to show exceptions.

This is an issue when users have added the show it self as a series exception.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fix for #3617