### PR TITLE
Fix #4013, #4022 TMDB metadata errors (TypeError, ZeroDivisionError)

### DIFF
--- a/lib/tmdbsimple/__init__.py
+++ b/lib/tmdbsimple/__init__.py
@@ -4,22 +4,22 @@
 tmdbsimple
 ~~~~~~~~~~
 
-*tmdbsimple* is a wrapper, written in Python, for The Movie Database (TMDb)
-API v3.  By calling the functions available in *tmdbsimple* you can simplify
-your code and easily access a vast amount of movie, tv, and cast data.  To find
-out more about The Movie Database API, check out the overview page
-http://www.themoviedb.org/documentation/api and documentation page
-http://docs.themoviedb.apiary.io.
+*tmdbsimple* is a wrapper, written in Python, for The Movie Database (TMDb) 
+API v3.  By calling the functions available in *tmdbsimple* you can simplify 
+your code and easily access a vast amount of movie, tv, and cast data.  To find 
+out more about The Movie Database API, check out the overview page 
+http://www.themoviedb.org/documentation/api and documentation page 
+https://developers.themoviedb.org/3/getting-started
 https://www.themoviedb.org/documentation/api/status-codes
 
-:copyright: (c) 2013-2014 by Celia Oakley.
+:copyright: (c) 2013-2018 by Celia Oakley.
 :license: GPLv3, see LICENSE for more details
 """
 
 __title__ = 'tmdbsimple'
-__version__ = '1.4.0'
+__version__ = '2.2.0'
 __author__ = 'Celia Oakley'
-__copyright__ = 'Copyright (c) 2013-1016 Celia Oakley'
+__copyright__ = 'Copyright (c) 2013-2018 Celia Oakley'
 __license__ = 'GPLv3'
 
 import os
@@ -36,13 +36,6 @@ from .people import People, Credits, Jobs
 from .search import Search
 from .tv import TV, TV_Seasons, TV_Episodes, Networks
 
-def _get_env_key(key):
-    try:
-        return os.environ[key]
-    except KeyError:
-        return None
 
-API_KEY = _get_env_key('TMDB_API_KEY')
+API_KEY = os.environ.get('TMDB_API_KEY', None)
 API_VERSION = '3'
-REQUESTS_SESSION = None
-

--- a/lib/tmdbsimple/account.py
+++ b/lib/tmdbsimple/account.py
@@ -8,7 +8,7 @@ of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -19,7 +19,7 @@ class Account(TMDB):
     """
     Account functionality.
 
-    See: http://docs.themoviedb.apiary.io/#account
+    See: https://developers.themoviedb.org/3/account
          https://www.themoviedb.org/documentation/api/sessions
     """
     BASE_PATH = 'account'
@@ -243,7 +243,7 @@ class Authentication(TMDB):
     """
     Authentication functionality.
 
-    See: http://docs.themoviedb.apiary.io/#authentication
+    See: https://developers.themoviedb.org/3/authentication
          https://www.themoviedb.org/documentation/api/sessions
     """
     BASE_PATH = 'authentication'
@@ -332,7 +332,7 @@ class GuestSessions(TMDB):
     """
     Guest Sessions functionality.
 
-    See: http://docs.themoviedb.apiary.io/#guestsessions
+    See: https://developers.themoviedb.org/3/guest-sessions
     """
     BASE_PATH = 'guest_session'
     URLS = {
@@ -366,7 +366,7 @@ class Lists(TMDB):
     """
     Lists functionality.
 
