### PR TITLE
Replace cmp with itemgetter/attrgetter or key

### DIFF
--- a/medusa/browser.py
+++ b/medusa/browser.py
@@ -8,8 +8,6 @@ import os
 import string
 from builtins import str
 
-from past.builtins import cmp
-
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
@@ -103,8 +101,7 @@ def list_folders(path, include_parent=False, include_files=False):
         log.warning('Unable to open %s: %s / %s', path, repr(e), str(e))
         file_list = get_file_list(parent_path, include_files)
 
-    file_list = sorted(file_list,
-                       lambda x, y: cmp(os.path.basename(x['name']).lower(), os.path.basename(y['path']).lower()))
+    file_list = sorted(file_list, key=lambda x: os.path.basename(x['name']).lower())
 
     entries = [{'currentPath': path}]
     if include_parent and parent_path != path:

--- a/medusa/generic_queue.py
+++ b/medusa/generic_queue.py
@@ -6,6 +6,7 @@ import datetime
 import logging
 import threading
 from builtins import object
+from functools import cmp_to_key
 
 log = logging.getLogger()
 
@@ -83,7 +84,7 @@ class GenericQueue(object):
                         else:
                             return y.priority - x.priority
 
-                    self.queue.sort(cmp=sorter)
+                    self.queue.sort(key=cmp_to_key(sorter))
                     if self.queue[0].priority < self.min_priority:
                         return
 

--- a/medusa/server/web/core/base.py
+++ b/medusa/server/web/core/base.py
@@ -26,8 +26,6 @@ from medusa import (
 )
 from medusa.server.api.v1.core import function_mapper
 
