### PR TITLE
Cache: Fix incorrect return value

### DIFF
--- a/medusa/db.py
+++ b/medusa/db.py
@@ -218,7 +218,7 @@ class DBConnection(object):
                                 logger.log(qu[0] + " with args " + str(qu[1]), logger.DEBUG)
                             sql_results.append(self._execute(qu[0], qu[1], fetchall=fetchall))
                     self.connection.commit()
-                    logger.log(u"Transaction with " + str(len(querylist)) + u" queries executed", logger.DEBUG)
+                    logger.log(u"Transaction with " + str(len(sql_results)) + u" queries executed", logger.DEBUG)
 
                     # finished
                     break

--- a/medusa/db.py
+++ b/medusa/db.py
@@ -198,9 +198,8 @@ class DBConnection(object):
         :param fetchall: Boolean, when using a select query force returning all results
         :return: list of results
         """
-        querylist = querylist or []
-        # remove None types
-        querylist = [i for i in querylist if i is not None and len(i)]
+        # Remove Falsey types
+        querylist = (q for q in querylist or [] if q)
 
         sql_results = []
         attempt = 0

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -310,7 +310,7 @@ class Cache(object):
         else:
             log.debug('The data returned from the {0} feed is incomplete,'
                       ' this result is unusable', self.provider.name)
-        return False
+        return None
 
     @property
     def updated(self):


### PR DESCRIPTION
The altered line used to not exist, as can be seen [here](https://github.com/pymedusa/Medusa/commit/18056a265f866fc0352761cccd1777e8287985ae#diff-04bdc0be0e7d1bf798758336637007b6).

As I explained [in this comment](https://github.com/pymedusa/Medusa/issues/4092#issuecomment-383708438), that function should return `None`.
Python methods that exit without a `return <VALUE>` statement, or with just a `return`, return `None`.
The commit above changed that to `False`.

This should fix #4092.