### PR TITLE
add 1 hour cache to series assets

### DIFF
--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -111,6 +111,7 @@ class BaseRequestHandler(RequestHandler):
                 self.finish(json.JSONEncoder(default=json_default_encoder).encode(data))
             elif stream:
                 # This is mainly for assets
+                self.set_header('cache-control', 'public, max-age=3600')
                 self.set_header('content-type', content_type)
                 self.finish(stream)
             elif kwargs and 'chunk' in kwargs:


### PR DESCRIPTION
I've noticed we're missing the `cache-control` header for our series assets. So far I've seen quite a good improvement in loading times for the homepage.