### PR TITLE
Fix 'Edit Show' link in Backlog Overview

### DIFF
--- a/themes-default/legacy/views/manage_backlogOverview.mako
+++ b/themes-default/legacy/views/manage_backlogOverview.mako
@@ -93,7 +93,7 @@
                                     <span class="listing-key qual">Quality: <b>${showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]}</b></span>
                                     % endif
                                     <a class="btn btn-inline forceBacklog" href="manage/backlogShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Force Backlog</a>
-                                    <a class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.series_id}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
+                                    <a class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
                                 </div>
                             </div>
                         </div>

--- a/themes-default/slim/views/manage_backlogOverview.mako
+++ b/themes-default/slim/views/manage_backlogOverview.mako
@@ -102,7 +102,7 @@ const startVue = () => {
                                     <span class="listing-key qual">Quality: <b>${showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]}</b></span>
                                     % endif
                                     <app-link class="btn btn-inline forceBacklog" href="manage/backlogShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Force Backlog</app-link>
-                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.series_id}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
+                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
                                 </div>
                             </div>
                         </div>

--- a/themes/dark/templates/manage_backlogOverview.mako
+++ b/themes/dark/templates/manage_backlogOverview.mako
@@ -102,7 +102,7 @@ const startVue = () => {
                                     <span class="listing-key qual">Quality: <b>${showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]}</b></span>
                                     % endif
                                     <app-link class="btn btn-inline forceBacklog" href="manage/backlogShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Force Backlog</app-link>
-                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.series_id}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
+                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
                                 </div>
                             </div>
                         </div>

--- a/themes/legacy/templates/manage_backlogOverview.mako
+++ b/themes/legacy/templates/manage_backlogOverview.mako
@@ -93,7 +93,7 @@
                                     <span class="listing-key qual">Quality: <b>${showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]}</b></span>
                                     % endif
                                     <a class="btn btn-inline forceBacklog" href="manage/backlogShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Force Backlog</a>
-                                    <a class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.series_id}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
+                                    <a class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</a>
                                 </div>
                             </div>
                         </div>

--- a/themes/light/templates/manage_backlogOverview.mako
+++ b/themes/light/templates/manage_backlogOverview.mako
@@ -102,7 +102,7 @@ const startVue = () => {
                                     <span class="listing-key qual">Quality: <b>${showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]}</b></span>
                                     % endif
                                     <app-link class="btn btn-inline forceBacklog" href="manage/backlogShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Force Backlog</app-link>
-                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.series_id}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
+                                    <app-link class="btn btn-inline editShow" href="manage/editShow?indexername=${cur_show.indexer_name}&seriesid=${cur_show.series_id}"><i class="icon-play-circle icon-white"></i> Edit Show</app-link>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Fixes #3928 (for legacy themes as well)