-from past.builtins import cmp
-
 from requests.compat import urljoin
 
 from six import (
@@ -308,7 +306,7 @@ class WebRoot(WebHandler):
             return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
 
         main_db_con = db.DBConnection(row_type='dict')
-        shows = sorted(app.showList, lambda x, y: cmp(titler(x.name), titler(y.name)))
+        shows = sorted(app.showList, key=lambda x: titler(x.name.lower()))
         episodes = {}
 
         results = main_db_con.select(

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -93,8 +93,6 @@ from medusa.system.restart import Restart
 from medusa.system.shutdown import Shutdown
 from medusa.version_checker import CheckVersion
 
-from past.builtins import cmp
-
 from requests.compat import (
     quote_plus,
     unquote_plus,
@@ -940,12 +938,12 @@ class Home(WebRoot):
                 else:
                     shows.append(show)
             sorted_show_lists = [
-                ['Shows', sorted(shows, lambda x, y: cmp(titler(x.name).lower(), titler(y.name).lower()))],
-                ['Anime', sorted(anime, lambda x, y: cmp(titler(x.name).lower(), titler(y.name).lower()))]
+                ['Shows', sorted(shows, key=lambda x: titler(x.name).lower())],
+                ['Anime', sorted(anime, key=lambda x: titler(x.name).lower())]
             ]
         else:
             sorted_show_lists = [
-                ['Shows', sorted(app.showList, lambda x, y: cmp(titler(x.name).lower(), titler(y.name).lower()))]
+                ['Shows', sorted(app.showList, key=lambda x: titler(x.name).lower())]
             ]
 
         bwl = None
@@ -1236,11 +1234,13 @@ class Home(WebRoot):
                 else:
                     shows.append(show)
             sorted_show_lists = [
-                ['Shows', sorted(shows, lambda x, y: cmp(titler(x.name), titler(y.name)))],
-                ['Anime', sorted(anime, lambda x, y: cmp(titler(x.name), titler(y.name)))]]
+                ['Shows', sorted(shows, key=lambda x: titler(x.name).lower())],
+                ['Anime', sorted(anime, key=lambda x: titler(x.name).lower())]
+            ]
         else:
             sorted_show_lists = [
-                ['Shows', sorted(app.showList, lambda x, y: cmp(titler(x.name), titler(y.name)))]]
+                ['Shows', sorted(app.showList, key=lambda x: titler(x.name).lower())]
+            ]
 
         bwl = None
         if series_obj.is_anime:

--- a/medusa/show/coming_episodes.py
+++ b/medusa/show/coming_episodes.py
@@ -21,6 +21,7 @@ from __future__ import unicode_literals
 from builtins import object
 from builtins import str
 from datetime import date, timedelta
+from operator import itemgetter
 
 from medusa import app
 from medusa.common import (
@@ -36,8 +37,6 @@ from medusa.network_timezones import parse_date_time
 from medusa.sbdatetime import sbdatetime
 from medusa.tv.series import SeriesIdentifier
 
-from past.builtins import cmp
-
 
 class ComingEpisodes(object):
     """
@@ -49,9 +48,9 @@ class ComingEpisodes(object):
 
     categories = ['later', 'missed', 'soon', 'today']
     sorts = {
-        'date': (lambda a, b: cmp(a['localtime'], b['localtime'])),
-        'network': (lambda a, b: cmp((a['network'], a['localtime']), (b['network'], b['localtime']))),
-        'show': (lambda a, b: cmp((a['show_name'], a['localtime']), (b['show_name'], b['localtime']))),
+        'date': itemgetter('localtime'),
+        'network': itemgetter('network', 'localtime'),
+        'show': itemgetter('show_name', 'localtime'),
     }
 
     def __init__(self):
@@ -132,7 +131,7 @@ class ComingEpisodes(object):
             results[index]['localtime'] = sbdatetime.convert_to_setting(
                 parse_date_time(item['airdate'], item['airs'], item['network']))
 
-        results.sort(ComingEpisodes.sorts[sort])
+        results.sort(key=ComingEpisodes.sorts[sort])
 
         if not group:
             return results

--- a/themes-default/slim/static/js/home/index.js
+++ b/themes-default/slim/static/js/home/index.js
@@ -117,7 +117,7 @@ MEDUSA.home.index = function() {
         headers: {
             0: { sorter: 'realISODate' },
             1: { sorter: 'realISODate' },
-            2: { sorter: 'loadingNames' },
+            2: { sorter: 'showNames' },
             4: { sorter: 'text' },
             5: { sorter: 'quality' },
             6: { sorter: 'eps' },

--- a/themes-default/slim/static/js/parsers.js
+++ b/themes-default/slim/static/js/parsers.js
@@ -1,5 +1,5 @@
 $.tablesorter.addParser({
-    id: 'loadingNames',
+    id: 'showNames',
     is() {
         return false;
     },

--- a/themes-default/slim/views/manage.mako
+++ b/themes-default/slim/views/manage.mako
@@ -3,6 +3,7 @@
     from medusa import app
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
     from medusa.common import statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script type="text/javascript" src="js/mass-update.js?${sbPID}"></script>
@@ -88,8 +89,11 @@ const startVue = () => {
                 </tfoot>
                 <tbody>
             <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
                 my_show_list = app.showList
-                my_show_list.sort(lambda x, y: cmp(x.name, y.name))
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>
                 % for cur_show in my_show_list:
                 <%

--- a/themes-default/slim/views/manage_backlogOverview.mako
+++ b/themes-default/slim/views/manage_backlogOverview.mako
@@ -1,8 +1,9 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     from medusa import app
-    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
     from medusa import sbdatetime
+    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script>
@@ -35,8 +36,14 @@ const startVue = () => {
 <div class="row">
     <div class="col-md-12">
 <%
+    def titler(x):
+        return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
     totalWanted = totalQual = 0
-    backLogShows = sorted([x for x in app.showList if x.paused == 0 and showCounts[(x.indexer, x.series_id)][Overview.QUAL] + showCounts[(x.indexer, x.series_id)][Overview.WANTED]], key=lambda x: x.name)
+    backLogShows = sorted([x for x in app.showList if x.paused == 0 and
+                           showCounts[(x.indexer, x.series_id)][Overview.QUAL] +
+                           showCounts[(x.indexer, x.series_id)][Overview.WANTED]],
+                          key=lambda x: titler(x.name).lower())
     for cur_show in backLogShows:
         totalWanted += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.WANTED]
         totalQual += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]

--- a/themes-default/slim/views/partials/home/banner.mako
+++ b/themes-default/slim/views/partials/home/banner.mako
@@ -75,7 +75,7 @@
             <tbody>
             <%
                 def titler(x):
-                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+                   return (remove_article(x), x)[not x or app.SORT_ARTICLE]
 
                 my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>

--- a/themes-default/slim/views/partials/home/banner.mako
+++ b/themes-default/slim/views/partials/home/banner.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes-default/slim/views/partials/home/poster.mako
+++ b/themes-default/slim/views/partials/home/poster.mako
@@ -1,11 +1,13 @@
 <%!
-    from medusa import app
     import calendar
+    import re
+
+    from medusa import app
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <div class="loading-spinner"></div>
@@ -42,7 +44,12 @@
                 </div>
             % endif
         % endfor
-        <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+        <%
+            def titler(x):
+                return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+            my_show_list.sort(key=lambda x: titler(x.name).lower())
+        %>
         % for cur_show in my_show_list:
         <%
             cur_airs_next = ''

--- a/themes-default/slim/views/partials/home/simple.mako
+++ b/themes-default/slim/views/partials/home/simple.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -75,7 +74,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes-default/slim/views/partials/home/small.mako
+++ b/themes-default/slim/views/partials/home/small.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes-default/slim/views/viewlogs.mako
+++ b/themes-default/slim/views/viewlogs.mako
@@ -87,7 +87,7 @@ pre {
                         <select name="min_level" id="min_level" class="form-control form-control-inline input-sm">
                             <%
                                 levels = LOGGING_LEVELS.keys()
-                                levels.sort(lambda x, y: cmp(LOGGING_LEVELS[x], LOGGING_LEVELS[y]))
+                                levels.sort(key=lambda x: LOGGING_LEVELS[x])
                                 if not app.DEBUG:
                                     levels.remove('DEBUG')
                                 if not app.DBDEBUG:

--- a/themes/dark/assets/js/home/index.js
+++ b/themes/dark/assets/js/home/index.js
@@ -117,7 +117,7 @@ MEDUSA.home.index = function() {
         headers: {
             0: { sorter: 'realISODate' },
             1: { sorter: 'realISODate' },
-            2: { sorter: 'loadingNames' },
+            2: { sorter: 'showNames' },
             4: { sorter: 'text' },
             5: { sorter: 'quality' },
             6: { sorter: 'eps' },

--- a/themes/dark/assets/js/parsers.js
+++ b/themes/dark/assets/js/parsers.js
@@ -1,5 +1,5 @@
 $.tablesorter.addParser({
-    id: 'loadingNames',
+    id: 'showNames',
     is() {
         return false;
     },

--- a/themes/dark/templates/manage.mako
+++ b/themes/dark/templates/manage.mako
@@ -3,6 +3,7 @@
     from medusa import app
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
     from medusa.common import statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script type="text/javascript" src="js/mass-update.js?${sbPID}"></script>
@@ -88,8 +89,11 @@ const startVue = () => {
                 </tfoot>
                 <tbody>
             <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
                 my_show_list = app.showList
-                my_show_list.sort(lambda x, y: cmp(x.name, y.name))
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>
                 % for cur_show in my_show_list:
                 <%

--- a/themes/dark/templates/manage_backlogOverview.mako
+++ b/themes/dark/templates/manage_backlogOverview.mako
@@ -1,8 +1,9 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     from medusa import app
-    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
     from medusa import sbdatetime
+    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script>
@@ -35,8 +36,14 @@ const startVue = () => {
 <div class="row">
     <div class="col-md-12">
 <%
+    def titler(x):
+        return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
     totalWanted = totalQual = 0
-    backLogShows = sorted([x for x in app.showList if x.paused == 0 and showCounts[(x.indexer, x.series_id)][Overview.QUAL] + showCounts[(x.indexer, x.series_id)][Overview.WANTED]], key=lambda x: x.name)
+    backLogShows = sorted([x for x in app.showList if x.paused == 0 and
+                           showCounts[(x.indexer, x.series_id)][Overview.QUAL] +
+                           showCounts[(x.indexer, x.series_id)][Overview.WANTED]],
+                          key=lambda x: titler(x.name).lower())
     for cur_show in backLogShows:
         totalWanted += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.WANTED]
         totalQual += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]

--- a/themes/dark/templates/partials/home/banner.mako
+++ b/themes/dark/templates/partials/home/banner.mako
@@ -75,7 +75,7 @@
             <tbody>
             <%
                 def titler(x):
-                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+                   return (remove_article(x), x)[not x or app.SORT_ARTICLE]
 
                 my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>

--- a/themes/dark/templates/partials/home/banner.mako
+++ b/themes/dark/templates/partials/home/banner.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/dark/templates/partials/home/poster.mako
+++ b/themes/dark/templates/partials/home/poster.mako
@@ -1,11 +1,13 @@
 <%!
-    from medusa import app
     import calendar
+    import re
+
+    from medusa import app
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <div class="loading-spinner"></div>
@@ -42,7 +44,12 @@
                 </div>
             % endif
         % endfor
-        <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+        <%
+            def titler(x):
+                return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+            my_show_list.sort(key=lambda x: titler(x.name).lower())
+        %>
         % for cur_show in my_show_list:
         <%
             cur_airs_next = ''

--- a/themes/dark/templates/partials/home/simple.mako
+++ b/themes/dark/templates/partials/home/simple.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -75,7 +74,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/dark/templates/partials/home/small.mako
+++ b/themes/dark/templates/partials/home/small.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/dark/templates/viewlogs.mako
+++ b/themes/dark/templates/viewlogs.mako
@@ -87,7 +87,7 @@ pre {
                         <select name="min_level" id="min_level" class="form-control form-control-inline input-sm">
                             <%
                                 levels = LOGGING_LEVELS.keys()
-                                levels.sort(lambda x, y: cmp(LOGGING_LEVELS[x], LOGGING_LEVELS[y]))
+                                levels.sort(key=lambda x: LOGGING_LEVELS[x])
                                 if not app.DEBUG:
                                     levels.remove('DEBUG')
                                 if not app.DBDEBUG:

--- a/themes/light/assets/js/home/index.js
+++ b/themes/light/assets/js/home/index.js
@@ -117,7 +117,7 @@ MEDUSA.home.index = function() {
         headers: {
             0: { sorter: 'realISODate' },
             1: { sorter: 'realISODate' },
-            2: { sorter: 'loadingNames' },
+            2: { sorter: 'showNames' },
             4: { sorter: 'text' },
             5: { sorter: 'quality' },
             6: { sorter: 'eps' },

--- a/themes/light/assets/js/parsers.js
+++ b/themes/light/assets/js/parsers.js
@@ -1,5 +1,5 @@
 $.tablesorter.addParser({
-    id: 'loadingNames',
+    id: 'showNames',
     is() {
         return false;
     },

--- a/themes/light/templates/manage.mako
+++ b/themes/light/templates/manage.mako
@@ -3,6 +3,7 @@
     from medusa import app
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST, FAILED
     from medusa.common import statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script type="text/javascript" src="js/mass-update.js?${sbPID}"></script>
@@ -88,8 +89,11 @@ const startVue = () => {
                 </tfoot>
                 <tbody>
             <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
                 my_show_list = app.showList
-                my_show_list.sort(lambda x, y: cmp(x.name, y.name))
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>
                 % for cur_show in my_show_list:
                 <%

--- a/themes/light/templates/manage_backlogOverview.mako
+++ b/themes/light/templates/manage_backlogOverview.mako
@@ -1,8 +1,9 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     from medusa import app
-    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
     from medusa import sbdatetime
+    from medusa.common import ARCHIVED, DOWNLOADED, Overview, Quality, qualityPresets, statusStrings
+    from medusa.helpers import remove_article
 %>
 <%block name="scripts">
 <script>
@@ -35,8 +36,14 @@ const startVue = () => {
 <div class="row">
     <div class="col-md-12">
 <%
+    def titler(x):
+        return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
     totalWanted = totalQual = 0
-    backLogShows = sorted([x for x in app.showList if x.paused == 0 and showCounts[(x.indexer, x.series_id)][Overview.QUAL] + showCounts[(x.indexer, x.series_id)][Overview.WANTED]], key=lambda x: x.name)
+    backLogShows = sorted([x for x in app.showList if x.paused == 0 and
+                           showCounts[(x.indexer, x.series_id)][Overview.QUAL] +
+                           showCounts[(x.indexer, x.series_id)][Overview.WANTED]],
+                          key=lambda x: titler(x.name).lower())
     for cur_show in backLogShows:
         totalWanted += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.WANTED]
         totalQual += showCounts[(cur_show.indexer, cur_show.series_id)][Overview.QUAL]

--- a/themes/light/templates/partials/home/banner.mako
+++ b/themes/light/templates/partials/home/banner.mako
@@ -75,7 +75,7 @@
             <tbody>
             <%
                 def titler(x):
-                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+                   return (remove_article(x), x)[not x or app.SORT_ARTICLE]
 
                 my_show_list.sort(key=lambda x: titler(x.name).lower())
             %>

--- a/themes/light/templates/partials/home/banner.mako
+++ b/themes/light/templates/partials/home/banner.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                   return (helpers.remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/light/templates/partials/home/poster.mako
+++ b/themes/light/templates/partials/home/poster.mako
@@ -1,11 +1,13 @@
 <%!
-    from medusa import app
     import calendar
+    import re
+
+    from medusa import app
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 <div class="loading-spinner"></div>
@@ -42,7 +44,12 @@
                 </div>
             % endif
         % endfor
-        <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+        <%
+            def titler(x):
+                return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+            my_show_list.sort(key=lambda x: titler(x.name).lower())
+        %>
         % for cur_show in my_show_list:
         <%
             cur_airs_next = ''

--- a/themes/light/templates/partials/home/simple.mako
+++ b/themes/light/templates/partials/home/simple.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -75,7 +74,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/light/templates/partials/home/small.mako
+++ b/themes/light/templates/partials/home/small.mako
@@ -1,12 +1,11 @@
 <%!
     from medusa import app
-    import calendar
     from medusa import sbdatetime
     from medusa import network_timezones
+    from medusa.helpers import remove_article
     from medusa.indexers.indexer_api import indexerApi
     from medusa.helper.common import pretty_file_size
     from medusa.scene_numbering import get_xem_numbering_for_show
-    import re
 %>
 <%namespace file="/inc_defs.mako" import="renderQualityPill"/>
 % for cur_show_list in show_lists:
@@ -74,7 +73,12 @@
                 </tbody>
             % endif
             <tbody>
-            <% my_show_list.sort(lambda x, y: cmp(x.name, y.name)) %>
+            <%
+                def titler(x):
+                    return (remove_article(x), x)[not x or app.SORT_ARTICLE]
+
+                my_show_list.sort(key=lambda x: titler(x.name).lower())
+            %>
             % for cur_show in my_show_list:
             <%
                 cur_airs_next = ''

--- a/themes/light/templates/viewlogs.mako
+++ b/themes/light/templates/viewlogs.mako
@@ -87,7 +87,7 @@ pre {
                         <select name="min_level" id="min_level" class="form-control form-control-inline input-sm">
                             <%
                                 levels = LOGGING_LEVELS.keys()
-                                levels.sort(lambda x, y: cmp(LOGGING_LEVELS[x], LOGGING_LEVELS[y]))
+                                levels.sort(key=lambda x: LOGGING_LEVELS[x])
                                 if not app.DEBUG:
                                     levels.remove('DEBUG')
                                 if not app.DBDEBUG:


### PR DESCRIPTION
Should fix #4087 
@medariox 
- [x] `medusa\browser.py`: **switch to `key=`**
- [x] `medusa\generic_queue.py`: **switch to `key=` & `cmp_to_key()`**
- [x] `medusa\server\web\core\base.py`: **switch to `key=`, apply the sort article**
- [x] `medusa\server\web\home\handler.py`: **switch to `key=`, apply the sort article**
- [x] `medusa\show\coming_episodes.py`: **switch to `itemgetter`**
- [x] `themes-default\slim\views\manage.mako`: **switch to `key=`, apply the sort article**
- [x] `themes-default\slim\views\partials\home\banner.mako`: **switch to `key=`, apply the sort article**
- [x] `themes-default\slim\views\partials\home\poster.mako`: **switch to `key=`, apply the sort article**
- [x] `themes-default\slim\views\partials\home\simple.mako`: **switch to `key=`, apply the sort article**
- [x] `themes-default\slim\views\partials\home\small.mako`: **switch to `key=`, apply the sort article**
- [x] `themes-default\slim\views\viewlogs.mako`: **switch to `key=`**

## Extra changes:
- [x] `themes-default\slim\views\manage_backlogOverview.mako`: **Apply the sort article - fixes #3715** 