### PR TITLE
Torrent Checker: Show warning when connection error

### DIFF
--- a/medusa/torrent_checker.py
+++ b/medusa/torrent_checker.py
@@ -24,7 +24,7 @@ from builtins import object
 from medusa import app
 from medusa.clients import torrent
 
-import requests
+from requests import RequestException
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class TorrentChecker(object):
         except NotImplementedError:
             logger.warning('Feature not currently implemented for this torrent client({torrent_client})',
                            torrent_client=app.TORRENT_METHOD)
-        except requests.RequestException as e:
+        except RequestException as e:
             logger.warning('Unable to connect to {torrent_client}. Error: {error}',
                            torrent_client=app.TORRENT_METHOD, error=e)
         except Exception:

--- a/medusa/torrent_checker.py
+++ b/medusa/torrent_checker.py
@@ -24,6 +24,8 @@ from builtins import object
 from medusa import app
 from medusa.clients import torrent
 
+import requests
+
 logger = logging.getLogger(__name__)
 
 
@@ -44,6 +46,9 @@ class TorrentChecker(object):
         except NotImplementedError:
             logger.warning('Feature not currently implemented for this torrent client({torrent_client})',
                            torrent_client=app.TORRENT_METHOD)
+        except requests.RequestException as e:
+            logger.warning('Unable to connect to {torrent_client}. Error: {error}',
+                           torrent_client=app.TORRENT_METHOD, error=e)
         except Exception:
             logger.exception('Exception while checking torrent status.')
         finally:


### PR DESCRIPTION
- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)


Fixes:
```
2018-04-12 17:33:37 ERROR    TORRENTCHECKER :: [204cf56] Exception while checking torrent status.
Traceback (most recent call last):
  File "/home/osmc/Medusa/medusa/torrent_checker.py", line 43, in run
    client.remove_ratio_reached()
  File "/home/osmc/Medusa/medusa/clients/torrent/transmission_client.py", line 313, in remove_ratio_reached
    if not self._request(method='post', data=post_data):
  File "/home/osmc/Medusa/medusa/clients/torrent/generic.py", line 60, in _request
    self._get_auth()
  File "/home/osmc/Medusa/medusa/clients/torrent/transmission_client.py", line 65, in _get_auth
    verify=app.TORRENT_VERIFY_CERT)
  File "/home/osmc/Medusa/ext/requests/sessions.py", line 555, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/home/osmc/Medusa/medusa/session/core.py", line 99, in request
    **kwargs)
  File "/home/osmc/Medusa/ext/requests/sessions.py", line 508, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/osmc/Medusa/ext/requests/sessions.py", line 618, in send
    r = adapter.send(request, **kwargs)
  File "/home/osmc/Medusa/ext/requests/adapters.py", line 521, in send
    raise ReadTimeout(e, request=request)
```