### PR TITLE
Fix to allow dev to use triangular workflow

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -470,14 +470,16 @@ class Application(object):
             app.GIT_REMOTE = check_setting_str(app.CFG, 'General', 'git_remote', 'origin')
             app.GIT_REMOTE_URL = check_setting_str(app.CFG, 'General', 'git_remote_url', app.APPLICATION_URL)
 
-            repo_url_re = re.compile(r'(?P<prefix>(?:git@github\.com:)|(?:https://github\.com/))(?P<org>\w+)/(?P<repo>\w+)\.git')
-            m = repo_url_re.match(app.GIT_REMOTE_URL)
-            if m:
-                groups = m.groupdict()
-                if groups['org'].lower() != app.GIT_ORG.lower() or groups['repo'].lower() != app.GIT_REPO.lower():
-                    app.GIT_REMOTE_URL = groups['prefix'] + app.GIT_ORG + '/' + app.GIT_REPO + '.git'
-            else:
-                app.GIT_REMOTE_URL = app.APPLICATION_URL
+            if not app.DEVELOPER:
+                repo_url_re = re.compile(
+                    r'(?P<prefix>(?:git@github\.com:)|(?:https://github\.com/))(?P<org>\w+)/(?P<repo>\w+)\.git')
+                m = repo_url_re.match(app.GIT_REMOTE_URL)
+                if m:
+                    groups = m.groupdict()
+                    if groups['org'].lower() != app.GIT_ORG.lower() or groups['repo'].lower() != app.GIT_REPO.lower():
+                        app.GIT_REMOTE_URL = groups['prefix'] + app.GIT_ORG + '/' + app.GIT_REPO + '.git'
+                else:
+                    app.GIT_REMOTE_URL = app.APPLICATION_URL
 
             # current commit hash
             app.CUR_COMMIT_HASH = check_setting_str(app.CFG, 'General', 'cur_commit_hash', '')


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR bypass the git_remote_url validation when app.developer=1. This allow the usage of a forked repo for development.