### PR TITLE
Always show "Keep" option for quality chooser on mass edit page

### DIFF
--- a/themes-default/slim/views/manage_massEdit.mako
+++ b/themes-default/slim/views/manage_massEdit.mako
@@ -120,7 +120,7 @@ const startVue = () => {
                                                 allowed_qualities, preferred_qualities = Quality.split_quality(initial_quality)
                                                 overall_quality = Quality.combine_qualities(allowed_qualities, preferred_qualities)
                                             %>
-                                            <quality-chooser ${('', 'keep')[quality_value is None]}
+                                            <quality-chooser keep="${('show', 'keep')[quality_value is None]}"
                                                              :overall-quality.number="${overall_quality}" />
                                         </span>
                                     </label>

--- a/themes-default/slim/views/vue-components/quality-chooser.mako
+++ b/themes-default/slim/views/vue-components/quality-chooser.mako
@@ -84,8 +84,11 @@ Vue.component('quality-chooser', {
             default: ${overall_quality}
         },
         keep: {
-            type: Boolean,
-            default: false
+            type: String,
+            default: null,
+            validator(value) {
+                return ['keep', 'show'].includes(value);
+            }
         }
     },
     data() {
@@ -100,7 +103,7 @@ Vue.component('quality-chooser', {
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
-            selectedQualityPreset: this.keep ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
+            selectedQualityPreset: this.keep === 'keep' ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
             archive: false,
             archivedStatus: '',
             archiveButton: {

--- a/themes/dark/templates/manage_massEdit.mako
+++ b/themes/dark/templates/manage_massEdit.mako
@@ -120,7 +120,7 @@ const startVue = () => {
                                                 allowed_qualities, preferred_qualities = Quality.split_quality(initial_quality)
                                                 overall_quality = Quality.combine_qualities(allowed_qualities, preferred_qualities)
                                             %>
-                                            <quality-chooser ${('', 'keep')[quality_value is None]}
+                                            <quality-chooser keep="${('show', 'keep')[quality_value is None]}"
                                                              :overall-quality.number="${overall_quality}" />
                                         </span>
                                     </label>

--- a/themes/dark/templates/vue-components/quality-chooser.mako
+++ b/themes/dark/templates/vue-components/quality-chooser.mako
@@ -84,8 +84,11 @@ Vue.component('quality-chooser', {
             default: ${overall_quality}
         },
         keep: {
-            type: Boolean,
-            default: false
+            type: String,
+            default: null,
+            validator(value) {
+                return ['keep', 'show'].includes(value);
+            }
         }
     },
     data() {
@@ -100,7 +103,7 @@ Vue.component('quality-chooser', {
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
-            selectedQualityPreset: this.keep ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
+            selectedQualityPreset: this.keep === 'keep' ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
             archive: false,
             archivedStatus: '',
             archiveButton: {

--- a/themes/light/templates/manage_massEdit.mako
+++ b/themes/light/templates/manage_massEdit.mako
@@ -120,7 +120,7 @@ const startVue = () => {
                                                 allowed_qualities, preferred_qualities = Quality.split_quality(initial_quality)
                                                 overall_quality = Quality.combine_qualities(allowed_qualities, preferred_qualities)
                                             %>
-                                            <quality-chooser ${('', 'keep')[quality_value is None]}
+                                            <quality-chooser keep="${('show', 'keep')[quality_value is None]}"
                                                              :overall-quality.number="${overall_quality}" />
                                         </span>
                                     </label>

--- a/themes/light/templates/vue-components/quality-chooser.mako
+++ b/themes/light/templates/vue-components/quality-chooser.mako
@@ -84,8 +84,11 @@ Vue.component('quality-chooser', {
             default: ${overall_quality}
         },
         keep: {
-            type: Boolean,
-            default: false
+            type: String,
+            default: null,
+            validator(value) {
+                return ['keep', 'show'].includes(value);
+            }
         }
     },
     data() {
@@ -100,7 +103,7 @@ Vue.component('quality-chooser', {
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
-            selectedQualityPreset: this.keep ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
+            selectedQualityPreset: this.keep === 'keep' ? 'keep' : (qualityPresets.includes(this.overallQuality) ? this.overallQuality : 0),
             archive: false,
             archivedStatus: '',
             archiveButton: {


### PR DESCRIPTION
As suggested on Slack.

For the current sceduled release.
This is basically restoring a functionality that's available in current master, and I implemented it in a wrong way when I converted the page to Vue.

**Always** show "Keep" option for quality chooser on **mass edit page**
If the qualities of the edited shows are the same, it will still select the correct quality.
But, you get the option to just select "Keep".
So if you changed a bunch of options including the quality, then changed your mind before submitting the form, you don't have to remember what quality was selected, or refresh the page.