### PR TITLE
Fix torrent_checker scheduler not working properly

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -1327,7 +1327,7 @@ class Application(object):
                 app.trakt_checker_scheduler.silent = True
             app.trakt_checker_scheduler.start()
 
-            if app.USE_TORRENTS and app.REMOVE_FROM_CLIENT:
+            if app.USE_TORRENTS and app.REMOVE_FROM_CLIENT and app.TORRENT_METHOD != 'blackhole':
                 app.torrent_checker_scheduler.enable = True
             app.torrent_checker_scheduler.silent = False
             app.torrent_checker_scheduler.start()

--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -318,3 +318,23 @@ class GenericClient(object):
                 return False, 'Error: Unable to get {name} Authentication, check your config!'.format(name=self.name)
         except Exception as error:
             return False, 'Unable to connect to {name}. Error: {msg}'.format(name=self.name, msg=error)
+
+    def remove_torrent(self, info_hash):
+        """Remove torrent from client using given info_hash.
+
+        :param info_hash:
+        :type info_hash: string
+        :return
+        :rtype: bool
+        """
+        raise NotImplementedError
+
+    def remove_ratio_reached(self):
+        """Remove all Medusa torrents that ratio was reached.
+
+        It loops in all hashes returned from client and check if it is in the snatch history
+        if its then it checks if we already processed media from the torrent (episode status `Downloaded`)
+        If is a RARed torrent then we don't have a media file so we check if that hash is from an
+        episode that has a `Downloaded` status
+        """
+        raise NotImplementedError

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -440,6 +440,32 @@ def change_PROCESS_AUTOMATICALLY(process_automatically):
         app.auto_post_processor_scheduler.silent = True
 
 
+def change_remove_from_client(new_state):
+    """
+    Enable/disable TorrentChecker thread
+    TODO: Make this return true/false on success/failure
+
+    :param new_state: New desired state
+    """
+    new_state = checkbox_to_value(new_state)
+
+    if app.REMOVE_FROM_CLIENT == new_state:
+        return
+
+    app.REMOVE_FROM_CLIENT = new_state
+    if app.REMOVE_FROM_CLIENT:
+        if not app.torrent_checker_scheduler.enable:
+            log.info(u'Starting TORRENTCHECKER thread')
+            app.torrent_checker_scheduler.silent = False
+            app.torrent_checker_scheduler.enable = True
+        else:
+            log.info(u'Unable to start TORRENTCHECKER thread. Already running')
+    else:
+        app.torrent_checker_scheduler.enable = False
+        app.torrent_checker_scheduler.silent = True
+        log.info(u'Stopping TORRENTCHECKER thread')
+
+
 def CheckSection(CFG, sec):
     """ Check if INI section exists, if not create it """
 

--- a/medusa/server/web/config/search.py
+++ b/medusa/server/web/config/search.py
@@ -80,6 +80,11 @@ class ConfigSearch(Config):
         app.TORRENT_METHOD = torrent_method
         app.USENET_RETENTION = try_int(usenet_retention, 500)
 
+        if app.TORRENT_METHOD != 'blackhole' and app.TORRENT_METHOD in ('transmission', 'deluge', 'deluged'):
+            config.change_remove_from_client(remove_from_client)
+        else:
+            config.change_remove_from_client('false')
+
         app.IGNORE_WORDS = [_.strip() for _ in ignore_words.split(',')] if ignore_words else []
         app.PREFERRED_WORDS = [_.strip() for _ in preferred_words.split(',')] if preferred_words else []
         app.UNDESIRED_WORDS = [_.strip() for _ in undesired_words.split(',')] if undesired_words else []
@@ -92,7 +97,6 @@ class ConfigSearch(Config):
 
         config.change_DOWNLOAD_PROPERS(download_propers)
         app.PROPERS_SEARCH_DAYS = try_int(propers_search_days, 2)
-        app.REMOVE_FROM_CLIENT = config.checkbox_to_value(remove_from_client)
         config.change_PROPERS_FREQUENCY(check_propers_interval)
 
         app.ALLOW_HIGH_PRIORITY = config.checkbox_to_value(allow_high_priority)

--- a/medusa/torrent_checker.py
+++ b/medusa/torrent_checker.py
@@ -34,15 +34,15 @@ class TorrentChecker(object):
 
     def run(self, force=False):
         """Start the Torrent Checker Thread."""
-        if not (app.USE_TORRENTS and app.REMOVE_FROM_CLIENT):
-            return
-
         self.amActive = True
 
         try:
             client = torrent.get_client_class(app.TORRENT_METHOD)()
             client.remove_ratio_reached()
-        except Exception as e:
-            logger.debug('Failed to check torrent status. Error: {error}', error=e)
-
-        self.amActive = False
+        except NotImplementedError:
+            logger.warning('Feature not currently implemented for this torrent client({torrent_client})',
+                           torrent_client=app.TORRENT_METHOD)
+        except Exception:
+            logger.exception('Exception while checking torrent status.')
+        finally:
+            self.amActive = False


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR fix an issue with torrent_checker not starting/stopping properly after enabling it in the config and at startup.

Also added remove_ratio_reached() and remove_torrent() in generic.py as they should be a requirement for torrent_checker.py

Replaced the log debug in torrent_checker.py to logger.exception as I think remove_ratio_reached() should handle it's own exception and anything else should constitute an error.