### PR TITLE
Added Medusa Icon to Slack Notifications

### DIFF
--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -92,7 +92,7 @@ class Notifier(object):
 
         headers = {b'Content-Type': b'application/json'}
         try:
-            r = requests.post(webhook, data=json.dumps(dict(text=message, username='MedusaBot')), headers=headers)
+            r = requests.post(webhook, data=json.dumps(dict(text=message, username='MedusaBot', icon_url='https://raw.githubusercontent.com/pymedusa/Medusa/master/static/images/ico/favicon-310.png')), headers=headers)
             r.raise_for_status()
         except Exception:
             log.exception('Error Sending Slack message')

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 
+import json
 import logging
 from medusa import app, common
 from medusa.logger.adapters.style import BraceAdapter
@@ -97,7 +98,7 @@ class Notifier(object):
         }
 
         try:
-            r = requests.post(webhook, data, headers=headers)
+            r = requests.post(webhook, data=json.dumps(data), headers=headers)
             r.raise_for_status()
         except Exception:
             log.exception('Error Sending Slack message')

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -92,7 +92,7 @@ class Notifier(object):
 
         headers = {b'Content-Type': b'application/json'}
         try:
-            r = requests.post(webhook, data=json.dumps(dict(text=message, username='MedusaBot', icon_url='https://raw.githubusercontent.com/pymedusa/Medusa/master/static/images/ico/favicon-310.png')), headers=headers)
+            r = requests.post(webhook, data=json.dumps(dict(text=message, username='MedusaBot', icon_url='https://cdn.pymedusa.com/images/ico/favicon-310.png')), headers=headers)
             r.raise_for_status()
         except Exception:
             log.exception('Error Sending Slack message')

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -91,10 +91,11 @@ class Notifier(object):
             message = message.encode('utf-8')
 
         headers = {b'Content-Type': b'application/json'}
-        data=json.dumps(dict(
-            text=message,
-            username='MedusaBot',
-            icon_url='https://cdn.pymedusa.com/images/ico/favicon-310.png'))
+        data={
+            'text': message,
+            'username': 'MedusaBot',
+            'icon_url': 'https://cdn.pymedusa.com/images/ico/favicon-310.png'
+        }
 
         try:
             r = requests.post(webhook, data, headers=headers)

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -91,7 +91,7 @@ class Notifier(object):
             message = message.encode('utf-8')
 
         headers = {b'Content-Type': b'application/json'}
-        data={
+        data = {
             'text': message,
             'username': 'MedusaBot',
             'icon_url': 'https://cdn.pymedusa.com/images/ico/favicon-310.png'

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -3,7 +3,6 @@
 
 from __future__ import unicode_literals
 
-import json
 import logging
 from medusa import app, common
 from medusa.logger.adapters.style import BraceAdapter

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -91,8 +91,13 @@ class Notifier(object):
             message = message.encode('utf-8')
 
         headers = {b'Content-Type': b'application/json'}
+        data=json.dumps(dict(
+            text=message,
+            username='MedusaBot',
+            icon_url='https://cdn.pymedusa.com/images/ico/favicon-310.png'))
+
         try:
-            r = requests.post(webhook, data=json.dumps(dict(text=message, username='MedusaBot', icon_url='https://cdn.pymedusa.com/images/ico/favicon-310.png')), headers=headers)
+            r = requests.post(webhook, data, headers=headers)
             r.raise_for_status()
         except Exception:
             log.exception('Error Sending Slack message')


### PR DESCRIPTION
I added a slack_url field so that the medusa Icon shows up in slack instead of the generic webhook icon. 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)