### PR TITLE
Fix /config for web root users

### DIFF
--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: '${app.WEB_ROOT}/',
+                    base: document.body.getAttribute('api-root').replace('api/v2/', ''),
                     mode: 'history',
                     routes
                 });

--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: document.getElementsByTagName('base')[0].getAttribute('href'),
+                    base: '${app.WEB_ROOT}/',
                     mode: 'history',
                     routes
                 });

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: '${app.WEB_ROOT}/',
+                    base: document.body.getAttribute('api-root').replace('api/v2/', ''),
                     mode: 'history',
                     routes
                 });

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: document.getElementsByTagName('base')[0].getAttribute('href'),
+                    base: '${app.WEB_ROOT}/',
                     mode: 'history',
                     routes
                 });

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: '${app.WEB_ROOT}/',
+                    base: document.body.getAttribute('api-root').replace('api/v2/', ''),
                     mode: 'history',
                     routes
                 });

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -134,7 +134,7 @@
             if (!window.app) {
                 console.info('Loading Vue with router since window.app is missing.');
                 const router = new vueRouter({
-                    base: document.getElementsByTagName('base')[0].getAttribute('href'),
+                    base: '${app.WEB_ROOT}/',
                     mode: 'history',
                     routes
                 });


### PR DESCRIPTION
@OmgImAlexis  According to https://router.vuejs.org/en/api/options.html#base we should use a relative path and not the full URL for the router `base`.
Tested and working for both an empty `WEB_ROOT` and a non-empty one.
Notice that I added `/` that will always be there.

@medariox @p0psicles 