### PR TITLE
Never split torrent files on NZB providers. Fix #3946

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -171,6 +171,7 @@ class GenericProvider(object):
 
         # TODO: Remove this in future versions, kept for the warning
         # Some NZB providers (e.g. Jackett) can also download torrents
+        # A similar check is performed for NZB splitting in medusa/search/core.py @ search_providers()
         if (result.url.endswith(GenericProvider.TORRENT) or
                 result.url.startswith('magnet:')) and self.provider_type == GenericProvider.NZB:
             filename = join(app.TORRENT_DIR, result_name + '.torrent')

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -729,7 +729,9 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                           best_season_result.provider.provider_type,
                           best_season_result.name)
             else:
-                if best_season_result.provider.provider_type == GenericProvider.NZB:
+                # Some NZB providers (e.g. Jackett) can also download torrents, but torrents cannot be split like NZB
+                if (best_season_result.provider.provider_type == GenericProvider.NZB and
+                        not best_season_result.url.endswith(GenericProvider.TORRENT)):
                     log.debug(u'Breaking apart the NZB and adding the individual ones to our results')
 
                     # if not, break it apart and add them as the lowest priority results


### PR DESCRIPTION
- Never split torrent files on NZB providers, hopefully fixes #3946 
- Use BraceAdapter logging in nzb_splitter.