### PR TITLE
Newznab|Torznab: Replace newstr with six.text_type

### DIFF
--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 from builtins import range
-from builtins import str
 from builtins import zip
 from collections import namedtuple
 
@@ -33,7 +32,7 @@ from medusa.providers.nzb.nzb_provider import NZBProvider
 
 from requests.compat import urljoin
 
-from six import iteritems, itervalues
+from six import iteritems, itervalues, text_type as str
 
 import validators
 

--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import os
-from builtins import str
 from collections import namedtuple
 
 from medusa import (
@@ -26,7 +25,7 @@ from medusa.providers.torrent.torrent_provider import TorrentProvider
 
 from requests.compat import urljoin
 
-from six import iteritems, itervalues
+from six import iteritems, itervalues, text_type as str
 
 
 log = BraceAdapter(logging.getLogger(__name__))


### PR DESCRIPTION
Fixes:
```
2018-04-25 17:15:48 DEBUG    SEARCHQUEUE-BACKLOG-80748 :: [NZBGeek] :: [c3e7e58] Traceback (most recent call last):
  File "C:\Medusa\medusa\session\core.py", line 147, in request
    timeout=timeout, verify=verify, **kwargs)
  File "C:\Medusa\medusa\session\core.py", line 99, in request
    **kwargs)
  File "C:\Medusa\ext\requests\sessions.py", line 494, in request
    prep = self.prepare_request(req)
  File "C:\Medusa\ext\requests\sessions.py", line 437, in prepare_request
    hooks=merge_hooks(request.hooks, self.hooks),
  File "C:\Medusa\ext\requests\models.py", line 305, in prepare
    self.prepare_url(url, params)
  File "C:\Medusa\ext\requests\models.py", line 423, in prepare_url
    enc_params = self._encode_params(params)
  File "C:\Medusa\ext\requests\models.py", line 105, in _encode_params
    return urlencode(result, doseq=True)
  File "C:\Python27\lib\urllib.py", line 1349, in urlencode
    v = quote_plus(v)
  File "C:\Python27\lib\urllib.py", line 1306, in quote_plus
    return quote(s, safe)
  File "C:\Python27\lib\urllib.py", line 1299, in quote
    return ''.join(map(quoter, s))
KeyError: 48
```