### PR TITLE
Update thread name while processing cached results from DB

### DIFF
--- a/medusa/search/manual.py
+++ b/medusa/search/manual.py
@@ -220,7 +220,7 @@ def get_provider_cache_results(series_obj, show_all_results=None, perform_search
                 b"SELECT rowid, ? AS 'provider_type', ? AS 'provider_image',"
                 b" ? AS 'provider', ? AS 'provider_id', ? 'provider_minseed',"
                 b" ? 'provider_minleech', name, season, episodes, indexer, indexerid,"
-                b" url, time, proper_tags, quality, release_group, version,"
+                b" url, proper_tags, quality, release_group, version,"
                 b" seeders, leechers, size, time, pubdate, date_added "
                 b"FROM '{provider_id}' "
                 b"WHERE indexer = ? AND indexerid = ? AND quality > 0 ".format(
@@ -291,6 +291,9 @@ def get_provider_cache_results(series_obj, show_all_results=None, perform_search
     else:
         cached_results = [dict(row) for row in sql_total]
         for i in cached_results:
+            threading.currentThread().name = '{thread} :: [{provider}]'.format(
+                thread=original_thread_name, provider=i['provider'])
+
             i['quality_name'] = Quality.split_quality(int(i['quality']))
             i['time'] = datetime.fromtimestamp(i['time'])
             i['release_group'] = i['release_group'] or 'None'


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Update thread name with provider name while processing cached results from the database (for manual search). In the future this might help determine issues with cached results more easily (like the issue of timezone-naive/null `pub_date`s discussed on Slack)