### PR TITLE
Fix git origin.remote.pushurl invalid when using git_token

### DIFF
--- a/medusa/version_checker.py
+++ b/medusa/version_checker.py
@@ -742,20 +742,7 @@ class GitUpdateManager(UpdateManager):
 
     def update_remote_origin(self):
         self._run_git(self._git_path, 'config remote.%s.url %s' % (app.GIT_REMOTE, app.GIT_REMOTE_URL))
-        if app.GIT_AUTH_TYPE == 0:
-            if app.GIT_USERNAME:
-                if app.DEVELOPER:
-                    self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (app.GIT_REMOTE, app.GIT_REMOTE_URL))
-                else:
-                    self._run_git(self._git_path, 'config remote.%s.pushurl %s'
-                                  % (app.GIT_REMOTE, app.GIT_REMOTE_URL.replace(app.GIT_ORG, app.GIT_USERNAME, 1)))
-        else:
-            if app.GIT_TOKEN:
-                if app.DEVELOPER:
-                    self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (app.GIT_REMOTE, app.GIT_REMOTE_URL))
-                else:
-                    self._run_git(self._git_path, 'config remote.%s.pushurl %s'
-                                  % (app.GIT_REMOTE, app.GIT_REMOTE_URL.replace(app.GIT_ORG, app.GIT_USERNAME, 1)))
+        self._run_git(self._git_path, 'config remote.%s.pushurl %s' % (app.GIT_REMOTE, app.GIT_REMOTE_URL))
 
 
 class SourceUpdateManager(UpdateManager):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR fix #3779:
- Removed the if for app.git_auth_type as it is not needed.
- Removed the if for app.developer as both URL should point to the same location.