### PR TITLE
Add support for downloading dramas

### DIFF
--- a/medusa/databases/main_db.py
+++ b/medusa/databases/main_db.py
@@ -706,3 +706,21 @@ class AddIndexerIds(AddIndexerInteger):
         # Flag the image migration.
         from medusa import app
         app.MIGRATE_IMAGES = True
+
+
+class AddDramaSupport(AddIndexerIds):
+
+    def test(self):
+        """
+        Test if the version is at least 44.10
+        """
+        return self.connection.version >= (44, 10)
+
+    def execute(self):
+        backupDatabase(self.connection.version)
+
+        log.info(u'Adding column drama in tv_shows')
+        if not self.hasColumn('tv_shows', 'drama'):
+            self.addColumn('tv_shows', 'drama', 'NUMERIC', False)
+
+        self.inc_minor_version()

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -635,6 +635,8 @@ class GenericProvider(object):
                 episode_string += str(episode.airdate).replace('-', ' ')
                 episode_string += ('|', ' ')[len(self.proper_strings) > 1]
                 episode_string += episode.airdate.strftime('%b')
+            elif episode.series.drama:
+                episode_string += 'E{0:0>2}'.format(episode.episode)
             elif episode.series.anime:
                 # If the showname is a season scene exception, we want to use the indexer episode number.
                 if (episode.scene_season > 1 and

--- a/medusa/server/api/v2/series.py
+++ b/medusa/server/api/v2/series.py
@@ -120,6 +120,7 @@ class SeriesHandler(BaseRequestHandler):
             'config.dvdOrder': BooleanField(series, 'dvd_order'),
             'config.flattenFolders': BooleanField(series, 'flatten_folders'),
             'config.anime': BooleanField(series, 'anime'),
+            'config.drama': BooleanField(series, 'drama'),
             'config.scene': BooleanField(series, 'scene'),
             'config.sports': BooleanField(series, 'sports'),
             'config.paused': BooleanField(series, 'paused'),

--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -457,7 +457,7 @@ class HomeAddShows(Home):
 
         # add the show
         app.show_queue_scheduler.action.addShow(INDEXER_TVDBV2, int(series_id), show_dir, int(default_status), quality,
-                                                flatten_folders, indexer_lang, subtitles, anime, drama, scene, None,
+                                                flatten_folders, indexer_lang, subtitles, anime, scene, None,
                                                 blacklist, whitelist, int(default_status_after), root_dir=location)
 
         ui.notifications.message('Show added', 'Adding the specified show {0}'.format(show_name))
@@ -575,7 +575,7 @@ class HomeAddShows(Home):
 
         # add the show
         app.show_queue_scheduler.action.addShow(indexer, indexer_id, show_dir, int(defaultStatus), new_quality,
-                                                flatten_folders, indexer_lang, subtitles, anime, drama,
+                                                flatten_folders, indexer_lang, subtitles, anime,
                                                 scene, None, blacklist, whitelist, int(defaultStatusAfter))
         ui.notifications.message('Show added', 'Adding the specified show into {path}'.format(path=show_dir))
 

--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -408,6 +408,7 @@ class HomeAddShows(Home):
             # prepare the inputs for passing along
             scene = config.checkbox_to_value(scene)
             anime = config.checkbox_to_value(anime)
+            drama = config.checkbox_to_value(drama)
             flatten_folders = config.checkbox_to_value(flatten_folders)
             subtitles = config.checkbox_to_value(subtitles)
 
@@ -457,8 +458,8 @@ class HomeAddShows(Home):
 
         # add the show
         app.show_queue_scheduler.action.addShow(INDEXER_TVDBV2, int(series_id), show_dir, int(default_status), quality,
-                                                flatten_folders, indexer_lang, subtitles, anime, scene, None, blacklist,
-                                                whitelist, int(default_status_after), root_dir=location)
+                                                flatten_folders, indexer_lang, subtitles, anime, drama, scene, None,
+                                                blacklist, whitelist, int(default_status_after), root_dir=location)
 
         ui.notifications.message('Show added', 'Adding the specified show {0}'.format(show_name))
 
@@ -555,6 +556,7 @@ class HomeAddShows(Home):
         # prepare the inputs for passing along
         scene = config.checkbox_to_value(scene)
         anime = config.checkbox_to_value(anime)
+        drama = config.checkbox_to_value(drama)
         flatten_folders = config.checkbox_to_value(flatten_folders)
         subtitles = config.checkbox_to_value(subtitles)
 
