### PR TITLE
Fix Git token re-encryption

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -437,7 +437,7 @@ class Application(object):
             app.GIT_AUTH_TYPE = check_setting_int(app.CFG, 'General', 'git_auth_type', 0)
             app.GIT_USERNAME = check_setting_str(app.CFG, 'General', 'git_username', '')
             app.GIT_PASSWORD = check_setting_str(app.CFG, 'General', 'git_password', '', censor_log='low')
-            app.GIT_TOKEN = check_setting_str(app.CFG, 'General', 'git_token', '', censor_log='low')
+            app.GIT_TOKEN = check_setting_str(app.CFG, 'General', 'git_token', '', censor_log='low', encrypted=True)
             app.DEVELOPER = bool(check_setting_int(app.CFG, 'General', 'developer', 0))
 
             # debugging

--- a/medusa/config.py
+++ b/medusa/config.py
@@ -674,15 +674,15 @@ def check_setting_float(config, cfg_name, item_name, def_val, silent=True):
 ################################################################################
 # Check_setting_str                                                            #
 ################################################################################
-def check_setting_str(config, cfg_name, item_name, def_val, silent=True, censor_log=False, valid_values=None):
-    # For passwords you must include the word `password` in the item_name
+def check_setting_str(config, cfg_name, item_name, def_val, silent=True, censor_log=False, valid_values=None, encrypted=False):
+    # For passwords you must include the word `password` in the item_name or pass `encrypted=True`
     # and add `helpers.encrypt(ITEM_NAME, ENCRYPTION_VERSION)` in save_config()
     if not censor_log:
         censor_level = common.privacy_levels['stupid']
     else:
         censor_level = common.privacy_levels[censor_log]
     privacy_level = common.privacy_levels[app.PRIVACY_LEVEL]
-    if bool(item_name.find('password') + 1):
+    if bool(item_name.find('password') + 1) or encrypted:
         encryption_version = app.ENCRYPTION_VERSION
     else:
         encryption_version = 0


### PR DESCRIPTION
This is one way to solve the issue (tested, working).
Though, it may be a bit confusing to see other encrypted config entries without the `encrypted=True`.

In my mind - it's either this fix or changing the entry name to `git_token_password`, which looks weird.
(Note: Adding `token` as a keyword for encryption like `password` would cause a bigger change)

Your thoughts?

Fixes #3895