### PR TITLE
disable codecov comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,1 @@
+comment: off


### PR DESCRIPTION
I added Codecov as a Github App so we no longer needed the comment as it'll show in the checks section with travis, etc.

![screen shot 2018-04-28 at 9 32 41 pm](https://user-images.githubusercontent.com/6525926/39396345-ba8f8980-4b2b-11e8-8ec3-d1eb46329d8e.png)
