### PR TITLE
Fix metadata issues

### DIFF
--- a/medusa/metadata/generic.py
+++ b/medusa/metadata/generic.py
@@ -462,6 +462,10 @@ class GenericMetadata(object):
         nfo_file_path = self.get_episode_file_path(ep_obj)
         nfo_file_dir = os.path.dirname(nfo_file_path)
 
+        if not (nfo_file_path and nfo_file_dir):
+            log.debug(u'Unable to write episode nfo file because episode location is missing.')
+            return False
+
         try:
             if not os.path.isdir(nfo_file_dir):
                 log.debug(u'Metadata directory missing, creating it at {location}',

--- a/medusa/metadata/mede8er.py
+++ b/medusa/metadata/mede8er.py
@@ -15,7 +15,7 @@ from medusa.indexers.indexer_exceptions import IndexerEpisodeNotFound, IndexerSe
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.metadata import media_browser
 
-from six import string_types, text_type
+from six import string_types, text_type as str
 
 try:
     import xml.etree.cElementTree as etree
@@ -117,7 +117,7 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
             first_aired = etree.SubElement(tv_node, 'premiered')
             first_aired.text = my_show['firstaired']
             try:
-                year_text = text_type(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
+                year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                 if year_text:
                     year = etree.SubElement(tv_node, 'year')
                     year.text = year_text
@@ -136,7 +136,7 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
 
             if rating:
                 rating = etree.SubElement(tv_node, 'rating')
-                rating.text = text_type(rating)
+                rating.text = str(rating)
 
         if getattr(my_show, 'status', None):
             status = etree.SubElement(tv_node, 'status')
@@ -153,11 +153,11 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
 
         if getattr(my_show, 'id', None):
             indexer_id = etree.SubElement(tv_node, 'indexerid')
-            indexer_id.text = my_show['id']
+            indexer_id.text = str(my_show['id'])
 
         if getattr(my_show, 'runtime', None):
             runtime = etree.SubElement(tv_node, 'runtime')
-            runtime.text = my_show['runtime']
+            runtime.text = str(my_show['runtime'])
 
         if getattr(my_show, '_actors', None):
             cast = etree.SubElement(tv_node, 'cast')
@@ -213,7 +213,7 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
 
                 # default to today's date for specials if firstaired is not set
                 if ep_to_write.season == 0 and not getattr(my_ep, 'firstaired', None):
-                    my_ep['firstaired'] = text_type(datetime.date.fromordinal(1))
+                    my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
                 if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                     return None
@@ -225,14 +225,14 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
                     episode_name.text = ep_to_write.name
 
                 season_number = etree.SubElement(episode, 'season')
-                season_number.text = text_type(ep_to_write.season)
+                season_number.text = str(ep_to_write.season)
 
                 episode_number = etree.SubElement(episode, 'episode')
-                episode_number.text = text_type(ep_to_write.episode)
+                episode_number.text = str(ep_to_write.episode)
 
                 if getattr(my_show, 'firstaired', None):
                     try:
-                        year_text = text_type(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
+                        year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                         if year_text:
                             year = etree.SubElement(episode, 'year')
                             year.text = year_text
@@ -259,7 +259,7 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
 
                     if rating:
                         rating = etree.SubElement(episode, 'rating')
-                        rating.text = text_type(rating)
+                        rating.text = str(rating)
 
                 if getattr(my_ep, 'director', None):
                     director = etree.SubElement(episode, 'director')

--- a/medusa/metadata/mede8er.py
+++ b/medusa/metadata/mede8er.py
@@ -380,6 +380,10 @@ class Mede8erMetadata(media_browser.MediaBrowserMetadata):
         nfo_file_path = self.get_episode_file_path(ep_obj)
         nfo_file_dir = os.path.dirname(nfo_file_path)
 
+        if not (nfo_file_path and nfo_file_dir):
+            log.debug(u'Unable to write episode nfo file because episode location is missing.')
+            return False
+
         try:
             if not os.path.isdir(nfo_file_dir):
                 log.debug('Metadata directory did not exist, creating it at {location}',

--- a/medusa/metadata/media_browser.py
+++ b/medusa/metadata/media_browser.py
@@ -13,7 +13,7 @@ from medusa.indexers.indexer_exceptions import IndexerEpisodeNotFound, IndexerSe
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.metadata import generic
 
-from six import iteritems, string_types, text_type
+from six import iteritems, string_types, text_type as str
 
 try:
     import xml.etree.cElementTree as etree
@@ -231,7 +231,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
         if getattr(my_show, u'id', None):
             indexerid = etree.SubElement(tv_node, u'id')
-            indexerid.text = text_type(my_show[u'id'])
+            indexerid.text = str(my_show[u'id'])
 
         if getattr(my_show, u'seriesname', None):
             series_name = etree.SubElement(tv_node, u'SeriesName')
@@ -280,11 +280,11 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
         if getattr(my_show, u'rating', None):
             rating = etree.SubElement(tv_node, u'Rating')
-            rating.text = text_type(my_show[u'rating'])
+            rating.text = str(my_show[u'rating'])
 
         if getattr(my_show, u'firstaired', None):
             try:
-                year_text = text_type(datetime.datetime.strptime(my_show[u'firstaired'], dateFormat).year)
+                year_text = str(datetime.datetime.strptime(my_show[u'firstaired'], dateFormat).year)
                 if year_text:
                     production_year = etree.SubElement(tv_node, u'ProductionYear')
                     production_year.text = year_text
@@ -293,10 +293,10 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
         if getattr(my_show, u'runtime', None):
             running_time = etree.SubElement(tv_node, u'RunningTime')
-            running_time.text = my_show[u'runtime']
+            running_time.text = str(my_show[u'runtime'])
 
             runtime = etree.SubElement(tv_node, u'Runtime')
-            runtime.text = my_show[u'runtime']
+            runtime.text = str(my_show[u'runtime'])
 
         if getattr(my_show, u'imdb_id', None):
             imdb_id = etree.SubElement(tv_node, u'IMDB_ID')
@@ -392,7 +392,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
                 # default to today's date for specials if firstaired is not set
                 if ep_to_write.season == 0 and not getattr(my_ep, u'firstaired', None):
-                    my_ep[u'firstaired'] = text_type(datetime.date.fromordinal(1))
+                    my_ep[u'firstaired'] = str(datetime.date.fromordinal(1))
 
                 if not (getattr(my_ep, u'episodename', None) and getattr(my_ep, u'firstaired', None)):
                     return None
@@ -404,22 +404,22 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                     episode_name.text = ep_to_write.name
 
                 episode_number = etree.SubElement(episode, u'EpisodeNumber')
-                episode_number.text = text_type(ep_obj.episode)
+                episode_number.text = str(ep_obj.episode)
 
                 if ep_obj.related_episodes:
                     episode_number_end = etree.SubElement(episode, u'EpisodeNumberEnd')
-                    episode_number_end.text = text_type(ep_to_write.episode)
+                    episode_number_end.text = str(ep_to_write.episode)
 
                 season_number = etree.SubElement(episode, u'SeasonNumber')
-                season_number.text = text_type(ep_to_write.season)
+                season_number.text = str(ep_to_write.season)
 
                 if not ep_obj.related_episodes and getattr(my_ep, u'absolute_number', None):
                     absolute_number = etree.SubElement(episode, u'absolute_number')
-                    absolute_number.text = text_type(my_ep[u'absolute_number'])
+                    absolute_number.text = str(my_ep[u'absolute_number'])
 
                 if ep_to_write.airdate != datetime.date.fromordinal(1):
                     first_aired = etree.SubElement(episode, u'FirstAired')
-                    first_aired.text = text_type(ep_to_write.airdate)
+                    first_aired.text = str(ep_to_write.airdate)
 
                 metadata_type = etree.SubElement(episode, u'Type')
                 metadata_type.text = u'Episode'
@@ -431,7 +431,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                 if not ep_obj.related_episodes:
                     if getattr(my_ep, u'rating', None):
                         rating = etree.SubElement(episode, u'Rating')
-                        rating.text = text_type(my_ep[u'rating'])
+                        rating.text = str(my_ep[u'rating'])
 
                     if getattr(my_show, u'imdb_id', None):
                         IMDB_ID = etree.SubElement(episode, u'IMDB_ID')
@@ -444,7 +444,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
                         IMDbId.text = my_show[u'imdb_id']
 
                 indexer_id = etree.SubElement(episode, u'id')
-                indexer_id.text = text_type(ep_to_write.indexerid)
+                indexer_id.text = str(ep_to_write.indexerid)
 
                 persons = etree.SubElement(episode, u'Persons')
 
@@ -481,7 +481,7 @@ class MediaBrowserMetadata(generic.GenericMetadata):
 
             else:
                 # append data from (if any) related episodes
-                episode_number_end.text = text_type(ep_to_write.episode)
+                episode_number_end.text = str(ep_to_write.episode)
 
                 if ep_to_write.name:
                     if not episode_name.text:

--- a/medusa/metadata/tivo.py
+++ b/medusa/metadata/tivo.py
@@ -294,6 +294,10 @@ class TIVOMetadata(generic.GenericMetadata):
         nfo_file_path = self.get_episode_file_path(ep_obj)
         nfo_file_dir = os.path.dirname(nfo_file_path)
 
+        if not (nfo_file_path and nfo_file_dir):
+            log.debug(u'Unable to write episode nfo file because episode location is missing.')
+            return False
+
         try:
             if not os.path.isdir(nfo_file_dir):
                 log.debug(u'Metadata directory missing, creating it at {location}',

--- a/medusa/metadata/wdtv.py
+++ b/medusa/metadata/wdtv.py
@@ -13,7 +13,8 @@ from medusa.indexers.indexer_api import indexerApi
 from medusa.indexers.indexer_exceptions import IndexerEpisodeNotFound, IndexerSeasonNotFound
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.metadata import generic
-from six import text_type
+
+from six import text_type as str
 
 try:
     import xml.etree.cElementTree as etree
@@ -191,7 +192,7 @@ class WDTVMetadata(generic.GenericMetadata):
                 return None
 
             if ep_obj.season == 0 and not getattr(my_ep, 'firstaired', None):
-                my_ep['firstaired'] = text_type(datetime.date.fromordinal(1))
+                my_ep['firstaired'] = str(datetime.date.fromordinal(1))
 
             if not (getattr(my_ep, 'episodename', None) and getattr(my_ep, 'firstaired', None)):
                 return None
@@ -203,7 +204,7 @@ class WDTVMetadata(generic.GenericMetadata):
 
             # TODO: get right EpisodeID
             episode_id = etree.SubElement(episode, 'id')
-            episode_id.text = text_type(ep_to_write.indexerid)
+            episode_id.text = str(ep_to_write.indexerid)
 
             title = etree.SubElement(episode, 'title')
             title.text = ep_obj.pretty_name()
@@ -217,19 +218,19 @@ class WDTVMetadata(generic.GenericMetadata):
                 episode_name.text = ep_to_write.name
 
             season_number = etree.SubElement(episode, 'season_number')
-            season_number.text = text_type(ep_to_write.season)
+            season_number.text = str(ep_to_write.season)
 
             episode_num = etree.SubElement(episode, 'episode_number')
-            episode_num.text = text_type(ep_to_write.episode)
+            episode_num.text = str(ep_to_write.episode)
 
             first_aired = etree.SubElement(episode, 'firstaired')
 
             if ep_to_write.airdate != datetime.date.fromordinal(1):
-                first_aired.text = text_type(ep_to_write.airdate)
+                first_aired.text = str(ep_to_write.airdate)
 
             if getattr(my_show, 'firstaired', None):
                 try:
-                    year_text = text_type(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
+                    year_text = str(datetime.datetime.strptime(my_show['firstaired'], dateFormat).year)
                     if year_text:
                         year = etree.SubElement(episode, 'year')
                         year.text = year_text
@@ -238,7 +239,7 @@ class WDTVMetadata(generic.GenericMetadata):
 
             if ep_to_write.season != 0 and getattr(my_show, 'runtime', None):
                 runtime = etree.SubElement(episode, 'runtime')
-                runtime.text = my_show['runtime']
+                runtime.text = str(my_show['runtime'])
 
             if getattr(my_show, 'genre', None):
                 genre = etree.SubElement(episode, 'genre')


### PR DESCRIPTION
Fixes #3297 - mede8er integers in XML
Tested and working (the written XML file is now valid)

---

Found more metadata providers that had the issue and added a fix for them as well:
 - MediaBrowser [Emby]
 - WDTV

---

Should also fix #4151 - exception if the episode location is empty.