### PR TITLE
Traktor: Catch HTTPError 413, log attempt counter

### DIFF
--- a/lib/traktor/trakt.py
+++ b/lib/traktor/trakt.py
@@ -123,7 +123,7 @@ class TraktApi(object):
             code = getattr(e.response, 'status_code', None)
             if code == 502:
                 # Retry the request, cloudflare had a proxying issue
-                log.debug(u'Retrying trakt api request: %s (attempt: %d)', path, count)
+                log.debug(u'Retrying trakt api request: {0} (attempt: {1})'.format(path, count))
                 return self.request(path, data, headers, url, method, count=count)
             elif code == 401:
                 if self.get_token(refresh_token=True, count=count):
@@ -137,7 +137,7 @@ class TraktApi(object):
                 # http://docs.trakt.apiary.io/#introduction/status-codes
                 raise UnavailableException(u"Trakt may have some issues and it's unavailable. Try again later please")
             elif code == 404:
-                log_message = u'Trakt error (404) Not found - the resource does not exist: %s' % url + path
+                log_message = u'Trakt error (404) Not found - the resource does not exist: {0}'.format(url + path)
                 log.error(log_message)
                 raise ResourceUnavailable(log_message)
             elif code == 410:
@@ -155,7 +155,7 @@ class TraktApi(object):
                 log.debug(u'Trakt response body:\n{0}'.format(e.response.body))
                 raise TraktException(log_message)
             else:
-                log_message = u'Unknown Trakt request exception. Error: %s' % code if code else e
+                log_message = u'Unknown Trakt request exception. Error: {0}'.format(code or e)
                 log.error(log_message)
                 raise TraktException(log_message)
 


### PR DESCRIPTION
- Not really a bugfix since we couldn't figure out what the was the actual issue.
  Added a check for HTTPError 413, and request + response info for troubleshooting.
- Added the attempt counter to HTTPError 502.

Related to #4090 