@@ -575,7 +577,7 @@ class HomeAddShows(Home):
 
         # add the show
         app.show_queue_scheduler.action.addShow(indexer, indexer_id, show_dir, int(defaultStatus), new_quality,
-                                                flatten_folders, indexer_lang, subtitles, anime,
+                                                flatten_folders, indexer_lang, subtitles, anime, drama,
                                                 scene, None, blacklist, whitelist, int(defaultStatusAfter))
         ui.notifications.message('Show added', 'Adding the specified show into {path}'.format(path=show_dir))
 
@@ -652,6 +654,7 @@ class HomeAddShows(Home):
                     flatten_folders=app.FLATTEN_FOLDERS_DEFAULT,
                     subtitles=app.SUBTITLES_DEFAULT,
                     anime=app.ANIME_DEFAULT,
+                    drama=app.DRAMA_DEFAULT,
                     scene=app.SCENE_DEFAULT,
                     default_status_after=app.STATUS_DEFAULT_AFTER
                 )

--- a/medusa/server/web/home/add_shows.py
+++ b/medusa/server/web/home/add_shows.py
@@ -408,7 +408,6 @@ class HomeAddShows(Home):
             # prepare the inputs for passing along
             scene = config.checkbox_to_value(scene)
             anime = config.checkbox_to_value(anime)
-            drama = config.checkbox_to_value(drama)
             flatten_folders = config.checkbox_to_value(flatten_folders)
             subtitles = config.checkbox_to_value(subtitles)
 
@@ -556,7 +555,6 @@ class HomeAddShows(Home):
         # prepare the inputs for passing along
         scene = config.checkbox_to_value(scene)
         anime = config.checkbox_to_value(anime)
-        drama = config.checkbox_to_value(drama)
         flatten_folders = config.checkbox_to_value(flatten_folders)
         subtitles = config.checkbox_to_value(subtitles)
 

--- a/medusa/show/recommendations/recommended.py
+++ b/medusa/show/recommendations/recommended.py
@@ -109,6 +109,7 @@ class RecommendedShow(object):
         self.image_src = show_attr.get('image_src')
         self.ids = show_attr.get('ids', {})
         self.is_anime = False
+        self.is_drama = False
 
         # Check if the show is currently already in the db
         self.show_in_list = bool([show.indexerid for show in app.showList

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -234,14 +234,14 @@ class ShowQueue(generic_queue.GenericQueue):
         return queueItemObj
 
     def addShow(self, indexer, indexer_id, showDir, default_status=None, quality=None, flatten_folders=None,
-                lang=None, subtitles=None, anime=None, drama=None, scene=None, paused=None,
+                lang=None, subtitles=None, anime=None, scene=None, paused=None,
                 blacklist=None, whitelist=None, default_status_after=None, root_dir=None):
 
         if lang is None:
             lang = app.INDEXER_DEFAULT_LANGUAGE
 
         queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang,
-                                    subtitles, anime, drama, scene, paused, blacklist, whitelist, default_status_after,
+                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after,
                                     root_dir)
 
         self.add_item(queueItemObj)
@@ -308,7 +308,7 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 class QueueItemAdd(ShowQueueItem):
     def __init__(self, indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang, subtitles, anime,
-                 drama, scene, paused, blacklist, whitelist, default_status_after, root_dir):
+                scene, paused, blacklist, whitelist, default_status_after, root_dir):
 
         if isinstance(showDir, binary_type):
             self.showDir = text_type(showDir, 'utf-8')
@@ -323,7 +323,6 @@ class QueueItemAdd(ShowQueueItem):
         self.lang = lang
         self.subtitles = subtitles
         self.anime = anime
-        self.drama = drama
         self.scene = scene
         self.paused = paused
         self.blacklist = blacklist

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -234,14 +234,14 @@ class ShowQueue(generic_queue.GenericQueue):
         return queueItemObj
 
     def addShow(self, indexer, indexer_id, showDir, default_status=None, quality=None, flatten_folders=None,
-                lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None,
-                default_status_after=None, root_dir=None):
+                lang=None, subtitles=None, anime=None, drama=None, scene=None, paused=None,
+                blacklist=None, whitelist=None, default_status_after=None, root_dir=None):
 
         if lang is None:
             lang = app.INDEXER_DEFAULT_LANGUAGE
 
         queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang,
-                                    subtitles, anime, scene, paused, blacklist, whitelist, default_status_after,
+                                    subtitles, anime, drama, scene, paused, blacklist, whitelist, default_status_after,
                                     root_dir)
 
         self.add_item(queueItemObj)
@@ -308,7 +308,7 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 class QueueItemAdd(ShowQueueItem):
     def __init__(self, indexer, indexer_id, showDir, default_status, quality, flatten_folders, lang, subtitles, anime,
-                 scene, paused, blacklist, whitelist, default_status_after, root_dir):
+                 drama, scene, paused, blacklist, whitelist, default_status_after, root_dir):
 
         if isinstance(showDir, binary_type):
             self.showDir = text_type(showDir, 'utf-8')
