### PR TITLE
[Torrentday] The `download-multiplier` key is optional

### DIFF
--- a/medusa/providers/torrent/json/torrentday.py
+++ b/medusa/providers/torrent/json/torrentday.py
@@ -118,7 +118,7 @@ class TorrentDayProvider(TorrentProvider):
 
             try:
                 # Check if this is a freeleech torrent and if we've configured to only allow freeleech.
-                if self.freeleech and row['download-multiplier'] != 0:
+                if self.freeleech and row.get('download-multiplier') != 0:
                     continue
 
                 title = re.sub(r'\[.*\=.*\].*\[/.*\]', '', row['name']) if row['name'] else None


### PR DESCRIPTION
The `t.json` endpoint doesn't return the `download-multiplier` key for items that isn't freeleech.