### PR TITLE
Fixing issue of no matches showing when only one result available (hebits)

### DIFF
--- a/medusa/providers/torrent/html/hebits.py
+++ b/medusa/providers/torrent/html/hebits.py
@@ -117,7 +117,7 @@ class HeBitsProvider(TorrentProvider):
             torrent_rows = torrent_table('div', class_=re.compile('^line')) if torrent_table else []
 
             # Continue only if at least one release is found
-            if len(torrent_rows) < 2:
+            if len(torrent_rows) < 1:
                 log.debug('Data returned from provider does not contain any torrents')
                 return items
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

When only one result appeared in the search it was not parsing it.
Tiny fix.