### PR TITLE
Parse runtime (int) to str.

### DIFF
--- a/medusa/metadata/kodi_12plus.py
+++ b/medusa/metadata/kodi_12plus.py
@@ -19,7 +19,7 @@ from medusa.indexers.tvdbv2.tvdbv2_api import API_BASE_TVDB
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.metadata import generic
 
-from six import string_types, text_type
+from six import string_types
 
 try:
     import xml.etree.cElementTree as etree
@@ -117,7 +117,7 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
 
         if getattr(my_show, 'rating', None):
             rating = etree.SubElement(tv_node, 'rating')
-            rating.text = text_type(my_show['rating'])
+            rating.text = str(my_show['rating'])
 
         if getattr(my_show, 'firstaired', None):
             try:
@@ -283,7 +283,7 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
 
             if ep_to_write.season and getattr(series_obj, 'runtime', None):
                 runtime = etree.SubElement(episode, 'runtime')
-                runtime.text = series_obj['runtime']
+                runtime.text = str(series_obj['runtime'])
 
             if getattr(my_ep, 'airsbefore_season', None):
                 displayseason = etree.SubElement(episode, 'displayseason')
@@ -302,7 +302,7 @@ class KODI_12PlusMetadata(generic.GenericMetadata):
 
             if getattr(my_ep, 'rating', None):
                 rating = etree.SubElement(episode, 'rating')
-                rating.text = text_type(my_ep['rating'])
+                rating.text = str(my_ep['rating'])
 
             if getattr(my_ep, 'writer', None) and isinstance(my_ep['writer'], string_types):
                 for writer in self._split_info(my_ep['writer']):


### PR DESCRIPTION
Needed because tmdb stores the runtime as int.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
