### PR TITLE
Fix thread names and up thread count

### DIFF
--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -294,9 +294,10 @@ class LogLine(object):
     # log regular expression:
     #   2016-08-06 15:58:34 ERROR    DAILYSEARCHER :: [d4ea5af] Exception generated in thread DAILYSEARCHER
     #   2016-08-25 20:12:03 INFO     SEARCHQUEUE-MANUAL-290853 :: [ProviderName] :: [d4ea5af] Performing episode search for Show Name
+    #   2018-04-14 23:32:37 INFO     Thread_5 :: [6d54662] Broken providers found: [u'']
     log_re = re.compile(r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})\s+'
                         r'(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?:,(?P<microsecond>\d{3}))?\s+'
-                        r'(?P<level_name>[A-Z]+)\s+(?P<thread_name>.+?)(?:_(?P<thread_id>\d+))?\s+'
+                        r'(?P<level_name>[A-Z]+)\s+(?P<thread_name>.+?)(?:[-_](?P<thread_id>\d+))?\s+'
                         r'(?:::\s+\[(?P<extra>.+?)\]\s+)?::\s+\[(?P<curhash>[a-f0-9]{7})?\]\s+(?P<message>.*)$')
 
     tracebackline_re = re.compile(r'(?P<before>\s*File ")(?P<file>.+)(?P<middle>", line )(?P<line>\d+)(?P<after>, in .+)')

--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -296,7 +296,7 @@ class LogLine(object):
     #   2016-08-25 20:12:03 INFO     SEARCHQUEUE-MANUAL-290853 :: [ProviderName] :: [d4ea5af] Performing episode search for Show Name
     log_re = re.compile(r'^(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})\s+'
                         r'(?P<hour>\d{2}):(?P<minute>\d{2}):(?P<second>\d{2})(?:,(?P<microsecond>\d{3}))?\s+'
-                        r'(?P<level_name>[A-Z]+)\s+(?P<thread_name>.+?)(?:-(?P<thread_id>\d+))?\s+'
+                        r'(?P<level_name>[A-Z]+)\s+(?P<thread_name>.+?)(?:_(?P<thread_id>\d+))?\s+'
                         r'(?:::\s+\[(?P<extra>.+?)\]\s+)?::\s+\[(?P<curhash>[a-f0-9]{7})?\]\s+(?P<message>.*)$')
 
     tracebackline_re = re.compile(r'(?P<before>\s*File ")(?P<file>.+)(?P<middle>", line )(?P<line>\d+)(?P<after>, in .+)')

--- a/medusa/server/web/core/base.py
+++ b/medusa/server/web/core/base.py
@@ -240,7 +240,7 @@ class BaseHandler(RequestHandler):
 class WebHandler(BaseHandler):
     """Base Handler for the web server."""
 
-    executor = ThreadPoolExecutor(cpu_count())
+    executor = ThreadPoolExecutor(cpu_count(), thread_name_prefix='Thread')
 
     def __init__(self, *args, **kwargs):
         super(WebHandler, self).__init__(*args, **kwargs)

--- a/medusa/server/web/core/base.py
+++ b/medusa/server/web/core/base.py
@@ -38,7 +38,6 @@ from six import (
 from tornado.concurrent import run_on_executor
 from tornado.escape import utf8
 from tornado.gen import coroutine
-from tornado.process import cpu_count
 from tornado.web import (
     HTTPError,
     RequestHandler,
@@ -240,7 +239,7 @@ class BaseHandler(RequestHandler):
 class WebHandler(BaseHandler):
     """Base Handler for the web server."""
 
-    executor = ThreadPoolExecutor(cpu_count(), thread_name_prefix='Thread')
+    executor = ThreadPoolExecutor(thread_name_prefix='Thread')
 
     def __init__(self, *args, **kwargs):
         super(WebHandler, self).__init__(*args, **kwargs)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -263,7 +263,7 @@ def test_from_line(p):
     },
     {  # p4: thread_name doesn't match
         'line': '2016-08-25 20:12:03 INFO     SEARCHQUEUE-MANUAL-290853 :: [ProviderName] :: [d4ea5af] Performing episode search for Show Name',
-        'thread_name': 'Thread-19',
+        'thread_name': 'Thread_19',
         'expected': False,
     },
     {  # p5: everything matches


### PR DESCRIPTION
- Changes `ThreadPoolExecutor-%d_%d` back to `Thread_%d`
  This was changed in the recently updated [`[concurrent.]futures` package](https://github.com/agronholm/pythonfutures/commit/e8543e620d87f41f78751b4285a3f1af06023a62).
- Update log filter accordingly.
- **This is an optional change** - Remove `cpu_count()`
  There is no need for this, and it also might make the server go slower, as there would only be as many threads as CPU cores on the machine.
  Default value is cores times 5, as can be seen here: https://github.com/pymedusa/Medusa/blob/d976ae6b9665bd619ba7ad957221389c82266728/ext/concurrent/futures/thread.py#L106-L109