### PR TITLE
Don't stop newznab search if params are missing. Fixes #4115

### DIFF
--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -108,8 +108,6 @@ class NewznabProvider(NZBProvider):
         # For providers that don't have caps, or for which the t=caps is not working.
         if not self.params and all(provider not in self.url for provider in self.providers_without_caps):
             self.get_capabilities(just_params=True)
-            if not self.params:
-                return results
 
         # Search Params
         search_params = {


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

If the provider doesn't have any `(tv)-search params` it should still try to search without them, instead of giving up.