### PR TITLE
Fix branches missing in list when using git token in General Configuration

### DIFF
--- a/themes-default/legacy/views/config_general.mako
+++ b/themes-default/legacy/views/config_general.mako
@@ -724,9 +724,9 @@
                                     <select id="branchVersion" class="form-control form-control-inline input-sm pull-left">
                                     % if gh_branch:
                                         % for cur_branch in gh_branch:
-                                            % if app.GIT_USERNAME and app.GIT_PASSWORD and app.DEVELOPER == 1:
+                                            % if ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and app.DEVELOPER == 1:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
-                                            % elif app.GIT_USERNAME and app.GIT_PASSWORD and cur_branch in ['master', 'develop']:
+                                            % elif ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and cur_branch in ['master', 'develop']:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
                                             % elif cur_branch == 'master':
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>

--- a/themes-default/slim/views/config_general.mako
+++ b/themes-default/slim/views/config_general.mako
@@ -724,9 +724,9 @@
                                     <select id="branchVersion" class="form-control form-control-inline input-sm pull-left">
                                     % if gh_branch:
                                         % for cur_branch in gh_branch:
-                                            % if app.GIT_USERNAME and app.GIT_PASSWORD and app.DEVELOPER == 1:
+                                            % if ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and app.DEVELOPER == 1:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
-                                            % elif app.GIT_USERNAME and app.GIT_PASSWORD and cur_branch in ['master', 'develop']:
+                                            % elif ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and cur_branch in ['master', 'develop']:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
                                             % elif cur_branch == 'master':
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>

--- a/themes/dark/templates/config_general.mako
+++ b/themes/dark/templates/config_general.mako
@@ -724,9 +724,9 @@
                                     <select id="branchVersion" class="form-control form-control-inline input-sm pull-left">
                                     % if gh_branch:
                                         % for cur_branch in gh_branch:
-                                            % if app.GIT_USERNAME and app.GIT_PASSWORD and app.DEVELOPER == 1:
+                                            % if ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and app.DEVELOPER == 1:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
-                                            % elif app.GIT_USERNAME and app.GIT_PASSWORD and cur_branch in ['master', 'develop']:
+                                            % elif ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and cur_branch in ['master', 'develop']:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
                                             % elif cur_branch == 'master':
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>

--- a/themes/legacy/templates/config_general.mako
+++ b/themes/legacy/templates/config_general.mako
@@ -724,9 +724,9 @@
                                     <select id="branchVersion" class="form-control form-control-inline input-sm pull-left">
                                     % if gh_branch:
                                         % for cur_branch in gh_branch:
-                                            % if app.GIT_USERNAME and app.GIT_PASSWORD and app.DEVELOPER == 1:
+                                            % if ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and app.DEVELOPER == 1:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
-                                            % elif app.GIT_USERNAME and app.GIT_PASSWORD and cur_branch in ['master', 'develop']:
+                                            % elif ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and cur_branch in ['master', 'develop']:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
                                             % elif cur_branch == 'master':
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>

--- a/themes/light/templates/config_general.mako
+++ b/themes/light/templates/config_general.mako
@@ -724,9 +724,9 @@
                                     <select id="branchVersion" class="form-control form-control-inline input-sm pull-left">
                                     % if gh_branch:
                                         % for cur_branch in gh_branch:
-                                            % if app.GIT_USERNAME and app.GIT_PASSWORD and app.DEVELOPER == 1:
+                                            % if ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and app.DEVELOPER == 1:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
-                                            % elif app.GIT_USERNAME and app.GIT_PASSWORD and cur_branch in ['master', 'develop']:
+                                            % elif ((app.GIT_USERNAME and app.GIT_PASSWORD) or app.GIT_TOKEN) and cur_branch in ['master', 'develop']:
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>
                                             % elif cur_branch == 'master':
                                                 <option value="${cur_branch}" ${'selected="selected"' if app.BRANCH == cur_branch else ''}>${cur_branch}</option>


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR fix the inability to see all branches when using a git token instead of user/pass in the General Configuration page.