### PR TITLE
Fix exception_handler exception

### DIFF
--- a/medusa/exception_handler.py
+++ b/medusa/exception_handler.py
@@ -17,10 +17,10 @@ def handle(err, message='', *args, **kwargs):
     m = message.format(*args, **kwargs) + ': ' if message else ''
     if isinstance(err, EnvironmentError):
         if err.errno == 28:
-            logger.warning('{m}Out of disk space: {error_msg}', m=m, error_msg=err)
+            logger.warning('{m}Out of disk space: {error_msg}'.format(m=m, error_msg=err))
         elif err.errno == 13:
-            logger.warning('{m}Permission denied: {error_msg}', m=m, error_msg=err)
+            logger.warning('{m}Permission denied: {error_msg}'.format(m=m, error_msg=err))
         else:
-            logger.exception('{m}Environment error: {error_msg}', m=m, error_msg=err)
+            logger.exception('{m}Environment error: {error_msg}'.format(m=m, error_msg=err))
     else:
-        logger.exception('{m}Exception generated: {error_msg}', m=m, error_msg=err)
+        logger.exception('{m}Exception generated: {error_msg}'.format(m=m, error_msg=err))


### PR DESCRIPTION
Oh yeah, THAT happened:
```
>>> import exception_handler
>>> exception_handler.handle(IOError('da!'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "exception_handler.py", line 24, in handle
    logger.exception('{m}Environment error: {error_msg}', m=m, error_msg=err)
  File "C:\Python27\lib\logging\__init__.py", line 1200, in exception
    self.error(msg, *args, **kwargs)
  File "C:\Python27\lib\logging\__init__.py", line 1193, in error
    self._log(ERROR, msg, args, **kwargs)
TypeError: _log() got an unexpected keyword argument 'm'
```