@@ -323,6 +323,7 @@ class QueueItemAdd(ShowQueueItem):
         self.lang = lang
         self.subtitles = subtitles
         self.anime = anime
+        self.drama = drama
         self.scene = scene
         self.paused = paused
         self.blacklist = blacklist

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -368,6 +368,8 @@ class Episode(TV):
             return self.airdate.strftime(dateFormat)
         if self.series.is_anime and self.absolute_number is not None:
             return 'e{0:02d}'.format(self.absolute_number)
+        if self.series.is_drama:
+            return 'e{0:02d'.format(self.episode.episode)
 
         return 's{0:02d}e{1:02d}'.format(self.season, self.episode)
 

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -369,7 +369,7 @@ class Episode(TV):
         if self.series.is_anime and self.absolute_number is not None:
             return 'e{0:02d}'.format(self.absolute_number)
         if self.series.is_drama:
-            return 'e{0:02d'.format(self.episode.episode)
+            return 'e{0:02d}'.format(self.episode.episode)
 
         return 's{0:02d}e{1:02d}'.format(self.season, self.episode)
 

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -217,6 +217,7 @@ class Series(TV):
         self.last_update_indexer = 1
         self.sports = 0
         self.anime = 0
+        self.drama = 0
         self.scene = 0
         self.rls_ignore_words = ''
         self.rls_require_words = ''
@@ -323,6 +324,11 @@ class Series(TV):
     def is_anime(self):
         """Check if the show is Anime."""
         return bool(self.anime)
