### PR TITLE
Feature/increment cache invalidation

### DIFF
--- a/medusa/server/api/v2/series_asset.py
+++ b/medusa/server/api/v2/series_asset.py
@@ -33,6 +33,6 @@ class SeriesAssetHandler(BaseRequestHandler):
         if not asset:
             return self._not_found('Asset not found')
 
-        self.set_header('Cache-control', 'public, max-age=86400')
+        self.set_header('Cache-control', 'no-cache, must-revalidate')
 
         self._ok(stream=asset.media, content_type=asset.media_type)

--- a/medusa/server/api/v2/series_asset.py
+++ b/medusa/server/api/v2/series_asset.py
@@ -33,6 +33,4 @@ class SeriesAssetHandler(BaseRequestHandler):
         if not asset:
             return self._not_found('Asset not found')
 
-        self.set_header('Cache-control', 'no-cache, must-revalidate')
-
         self._ok(stream=asset.media, content_type=asset.media_type)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)


~~@OmgImAlexis do you know if an alternative solution? A way to invalidate the cache, without needing to change the url?~~

~~To be clear, i'm all for a better alternative.~~

I misread and thought we were always sending 200 from server. But apparently we already have a fine working ETag. So i'll use this PR to revert my hard caching.