### PR TITLE
Fix Error in Episode.to_json function

### DIFF
--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1095,7 +1095,7 @@ class Episode(TV):
             data['statistics']['subtitleSearch']['last'] = self.subtitles_lastsearch
             data['statistics']['subtitleSearch']['count'] = self.subtitles_searchcount
             data['wantedQualities'] = self.wanted_quality
-            data['wantedQualities'] = [ep.identifier() for ep in self.related_episodes]
+            data['wantedQualities'] = [ep.identifier for ep in self.related_episodes]
 
         return data
 


### PR DESCRIPTION
`https://localhost:8081/api/v2/series/tvdb12345?api_key=xxx`

```
Traceback (most recent call last):
  File "C:\Medusa\ext\tornado\web.py", line 1541, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "C:\Medusa\medusa\server\api\v2\series.py", line 60, in get
    data = series.to_json(detailed=detailed)
  File "C:\Medusa\medusa\tv\series.py", line 2050, in to_json
    groupby([ep.to_json() for ep in episodes], lambda item: item['season'])]
  File "C:\Medusa\medusa\tv\episode.py", line 1098, in to_json
    data['wantedQualities'] = [ep.identifier() for ep in self.related_episodes]
TypeError: 'unicode' object is not callable
```