### PR TITLE
GitUpdateManager: Always prune when fetching

### DIFF
--- a/medusa/version_checker.py
+++ b/medusa/version_checker.py
@@ -560,7 +560,7 @@ class GitUpdateManager(UpdateManager):
         self.update_remote_origin()
 
         # get all new info from github
-        output, _, exit_status = self._run_git(self._git_path, 'fetch %s' % app.GIT_REMOTE)
+        output, _, exit_status = self._run_git(self._git_path, 'fetch --prune %s' % app.GIT_REMOTE)
         if not exit_status == 0:
             log.warning(u"Unable to contact github, can't check for update")
             return


### PR DESCRIPTION
Preemptively add this so old branch refs get pruned from git.
When we don't do this, it could lead to git erroring because it can't update the ref.
```
CHECKVERSION :: git fetch origin returned : error: cannot lock ref 'refs/remotes/origin/ui/navbar-fixed-icon-width': 'refs/remotes/origin/ui' exists; cannot create 'refs/remotes/origin/ui/navbar-fixed-icon-width'
From https://github.com/org/repo
! [new branch] ui/navbar-fixed-icon-width -> origin/ui/navbar-fixed-icon-width (unable to update local ref)
error: some local refs could not be updated; try running
'git remote prune origin' to remove any old, conflicting branches
CHECKVERSION :: Unable to contact github, can't check for update
```