### PR TITLE
Lazy load the anidb (simpleanidb) object on module level.

### DIFF
--- a/medusa/show/recommendations/anidb.py
+++ b/medusa/show/recommendations/anidb.py
@@ -42,7 +42,7 @@ class AnidbPopular(object):  # pylint: disable=too-few-public-methods
         """Create the RecommendedShow object from the returned showobj."""
         try:
             tvdb_id = cached_aid_to_tvdb(series.aid)
-        except Exception as error:
+        except Exception:
             log.warning("Couldn't map AniDB id {0} to a TVDB id", series.aids)
             return None
 

--- a/medusa/show/recommendations/anidb.py
+++ b/medusa/show/recommendations/anidb.py
@@ -42,7 +42,7 @@ class AnidbPopular(object):  # pylint: disable=too-few-public-methods
         """Create the RecommendedShow object from the returned showobj."""
         try:
             tvdb_id = cached_aid_to_tvdb(series.aid)
-        except Exception:
+        except Exception as error:
             log.warning("Couldn't map AniDB id {0} to a TVDB id", series.aids)
             return None
 

--- a/medusa/show/recommendations/recommended.py
+++ b/medusa/show/recommendations/recommended.py
@@ -49,7 +49,7 @@ anidb_api = None
 
 def load_anidb_api(func):
     """
-    Simple wrapper/decorator to lazy load the anidb_api.
+    Decorate a function to lazy load the anidb_api.
 
     We need to do this, because we're passing the Medusa cache location to the lib. As the module is imported before
     the app.CACHE_DIR location has been read, we can't initialize it at module level.


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fix #3802 