+
+    @property
+    def is_drama(self):
+        """Check if the show is a drama."""
+        return bool(self.drama)
 
     def is_location_valid(self, location=None):
         """
@@ -1496,6 +1502,7 @@ class Series(TV):
             self.start_year = int(sql_results[0][b'startyear'] or 0)
             self.air_by_date = int(sql_results[0][b'air_by_date'] or 0)
             self.anime = int(sql_results[0][b'anime'] or 0)
+            self.drama = int(sql_results[0][b'drama'] or 0)
             self.sports = int(sql_results[0][b'sports'] or 0)
             self.scene = int(sql_results[0][b'scene'] or 0)
             self.subtitles = int(sql_results[0][b'subtitles'] or 0)
@@ -1961,6 +1968,7 @@ class Series(TV):
                           'paused': self.paused,
                           'air_by_date': self.air_by_date,
                           'anime': self.anime,
+                          'drama': self.drama,
                           'scene': self.scene,
                           'sports': self.sports,
                           'subtitles': self.subtitles,
@@ -2013,6 +2021,7 @@ class Series(TV):
         to_return += 'scene: ' + str(self.is_scene) + '\n'
         to_return += 'sports: ' + str(self.is_sports) + '\n'
         to_return += 'anime: ' + str(self.is_anime) + '\n'
+        to_return += 'drama: ' + str(self.is_drama) + '\n'
         return to_return
 
     def __unicode__(self):
@@ -2040,6 +2049,7 @@ class Series(TV):
         to_return += u'scene: {0}\n'.format(self.is_scene)
         to_return += u'sports: {0}\n'.format(self.is_sports)
         to_return += u'anime: {0}\n'.format(self.is_anime)
+        to_return += u'drama: {0}\n'.format(self.is_drama)
         return to_return
 
     def to_json(self, detailed=True):

--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -26,6 +26,7 @@ const startVue = () => {
                         defaultEpisodeStatus: '',
                         flattenFolders: false,
                         anime: false,
+                        drama: false,
                         scene: false,
                         sports: false,
                         paused: false,
@@ -84,6 +85,7 @@ const startVue = () => {
                             dvdOrder: this.series.config.dvdOrder,
                             flattenFolders: this.series.config.flattenFolders,
                             anime: this.series.config.anime,
+                            drama: this.series.config.drama,
                             scene: this.series.config.scene,
                             sports: this.series.config.sports,
                             paused: this.series.config.paused,
@@ -238,6 +240,14 @@ const startVue = () => {
                                 <span class="component-desc">
                                     <input type="checkbox" id="airbydate" name="air_by_date" v-model="series.config.airByDate" @change="saveSeries('series')" /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br>
                                     <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                </span>
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label for="drama">
+                                <span class="component-title">Drama</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="drama" name="drama" v-model="series.config.drama" @change="saveSeries('series')"> check if the show is a drama and episodes are released as Show.E01 rather than Show.S01E01<br>
                                 </span>
                             </label>
                         </div>

--- a/themes/dark/assets/js/add-shows/init.js
+++ b/themes/dark/assets/js/add-shows/init.js
@@ -141,6 +141,7 @@ MEDUSA.addShows.init = function() {
                 default_flatten_folders: !$('#season_folders').prop('checked'), // eslint-disable-line camelcase
                 subtitles: $('#subtitles').prop('checked'),
                 anime: $('#anime').prop('checked'),
+                drama: $('#drama').prop('checked'),
                 scene: $('#scene').prop('checked'),
                 default_status_after: $('#statusSelectAfter').val() // eslint-disable-line camelcase
             });

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -26,6 +26,7 @@ const startVue = () => {
                         defaultEpisodeStatus: '',
                         flattenFolders: false,
                         anime: false,
+                        drama: false,
                         scene: false,
                         sports: false,
                         paused: false,
@@ -84,6 +85,7 @@ const startVue = () => {
                             dvdOrder: this.series.config.dvdOrder,
                             flattenFolders: this.series.config.flattenFolders,
                             anime: this.series.config.anime,
+                            drama: this.series.config.drama,
                             scene: this.series.config.scene,
                             sports: this.series.config.sports,
                             paused: this.series.config.paused,
@@ -238,6 +240,14 @@ const startVue = () => {
                                 <span class="component-desc">
                                     <input type="checkbox" id="airbydate" name="air_by_date" v-model="series.config.airByDate" @change="saveSeries('series')" /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br>
                                     <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                </span>
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label for="drama">
+                                <span class="component-title">Drama</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="drama" name="drama" v-model="series.config.drama" @change="saveSeries('series')"> check if the show is a drama and episodes are released as Show.E01 rather than Show.S01E01<br>
                                 </span>
                             </label>
                         </div>

--- a/themes/dark/templates/partials/showheader.mako
+++ b/themes/dark/templates/partials/showheader.mako
@@ -241,6 +241,7 @@
                             <tr><td class="showLegend">Air-by-Date: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.air_by_date)]}" alt="${("N", "Y")[bool(show.air_by_date)]}" width="16" height="16" /></td></tr>
                             <tr><td class="showLegend">Sports: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.is_sports)]}" alt="${("N", "Y")[bool(show.is_sports)]}" width="16" height="16" /></td></tr>
                             <tr><td class="showLegend">Anime: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.is_anime)]}" alt="${("N", "Y")[bool(show.is_anime)]}" width="16" height="16" /></td></tr>
+                            <tr><td class="showLegend">Drama: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.is_drama)]}" alt="${("N", "Y")[bool(show.is_drama)]}" width="16" height="16" /></td></tr>
                             <tr><td class="showLegend">DVD Order: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.dvd_order)]}" alt="${("N", "Y")[bool(show.dvd_order)]}" width="16" height="16" /></td></tr>
                             <tr><td class="showLegend">Scene Numbering: </td><td><img src="images/${("no16.png", "yes16.png")[bool(show.scene)]}" alt="${("N", "Y")[bool(show.scene)]}" width="16" height="16" /></td></tr>
                         </table>

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -84,6 +84,7 @@ const startVue = () => {
                             dvdOrder: this.series.config.dvdOrder,
                             flattenFolders: this.series.config.flattenFolders,
                             anime: this.series.config.anime,
+                            drama: this.series.config.drama,
                             scene: this.series.config.scene,
                             sports: this.series.config.sports,
                             paused: this.series.config.paused,
@@ -238,6 +239,14 @@ const startVue = () => {
                                 <span class="component-desc">
                                     <input type="checkbox" id="airbydate" name="air_by_date" v-model="series.config.airByDate" @change="saveSeries('series')" /> check if the show is released as Show.03.02.2010 rather than Show.S02E03.<br>
                                     <span style="color:rgb(255, 0, 0);">In case of an air date conflict between regular and special episodes, the later will be ignored.</span>
+                                </span>
+                            </label>
+                        </div>
+                        <div class="field-pair">
+                            <label for="drama">
+                                <span class="component-title">Drama</span>
+                                <span class="component-desc">
+                                    <input type="checkbox" id="drama" name="drama" v-model="series.config.drama" @change="saveSeries('series')"> check if the show is a drama and episodes are released as Show.E01 rather than Show.S01E01<br>
                                 </span>
                             </label>
                         </div>


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This is a follow up on #4119.

This PR will allow Medusa to download shows without a season number, like: `Suits E02 1080p HDTV AAC H.264-NEXT`.

This PR adds a new shows type (like air by date, sports, anime) "dramas" which changes the search behavior to not include a season number, as this is how many of these dramas are released.

This PR doesn't currently change any post-processor logic as single season shows will parse files just fine without a season number in them.