-    See: http://docs.themoviedb.apiary.io/#lists
+    See: https://developers.themoviedb.org/3/lists
     """
     BASE_PATH = 'list'
     URLS = {
@@ -376,7 +376,6 @@ class Lists(TMDB):
         'add_item': '/{id}/add_item',
         'remove_item': '/{id}/remove_item',
         'clear': '/{id}/clear',
-        'delete_list': '/{id}',
     }
 
     def __init__(self, id=0, session_id=0):
@@ -508,20 +507,3 @@ class Lists(TMDB):
         response = self._POST(path, kwargs, payload)
         self._set_attrs_to_values(response)
         return response
-
-    def delete_list(self, **kwargs):
-        """
-        Delete a list that the user created.
-
-        A valid session id is required.
-
-        Returns:
-            A dict respresentation of the JSON returned from the API.
-        """
-        path = self._get_id_path('delete_list')
-        kwargs.update({'session_id': self.session_id})
-
-        response = self._DELETE(path, kwargs)
-        self._set_attrs_to_values(response)
-        return response
-

--- a/lib/tmdbsimple/base.py
+++ b/lib/tmdbsimple/base.py
@@ -7,7 +7,7 @@ This module implements the base class of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -27,11 +27,9 @@ class TMDB(object):
     URLS = {}
 
     def __init__(self):
-        from . import API_VERSION, REQUESTS_SESSION, __version__
+        from . import API_VERSION
         self.base_uri = 'https://api.themoviedb.org'
         self.base_uri += '/{version}'.format(version=API_VERSION)
-        self.session = REQUESTS_SESSION or requests.Session()
-        self.session.headers.setdefault('user-agent', 'tmdb_api/{}.{}.{}'.format(*__version__))
 
     def _get_path(self, key):
         return self.BASE_PATH + self.URLS[key]
@@ -42,12 +40,12 @@ class TMDB(object):
     def _get_guest_session_id_path(self, key):
         return self._get_path(key).format(
             guest_session_id=self.guest_session_id)
-
+    
     def _get_credit_id_path(self, key):
         return self._get_path(key).format(credit_id=self.credit_id)
 
-    def _get_id_season_number_path(self, key):
-        return self._get_path(key).format(id=self.id,
+    def _get_series_id_season_number_path(self, key):
+        return self._get_path(key).format(series_id=self.series_id,
             season_number=self.season_number)
 
     def _get_series_id_season_number_episode_number_path(self, key):
@@ -74,8 +72,8 @@ class TMDB(object):
         url = self._get_complete_url(path)
         params = self._get_params(params)
 
-        response = self.session.request(
-            method, url, params=params,
+        response = requests.request(
+            method, url, params=params, 
             data=json.dumps(payload) if payload else payload,
             headers=self.headers)
 
@@ -104,5 +102,6 @@ class TMDB(object):
         """
         if isinstance(response, dict):
             for key in response.keys():
-                setattr(self, key, response[key])
+                if not hasattr(self, key) or not callable(getattr(self, key)):
+                    setattr(self, key, response[key])
 

