### PR TITLE
Providers: Remove Traceback from errors, use log.exception

### DIFF
--- a/medusa/helper/common.py
+++ b/medusa/helper/common.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 import datetime
 import logging
 import re
-import traceback
 from fnmatch import fnmatch
 
 from medusa import app
@@ -320,7 +319,7 @@ def try_int(candidate, default_value=0):
         return int(candidate)
     except (ValueError, TypeError):
         if candidate and (',' in candidate or '.' in candidate):
-            log.error(u'Failed parsing provider. Traceback: %r', traceback.format_exc())
+            log.exception(u'Failed parsing provider.')
         return default_value
 
 

--- a/medusa/providers/nzb/anizb.py
+++ b/medusa/providers/nzb/anizb.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -94,8 +93,7 @@ class Anizb(NZBProvider):
 
                                 items.append(item)
                             except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                                log.error('Failed parsing provider. Traceback: {0!r}',
-                                          traceback.format_exc())
+                                log.exception('Failed parsing provider.')
                                 continue
 
                 results += items

--- a/medusa/providers/torrent/html/abnormal.py
+++ b/medusa/providers/torrent/html/abnormal.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -171,8 +170,7 @@ class ABNormalProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/alpharatio.py
+++ b/medusa/providers/torrent/html/alpharatio.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -174,8 +173,7 @@ class AlphaRatioProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/anidex.py
+++ b/medusa/providers/torrent/html/anidex.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -148,8 +147,7 @@ class AniDexProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/animebytes.py
+++ b/medusa/providers/torrent/html/animebytes.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -280,8 +279,7 @@ class AnimeBytes(TorrentProvider):
                                 continue
 
                     except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                        log.error('Failed parsing provider. Traceback: {0!r}',
-                                  traceback.format_exc())
+                        log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/animetorrents.py
+++ b/medusa/providers/torrent/html/animetorrents.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import (
     scene_exceptions,
@@ -181,8 +180,7 @@ class AnimeTorrentsProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/bithdtv.py
+++ b/medusa/providers/torrent/html/bithdtv.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -160,8 +159,7 @@ class BithdtvProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/elitetracker.py
+++ b/medusa/providers/torrent/html/elitetracker.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -182,8 +181,7 @@ class EliteTrackerProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/hdspace.py
+++ b/medusa/providers/torrent/html/hdspace.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -172,8 +171,7 @@ class HDSpaceProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/hdtorrents.py
+++ b/medusa/providers/torrent/html/hdtorrents.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -177,8 +176,7 @@ class HDTorrentsProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/hebits.py
+++ b/medusa/providers/torrent/html/hebits.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -169,8 +168,7 @@ class HeBitsProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/horriblesubs.py
+++ b/medusa/providers/torrent/html/horriblesubs.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -137,8 +136,7 @@ class HorribleSubsProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/iptorrents.py
+++ b/medusa/providers/torrent/html/iptorrents.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -149,8 +148,7 @@ class IPTorrentsProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/morethantv.py
+++ b/medusa/providers/torrent/html/morethantv.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 import logging
 import re
 import time
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -189,8 +188,7 @@ class MoreThanTVProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/nebulance.py
+++ b/medusa/providers/torrent/html/nebulance.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -173,8 +172,7 @@ class NebulanceProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/pretome.py
+++ b/medusa/providers/torrent/html/pretome.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -151,8 +150,7 @@ class PretomeProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/scenetime.py
+++ b/medusa/providers/torrent/html/scenetime.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -171,8 +170,7 @@ class SceneTimeProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/speedcd.py
+++ b/medusa/providers/torrent/html/speedcd.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -165,8 +164,7 @@ class SpeedCDProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/tntvillage.py
+++ b/medusa/providers/torrent/html/tntvillage.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -174,8 +173,7 @@ class TNTVillageProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/torrentbytes.py
+++ b/medusa/providers/torrent/html/torrentbytes.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -175,8 +174,7 @@ class TorrentBytesProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/html/tvchaosuk.py
+++ b/medusa/providers/torrent/html/tvchaosuk.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -192,8 +191,7 @@ class TVChaosUKProvider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/json/bitcannon.py
+++ b/medusa/providers/torrent/json/bitcannon.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.helper.common import (
@@ -150,8 +149,7 @@ class BitCannonProvider(TorrentProvider):
 
                 items.append(item)
             except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                log.error('Failed parsing provider. Traceback: {0!r}',
-                          traceback.format_exc())
+                log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/json/xthor.py
+++ b/medusa/providers/torrent/json/xthor.py
@@ -5,7 +5,6 @@
 from __future__ import unicode_literals
 
 import logging
-import traceback
 
 from medusa import tv
 from medusa.common import USER_AGENT
@@ -157,8 +156,7 @@ class XthorProvider(TorrentProvider):
 
                 items.append(item)
             except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                log.error('Failed parsing provider. Traceback: {0!r}',
-                          traceback.format_exc())
+                log.exception('Failed parsing provider.')
 
         return items
 

--- a/medusa/providers/torrent/xml/torrentz2.py
+++ b/medusa/providers/torrent/xml/torrentz2.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import traceback
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
@@ -144,8 +143,7 @@ class Torrentz2Provider(TorrentProvider):
 
                     items.append(item)
                 except (AttributeError, TypeError, KeyError, ValueError, IndexError):
-                    log.error('Failed parsing provider. Traceback: {0!r}',
-                              traceback.format_exc())
+                    log.exception('Failed parsing provider.')
 
         return items
 


### PR DESCRIPTION
Pretty sure that's the way it's supposed to be?