### PR TITLE
qBittorent: Don't error when torrent queueing is disabled

### DIFF
--- a/medusa/clients/torrent/qbittorrent_client.py
+++ b/medusa/clients/torrent/qbittorrent_client.py
@@ -4,10 +4,16 @@
 
 from __future__ import unicode_literals
 
+import logging
+
 from medusa import app
 from medusa.clients.torrent.generic import GenericClient
+from medusa.logger.adapters.style import BraceAdapter
 
 from requests.auth import HTTPDigestAuth
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
 
 
 class QBittorrentAPI(GenericClient):
@@ -105,7 +111,14 @@ class QBittorrentAPI(GenericClient):
         data = {
             'hashes': result.hash.lower(),
         }
-        return self._request(method='post', data=data, cookies=self.session.cookies)
+        ok = self._request(method='post', data=data, cookies=self.session.cookies)
+
+        if self.response.status_code == 403:
+            log.info('{name}: Unable to set torrent priority because torrent queueing'
+                     ' is disabled in {name} settings.', {'name': self.name})
+            ok = True
+
+        return ok
 
     def _set_torrent_pause(self, result):
         self.url = '{host}command/{state}'.format(host=self.host,


### PR DESCRIPTION
Stop errors like:
<pre>
DEBUG    THREAD :: [6148669] POST URL: http://x.x.x.x:xxxx/command/increasePrio [Status: 403]
INFO     THREAD :: [6148669] qbittorrent: Forbidden
<b>ERROR</b>    THREAD :: [6148669] qbittorrent: Unable to set priority for Torrent
</pre>

This will now show:
<pre>
INFO     THREAD :: [6148669] qbittorrent: Forbidden
<b>INFO</b>     THREAD :: [6148669] qbittorrent: Unable to set torrent priority because torrent queueing is disabled in qbittorrent settings.
</pre>

- Related to #4032
- Related to #2686