--- a/lib/tmdbsimple/changes.py
+++ b/lib/tmdbsimple/changes.py
@@ -7,7 +7,7 @@ This module implements the Changes functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -17,7 +17,7 @@ class Changes(TMDB):
     """
     Changes functionality.
 
-    See: http://docs.themoviedb.apiary.io/#changes
+    See: https://developers.themoviedb.org/3/changes
     """
     BASE_PATH = ''
     URLS = {

--- a/lib/tmdbsimple/configuration.py
+++ b/lib/tmdbsimple/configuration.py
@@ -9,7 +9,7 @@ functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -20,7 +20,7 @@ class Configuration(TMDB):
     """
     Configuration functionality.
 
-    See: http://docs.themoviedb.apiary.io/#configuration
+    See: https://developers.themoviedb.org/3/configuration
     """
     BASE_PATH = 'configuration'
     URLS = {
@@ -45,7 +45,7 @@ class Certifications(TMDB):
     """
     Certifications functionality.
 
-    See: http://docs.themoviedb.apiary.io/#certifications
+    See: https://developers.themoviedb.org/3/certifications
     """
     BASE_PATH = 'certification'
     URLS = {
@@ -70,7 +70,7 @@ class Timezones(TMDB):
     """
     Timezones functionality.
 
-    See: http://docs.themoviedb.apiary.io/#timezones
+    See: https://developers.themoviedb.org/3/timezones
     """
     BASE_PATH = 'timezones'
     URLS = {

--- a/lib/tmdbsimple/discover.py
+++ b/lib/tmdbsimple/discover.py
@@ -7,7 +7,7 @@ This module implements the Discover functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -17,7 +17,7 @@ class Discover(TMDB):
     """
     Discover functionality.
 
-    See: http://docs.themoviedb.apiary.io/#discover
+    See: https://developers.themoviedb.org/3/discover
     """
     BASE_PATH = 'discover'
     URLS = {
@@ -43,29 +43,32 @@ class Discover(TMDB):
             primary_release_year: (optional) Filter the results so that 
                                   only the primary release date year has 
                                   this value.  Expected value is a year.
-            vote_count.gte: (optional) Only include movies that are equal to,
-                            or have a vote count higher than this value. 
-                            Expected value is an integer.
-            vote_average.gte: (optional) Only include movies that are equal 
-                              to, or have a higher average rating than this 
-                              value.  Expected value is a float.
+            vote_count.gte or vote_count_gte: (optional) Only include movies 
+                            that are equal to, or have a vote count higher 
+                            than this value.  Expected value is an integer.
+            vote_average.gte or vote_average_gte: (optional) Only include 
+                              movies that are equal to, or have a higher 
+                              average rating than this value.  Expected value 
+                              is a float.
             with_genres: (optional) Only include movies with the specified 
                          genres.  Expected value is an integer (the id of 
                          a genre).  Multiple values can be specified. 
                          Comma separated indicates an 'AND' query, while 
                          a pipe (|) separated value indicates an 'OR'.
-            release_date.gte: (optional) The minimum release to include.
-                              Expected format is 'YYYY-MM-DD'.
-            release_date.lte: (optional) The maximum release to include. 
-                              Expected format is 'YYYY-MM-DD'.
+            release_date.gte or release_date_gte: (optional) The minimum 
+                              release to include.  Expected format is 
+                              'YYYY-MM-DD'.
+            releaste_date.lte or release_date_lte: (optional) The maximum 
+                              release to include.  Expected format is 
+                              'YYYY-MM-DD'.
             certification_country: (optional) Only include movies with
                                    certifications for a specific country. When
                                    this value is specified, 'certification.lte'
                                    is required. An ISO 3166-1 is expected.
-            certification.lte: (optional) Only include movies with this
-                               certification and lower. Expected value is a 
-                               valid certification for the specified 
-                               'certification_country'.
+            certification.lte or certification_lte: (optional) Only include 
+                               movies with this certification and lower. 
+                               Expected value is a valid certification for 
+                               the specified 'certification_country'.
             with_companies: (optional) Filter movies to include a specific 
                             company.  Expected value is an integer (the id 
                             of a company).  They can be comma separated 
@@ -74,6 +77,14 @@ class Discover(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
+        # Periods are not allowed in keyword arguments but several API 
+        # arguments contain periods. See both usages in tests/test_discover.py.
+        for param in kwargs:
+            if '_lte' in param:
+                kwargs[param.replace('_lte', '.lte')] = kwargs.pop(param)
+            if '_gte' in param:
+                kwargs[param.replace('_gte', '.gte')] = kwargs.pop(param)
+        
         path = self._get_path('movie')
 
         response = self._GET(path, kwargs)
@@ -94,10 +105,12 @@ class Discover(TMDB):
             first_air_year: (optional) Filter the results release dates to 
                             matches that include this value. Expected value 
                             is a year.
-            vote_count.gte: (optional) Only include TV shows that are equal to,
+            vote_count.gte or vote_count_gte: (optional) Only include TV shows 
+                            that are equal to,
                             or have vote count higher than this value. Expected
                             value is an integer.
-            vote_average.gte: (optional) Only include TV shows that are equal 
+            vote_average.gte or vote_average_gte: (optional) Only include TV 
+                              shows that are equal 
                               to, or have a higher average rating than this 
                               value.  Expected value is a float.
             with_genres: (optional) Only include TV shows with the specified 
@@ -109,14 +122,24 @@ class Discover(TMDB):
                            network. Expected value is an integer (the id of a
                            network).  They can be comma separated to indicate an
                            'AND' query.
-            first_air_date.gte: (optional) The minimum release to include. 
+            first_air_date.gte or first_air_date_gte: (optional) The minimum 
+                                release to include. 
                                 Expected format is 'YYYY-MM-DD'.
-            first_air_date.lte: (optional) The maximum release to include. 
+            first_air_date.lte or first_air_date_lte: (optional) The maximum 
+                                release to include. 
                                 Expected format is 'YYYY-MM-DD'.
           
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
+        # Periods are not allowed in keyword arguments but several API 
+        # arguments contain periods. See both usages in tests/test_discover.py.
+        for param in kwargs:
+            if '_lte' in param:
+                kwargs[param.replace('_lte', '.lte')] = kwargs.pop(param)
+            if '_gte' in param:
+                kwargs[param.replace('_gte', '.gte')] = kwargs.pop(param)
+        
         path = self._get_path('tv')
 
         response = self._GET(path, kwargs)

--- a/lib/tmdbsimple/find.py
+++ b/lib/tmdbsimple/find.py
@@ -7,7 +7,7 @@ This module implements the Find functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -17,7 +17,7 @@ class Find(TMDB):
     """
     Find functionality.
 
-    See: http://docs.themoviedb.apiary.io/#find
+    See: https://developers.themoviedb.org/3/find
     """
     BASE_PATH = 'find'
     URLS = {

--- a/lib/tmdbsimple/genres.py
+++ b/lib/tmdbsimple/genres.py
@@ -7,7 +7,7 @@ This module implements the Genres functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -18,11 +18,12 @@ class Genres(TMDB):
     """
     Genres functionality.
 
-    See: http://docs.themoviedb.apiary.io/#genres
+    See: https://developers.themoviedb.org/3/genres
     """
     BASE_PATH = 'genre'
     URLS = {
-        'list': '/list',
+        'movie_list': '/movie/list',
+        'tv_list': '/tv/list',
         'movies': '/{id}/movies',
     }
 
@@ -30,9 +31,9 @@ class Genres(TMDB):
         super(Genres, self).__init__()
         self.id = id
 
-    def list(self, **kwargs):
+    def movie_list(self, **kwargs):
         """
-        Get the list of genres.
+        Get the list of Movie genres.
 
         Args:
             language: (optional) ISO 639-1 code.
@@ -40,7 +41,23 @@ class Genres(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_path('list')
+        path = self._get_path('movie_list')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def tv_list(self, **kwargs):
+        """
+        Get the list of TV genres.
+
+        Args:
+            language: (optional) ISO 639-1 code.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_path('tv_list')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)

--- a/lib/tmdbsimple/movies.py
+++ b/lib/tmdbsimple/movies.py
@@ -3,12 +3,12 @@
 """
 tmdbsimple.movies
 ~~~~~~~~~~~~~~~~~
-This module implements the Movies, Collections, Companies, Keywords, and 
+This module implements the Movies, Collections, Companies, Keywords, and
 Reviews functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -18,15 +18,17 @@ class Movies(TMDB):
     """
     Movies functionality.
 
-    See: http://docs.themoviedb.apiary.io/#movies
+    See: https://developers.themoviedb.org/3/movies
     """
     BASE_PATH = 'movie'
     URLS = {
         'info': '/{id}',
         'alternative_titles': '/{id}/alternative_titles',
         'credits': '/{id}/credits',
+        'external_ids': '/{id}/external_ids',
         'images': '/{id}/images',
         'keywords': '/{id}/keywords',
+        'release_dates': '/{id}/release_dates',
         'releases': '/{id}/releases',
         'videos': '/{id}/videos',
         'translations': '/{id}/translations',
@@ -41,6 +43,7 @@ class Movies(TMDB):
         'top_rated': '/top_rated',
         'account_states': '/{id}/account_states',
         'rating': '/{id}/rating',
+        'recommendations': '/{id}/recommendations'
     }
 
     def __init__(self, id=0):
@@ -50,7 +53,7 @@ class Movies(TMDB):
     def info(self, **kwargs):
         """
         Get the basic movie information for a specific movie id.
-        
+
         Args:
             language: (optional) ISO 639-1 code.
             append_to_response: (optional) Comma separated, any movie method.
@@ -67,7 +70,7 @@ class Movies(TMDB):
     def alternative_titles(self, **kwargs):
         """
         Get the alternative titles for a specific movie id.
-        
+
         Args:
             country: (optional) ISO 3166-1 code.
             append_to_response: (optional) Comma separated, any movie method.
@@ -84,7 +87,7 @@ class Movies(TMDB):
     def credits(self, **kwargs):
         """
         Get the cast and crew information for a specific movie id.
-        
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
@@ -97,15 +100,32 @@ class Movies(TMDB):
         self._set_attrs_to_values(response)
         return response
 
-    def images(self, **kwargs):
+    def external_ids(self, **kwargs):
         """
-        Get the images (posters and backdrops) for a specific movie id.
-        
+        Get the external ids for a specific movie id.
+
         Args:
             language: (optional) ISO 639-1 code.
             append_to_response: (optional) Comma separated, any movie method.
-            include_image_language: (optional) Comma separated, a valid 
-                                    ISO 69-1. 
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('external_ids')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def images(self, **kwargs):
+        """
+        Get the images (posters and backdrops) for a specific movie id.
+
+        Args:
+            language: (optional) ISO 639-1 code.
+            append_to_response: (optional) Comma separated, any movie method.
+            include_image_language: (optional) Comma separated, a valid
+                                    ISO 69-1.
 
         Returns:
             A dict respresentation of the JSON returned from the API.
@@ -116,17 +136,47 @@ class Movies(TMDB):
         self._set_attrs_to_values(response)
         return response
 
-    def keywords(self, **kwargs):
+    def keywords(self):
         """
         Get the plot keywords for a specific movie id.
-        
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('keywords')
+
+        response = self._GET(path)
+        self._set_attrs_to_values(response)
+        return response
+
+    def recommendations(self, **kwargs):
+        """
+        Get a list of recommended movies for a movie.
+
+        Args:
+            language: (optional) ISO 639-1 code.
+            page: (optional) Minimum value of 1.  Expected value is an integer.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('recommendations')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def release_dates(self, **kwargs):
+        """
+        Get the release dates and certification for a specific movie id.
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_path('keywords')
+        path = self._get_id_path('release_dates')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -134,9 +184,9 @@ class Movies(TMDB):
 
     def releases(self, **kwargs):
         """
-        Get the release date and certification information by country for a 
+        Get the release date and certification information by country for a
         specific movie id.
-        
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
@@ -151,9 +201,9 @@ class Movies(TMDB):
 
     def videos(self, **kwargs):
         """
-        Get the videos (trailers, teasers, clips, etc...) for a 
+        Get the videos (trailers, teasers, clips, etc...) for a
         specific movie id.
-        
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
@@ -169,7 +219,7 @@ class Movies(TMDB):
     def translations(self, **kwargs):
         """
         Get the translations for a specific movie id.
-        
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
@@ -185,7 +235,7 @@ class Movies(TMDB):
     def similar_movies(self, **kwargs):
         """
         Get the similar movies for a specific movie id.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -203,7 +253,7 @@ class Movies(TMDB):
     def reviews(self, **kwargs):
         """
         Get the reviews for a particular movie id.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -221,7 +271,7 @@ class Movies(TMDB):
     def lists(self, **kwargs):
         """
         Get the lists that the movie belongs to.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -240,11 +290,11 @@ class Movies(TMDB):
         """
         Get the changes for a specific movie id.
 
-        Changes are grouped by key, and ordered by date in descending order. 
-        By default, only the last 24 hours of changes are returned. The 
-        maximum number of days that can be returned in a single request is 14. 
+        Changes are grouped by key, and ordered by date in descending order.
+        By default, only the last 24 hours of changes are returned. The
+        maximum number of days that can be returned in a single request is 14.
         The language is present on fields that are translatable.
-        
+
         Args:
             start_date: (optional) Expected format is 'YYYY-MM-DD'.
             end_date: (optional) Expected format is 'YYYY-MM-DD'.
@@ -261,7 +311,7 @@ class Movies(TMDB):
     def latest(self, **kwargs):
         """
         Get the latest movie id.
-        
+
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
@@ -273,9 +323,9 @@ class Movies(TMDB):
 
     def upcoming(self, **kwargs):
         """
-        Get the list of upcoming movies. This list refreshes every day. 
+        Get the list of upcoming movies. This list refreshes every day.
         The maximum number of items this list will include is 100.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -291,9 +341,9 @@ class Movies(TMDB):
 
     def now_playing(self, **kwargs):
         """
-        Get the list of movies playing in theatres. This list refreshes 
+        Get the list of movies playing in theatres. This list refreshes
         every day. The maximum number of items this list will include is 100.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -309,9 +359,9 @@ class Movies(TMDB):
 
     def popular(self, **kwargs):
         """
-        Get the list of popular movies on The Movie Database. This list 
+        Get the list of popular movies on The Movie Database. This list
         refreshes every day.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -327,10 +377,10 @@ class Movies(TMDB):
 
     def top_rated(self, **kwargs):
         """
-        Get the list of top rated movies. By default, this list will only 
-        include movies that have 10 or more votes. This list refreshes every 
+        Get the list of top rated movies. By default, this list will only
+        include movies that have 10 or more votes. This list refreshes every
         day.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -346,10 +396,10 @@ class Movies(TMDB):
 
     def account_states(self, **kwargs):
         """
-        This method lets users get the status of whether or not the movie has 
-        been rated or added to their favourite or watch lists. A valid session 
+        This method lets users get the status of whether or not the movie has
+        been rated or added to their favourite or watch lists. A valid session
         id is required.
-        
+
         Args:
             session_id: see Authentication.
 
@@ -364,7 +414,7 @@ class Movies(TMDB):
 
     def rating(self, **kwargs):
         """
-        This method lets users rate a movie. A valid session id or guest 
+        This method lets users rate a movie. A valid session id or guest
         session id is required.
 
         Args:
@@ -388,9 +438,9 @@ class Movies(TMDB):
 
 class Collections(TMDB):
     """
-    Collections functionality. 
+    Collections functionality.
 
-    See: http://docs.themoviedb.apiary.io/#collections
+    See: https://developers.themoviedb.org/3/collections
     """
     BASE_PATH = 'collection'
     URLS = {
@@ -404,13 +454,13 @@ class Collections(TMDB):
 
     def info(self, **kwargs):
         """
-        Get the basic collection information for a specific collection id. 
-        You can get the ID needed for this method by making a /movie/{id} 
+        Get the basic collection information for a specific collection id.
+        You can get the ID needed for this method by making a /movie/{id}
         request and paying attention to the belongs_to_collection hash.
 
-        Movie parts are not sorted in any particular order. If you would like 
+        Movie parts are not sorted in any particular order. If you would like
         to sort them yourself you can use the provided release_date.
-        
+
         Args:
             language: (optional) ISO 639-1 code.
             append_to_response: (optional) Comma separated, any movie method.
@@ -427,17 +477,17 @@ class Collections(TMDB):
     def images(self, **kwargs):
         """
         Get all of the images for a particular collection by collection id.
-        
+
         Args:
             language: (optional) ISO 639-1 code.
             append_to_response: (optional) Comma separated, any movie method.
-            include_image_language: (optional) Comma separated, a valid 
-            ISO 69-1. 
+            include_image_language: (optional) Comma separated, a valid
+            ISO 69-1.
 
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_path('info')
+        path = self._get_id_path('images')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -445,9 +495,9 @@ class Collections(TMDB):
 
 class Companies(TMDB):
     """
-    Companies functionality. 
+    Companies functionality.
 
-    See: http://docs.themoviedb.apiary.io/#companies
+    See: https://developers.themoviedb.org/3/companies
     """
     BASE_PATH = 'company'
     URLS = {
@@ -461,9 +511,9 @@ class Companies(TMDB):
 
     def info(self, **kwargs):
         """
-        This method is used to retrieve all of the basic information about a 
+        This method is used to retrieve all of the basic information about a
         company.
-        
+
         Args:
             append_to_response: (optional) Comma separated, any movie method.
 
@@ -475,11 +525,11 @@ class Companies(TMDB):
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
         return response
-        
+
     def movies(self, **kwargs):
         """
         Get the list of movies associated with a particular company.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -496,9 +546,9 @@ class Companies(TMDB):
 
 class Keywords(TMDB):
     """
-    Keywords functionality. 
+    Keywords functionality.
 
-    See: http://docs.themoviedb.apiary.io/#keywords
+    See: https://developers.themoviedb.org/3/keywords
     """
     BASE_PATH = 'keyword'
     URLS = {
@@ -513,7 +563,7 @@ class Keywords(TMDB):
     def info(self, **kwargs):
         """
         Get the basic information for a specific keyword id.
-        
+
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
@@ -526,7 +576,7 @@ class Keywords(TMDB):
     def movies(self, **kwargs):
         """
         Get the list of movies for a particular keyword by id.
-        
+
         Args:
             page: (optional) Minimum value of 1.  Expected value is an integer.
             language: (optional) ISO 639-1 code.
@@ -542,9 +592,9 @@ class Keywords(TMDB):
 
 class Reviews(TMDB):
     """
-    Reviews functionality. 
+    Reviews functionality.
 
-    See: http://docs.themoviedb.apiary.io/#reviews
+    See: https://developers.themoviedb.org/3/reviews
     """
     BASE_PATH = 'review'
     URLS = {
@@ -558,7 +608,7 @@ class Reviews(TMDB):
     def info(self, **kwargs):
         """
         Get the full details of a review by ID.
-        
+
         Returns:
             A dict respresentation of the JSON returned from the API.
         """

--- a/lib/tmdbsimple/people.py
+++ b/lib/tmdbsimple/people.py
@@ -8,7 +8,7 @@ of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -18,7 +18,7 @@ class People(TMDB):
     """
     People functionality.
 
-    See: http://docs.themoviedb.apiary.io/#people
+    See: https://developers.themoviedb.org/3/people
     """
     BASE_PATH = 'person'
     URLS = {
@@ -190,7 +190,7 @@ class Credits(TMDB):
     """
     Credits functionality.
 
-    See: http://docs.themoviedb.apiary.io/#credits
+    See: https://developers.themoviedb.org/3/credits
     """
     BASE_PATH = 'credit'
     URLS = {
@@ -230,7 +230,7 @@ class Jobs(TMDB):
     """
     Jobs functionality.
 
-    See: http://docs.themoviedb.apiary.io/#jobs
+    See: https://developers.themoviedb.org/3/jobs
     """
     BASE_PATH = 'job'
     URLS = {

--- a/lib/tmdbsimple/search.py
+++ b/lib/tmdbsimple/search.py
@@ -7,7 +7,7 @@ This module implements the Search functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
@@ -17,7 +17,7 @@ class Search(TMDB):
     """
     Search functionality
 
-    See: http://docs.themoviedb.apiary.io/#search
+    See: https://developers.themoviedb.org/3/search
     """
     BASE_PATH = 'search'
     URLS = {
@@ -25,7 +25,6 @@ class Search(TMDB):
         'collection': '/collection',
         'tv': '/tv',
         'person': '/person',
-        'list': '/list',
         'company': '/company',
         'keyword': '/keyword',
         'multi': '/multi'
@@ -125,25 +124,6 @@ class Search(TMDB):
             A dict respresentation of the JSON returned from the API.
         """
         path = self._get_path('person')
-
-        response = self._GET(path, kwargs)
-        self._set_attrs_to_values(response)
-        return response
-
-    def list(self, **kwargs):
-        """
-        Search for lists by name and description.
-
-        Args:
-            query: CGI escpaed string.
-            page: (optional) Minimum value of 1. Expected value is an integer.
-            include_adult: (optional) Toggle the inclusion of adult titles. 
-                           Expected value is True or False.
-
-        Returns:
-            A dict respresentation of the JSON returned from the API.
-        """
-        path = self._get_path('list')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)

--- a/lib/tmdbsimple/tv.py
+++ b/lib/tmdbsimple/tv.py
@@ -33,6 +33,7 @@ class TV(TMDB):
         'recommendations': '/{id}/recommendations',
         'translations': '/{id}/translations',
         'videos': '/{id}/videos',
+        'changes': '/{id}/changes',
         'latest': '/latest',
         'on_the_air': '/on_the_air',
         'airing_today': '/airing_today',
@@ -235,6 +236,28 @@ class TV(TMDB):
             A dict respresentation of the JSON returned from the API.
         """
         path = self._get_id_path('videos')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def changes(self, **kwargs):
+        """
+        Get the changes for a specific series id.
+
+        Changes are grouped by key, and ordered by date in descending order.
+        By default, only the last 24 hours of changes are returned. The
+        maximum number of days that can be returned in a single request is 14.
+        The language is present on fields that are translatable.
+
+        Args:
+            start_date: (optional) Expected format is 'YYYY-MM-DD'.
+            end_date: (optional) Expected format is 'YYYY-MM-DD'.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('changes')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)

--- a/lib/tmdbsimple/tv.py
+++ b/lib/tmdbsimple/tv.py
@@ -8,30 +8,32 @@ functionality of tmdbsimple.
 
 Created by Celia Oakley on 2013-10-31.
 
-:copyright: (c) 2013-2014 by Celia Oakley
+:copyright: (c) 2013-2018 by Celia Oakley
 :license: GPLv3, see LICENSE for more details
 """
 
 from .base import TMDB
 
-
 class TV(TMDB):
     """
     TV functionality.
 
-    See: http://docs.themoviedb.apiary.io/#tv
+    See: https://developers.themoviedb.org/3/tv
     """
     BASE_PATH = 'tv'
     URLS = {
         'info': '/{id}',
+        'alternative_titles': '/{id}/alternative_titles',
+        'content_ratings': '/{id}/content_ratings',
         'credits': '/{id}/credits',
         'external_ids': '/{id}/external_ids',
         'images': '/{id}/images',
         'rating': '/{id}/rating',
         'similar': '/{id}/similar',
+        'recommendations': '/{id}/recommendations',
         'translations': '/{id}/translations',
-        'changes': '/{id}/changes',
         'videos': '/{id}/videos',
+        'latest': '/latest',
         'on_the_air': '/on_the_air',
         'airing_today': '/airing_today',
         'top_rated': '/top_rated',
@@ -55,6 +57,42 @@ class TV(TMDB):
             A dict respresentation of the JSON returned from the API.
         """
         path = self._get_id_path('info')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+
+    def alternative_titles(self, **kwargs):
+        """
+        Get the alternative titles for a specific tv id.
+
+        Args:
+            language: (optional) ISO 3166-1 code.
+            append_to_response: (optional) Comma separated, any tv method.
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('alternative_titles')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+
+    def content_ratings(self, **kwargs):
+        """
+        Get the content ratings for a TV Series.
+
+        Args:
+            language: (optional) ISO 639 code.
+            append_to_response: (optional) Comma separated, any collection
+                                method.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('content_ratings')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -154,6 +192,23 @@ class TV(TMDB):
         self._set_attrs_to_values(response)
         return response
 
+    def recommendations(self, **kwargs):
+        """
+        Get the recommendations for TV series for a specific TV series id.
+
+        Args:
+            page: (optional) Minimum value of 1.  Expected value is an integer.
+            language: (optional) ISO 639-1 code.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('recommendations')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
     def translations(self, **kwargs):
         """
         Get the list of translations that exist for a TV series. These
@@ -180,6 +235,23 @@ class TV(TMDB):
             A dict respresentation of the JSON returned from the API.
         """
         path = self._get_id_path('videos')
+
+        response = self._GET(path, kwargs)
+        self._set_attrs_to_values(response)
+        return response
+
+    def latest(self, **kwargs):
+        """
+        Get the most newly created TV show. This is a live response
+		and will continuously change.
+
+        Args:
+            language: (optional) ISO 639 code.
+
+        Returns:
+            A dict respresentation of the JSON returned from the API.
+        """
+        path = self._get_id_path('latest')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -259,36 +331,14 @@ class TV(TMDB):
         self._set_attrs_to_values(response)
         return response
 
-    def changes(self, **kwargs):
-        """
-        Get the changes for a specific series id.
-
-        Changes are grouped by key, and ordered by date in descending order.
-        By default, only the last 24 hours of changes are returned. The
-        maximum number of days that can be returned in a single request is 14.
-        The language is present on fields that are translatable.
-
-        Args:
-            start_date: (optional) Expected format is 'YYYY-MM-DD'.
-            end_date: (optional) Expected format is 'YYYY-MM-DD'.
-
-        Returns:
-            A dict respresentation of the JSON returned from the API.
-        """
-        path = self._get_id_path('changes')
-
-        response = self._GET(path, kwargs)
-        self._set_attrs_to_values(response)
-        return response
-
 
 class TV_Seasons(TMDB):
     """
     TV Seasons functionality.
 
-    See: http://docs.themoviedb.apiary.io/#tvseasons
+    See: https://developers.themoviedb.org/3/tv-seasons
     """
-    BASE_PATH = 'tv/{id}/season/{season_number}'
+    BASE_PATH = 'tv/{series_id}/season/{season_number}'
     URLS = {
         'info': '',
         'credits': '/credits',
@@ -297,9 +347,9 @@ class TV_Seasons(TMDB):
         'videos': '/videos',
     }
 
-    def __init__(self, id, season_number):
+    def __init__(self, series_id, season_number):
         super(TV_Seasons, self).__init__()
-        self.id = id
+        self.series_id = series_id
         self.season_number = season_number
 
     def info(self, **kwargs):
@@ -314,7 +364,7 @@ class TV_Seasons(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_season_number_path('info')
+        path = self._get_series_id_season_number_path('info')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -327,7 +377,7 @@ class TV_Seasons(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_season_number_path('credits')
+        path = self._get_series_id_season_number_path('credits')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -344,7 +394,7 @@ class TV_Seasons(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_season_number_path('external_ids')
+        path = self._get_series_id_season_number_path('external_ids')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -363,7 +413,7 @@ class TV_Seasons(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_season_number_path('images')
+        path = self._get_series_id_season_number_path('images')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
@@ -380,17 +430,18 @@ class TV_Seasons(TMDB):
         Returns:
             A dict respresentation of the JSON returned from the API.
         """
-        path = self._get_id_season_number_path('videos')
+        path = self._get_series_id_season_number_path('videos')
 
         response = self._GET(path, kwargs)
         self._set_attrs_to_values(response)
         return response
 
+
 class TV_Episodes(TMDB):
     """
     TV Episodes functionality.
 
-    See: http://docs.themoviedb.apiary.io/#tvepisodes
+    See: https://developers.themoviedb.org/3/tv-episodes
     """
     BASE_PATH = 'tv/{series_id}/season/{season_number}/episode/{episode_number}'
     URLS = {
@@ -513,11 +564,12 @@ class TV_Episodes(TMDB):
         self._set_attrs_to_values(response)
         return response
 
+
 class Networks(TMDB):
     """
     Networks functionality.
 
-    See: http://docs.themoviedb.apiary.io/#networks
+    See: https://developers.themoviedb.org/3/networks
     """
     BASE_PATH = 'network'
     URLS = {

--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -314,7 +314,7 @@ class Tmdb(BaseIndexer):
         bid = images['id']
         for image_type, images in viewitems({'poster': images['posters'], 'fanart': images['backdrops']}):
             try:
-                if image_type not in _images:
+                if images and image_type not in _images:
                     _images[image_type] = {}
 
                 for image in images:

--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -65,7 +65,7 @@ class Tmdb(BaseIndexer):
             'last_air_date': 'airs_dayofweek',
             'last_updated': 'lastupdated',
             'network_id': 'networkid',
-            'vote_average': 'contentrating',
+            'vote_average': 'rating',
             'poster_path': 'poster',
             'genres': 'genre',
             'type': 'classification',
@@ -81,7 +81,7 @@ class Tmdb(BaseIndexer):
             'episode_run_time': 'runtime',
             'episode_number': 'episodenumber',
             'season_number': 'seasonnumber',
-            'vote_average': 'contentrating',
+            'vote_average': 'rating',
             'still_path': 'filename'
         }
 
@@ -440,6 +440,14 @@ class Tmdb(BaseIndexer):
         if not series_info:
             log.debug('Series result returned zero')
             raise IndexerError('Series result returned zero')
+
+        # Get MPAA rating if available
+        content_ratings = self.tmdb.TV(sid).content_ratings()
+        if content_ratings and content_ratings.get('results'):
+            mpaa_rating = next((r['rating'] for r in content_ratings['results']
+                                if r['iso_3166_1'].upper() == 'US'), None)
+            if mpaa_rating:
+                self._set_show_data(sid, 'contentrating', mpaa_rating)
 
         # get series data / add the base_url to the image urls
         # Create a key/value dict, to map the image type to a default image width.


### PR DESCRIPTION
### Fix saving metadata for show / episode exception when indexer is TMDB
- Updated `tmdbsimple` to version 2.2.0 for `TV(<id>).content_ratings()` (don't worry @p0psicles, I noticed the function you re-added :wink: )
- Fixed shows from TMDB not saving `tvshow.nfo` and `<episode>.nfo` properly

Fixes #4013 @duramato 

### Fix division by zero due to an empty image list when indexer is TMDB
[(explanation)](https://github.com/pymedusa/Medusa/pull/4026#issuecomment-381434390)
Fixes #4022 