### PR TITLE
Fix CloudFlare Bypass

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -48,7 +48,6 @@ from medusa.name_parser.parser import (
 from medusa.scene_exceptions import get_season_scene_exceptions
 from medusa.search import PROPER_SEARCH
 from medusa.session.core import MedusaSafeSession
-from medusa.session.hooks import cloudflare
 from medusa.show.show import Show
 
 from pytimeparse import parse
@@ -93,7 +92,7 @@ class GenericProvider(object):
         self.public = False
         self.search_fallback = False
         self.search_mode = None
-        self.session = MedusaSafeSession(hooks=[cloudflare])
+        self.session = MedusaSafeSession(cloudflare=True)
         self.session.headers.update(self.headers)
         self.series = None
         self.supports_absolute_numbering = False

--- a/medusa/session/core.py
+++ b/medusa/session/core.py
@@ -10,7 +10,7 @@ import certifi
 
 import medusa.common
 from medusa import app
-from medusa.session import factory, hooks
+from medusa.session import factory, handlers, hooks
 
 import requests
 
@@ -74,6 +74,9 @@ class MedusaSession(BaseSession):
         # Pop the cache_control config
         cache_control = kwargs.pop('cache_control', None)
 
+        # Apply handler for bypassing CloudFlare protection
+        self.cloudflare = kwargs.pop('cloudflare', False)
+
         # Initialize request.session after we've done the pop's.
         super(MedusaSession, self).__init__(**kwargs)
 
@@ -94,9 +97,13 @@ class MedusaSession(BaseSession):
         self.headers.update(self.default_headers)
 
     def request(self, method, url, data=None, params=None, headers=None, timeout=30, verify=True, **kwargs):
-        return super(MedusaSession, self).request(method, url, data=data, params=params, headers=headers,
-                                                  timeout=timeout, verify=self._get_ssl_cert(verify),
-                                                  **kwargs)
+        ssl_cert = self._get_ssl_cert(verify)
+        response = super(MedusaSession, self).request(method, url, data=data, params=params, headers=headers,
+                                                      timeout=timeout, verify=ssl_cert, **kwargs)
+        if self.cloudflare:
+            response = handlers.cloudflare(self, response, timeout=timeout, verify=ssl_cert, **kwargs)
+
+        return response
 
     def get_json(self, url, method='GET', *args, **kwargs):
         """Overwrite request, to be able to return the json value if possible. Else it will fail silently."""

--- a/medusa/session/handlers.py
+++ b/medusa/session/handlers.py
@@ -1,0 +1,85 @@
+# coding=utf-8
+
+"""Define custom response handlers - custom hooks with access to the session object."""
+
+from __future__ import unicode_literals
+
+import logging
+
+import cfscrape
+
+from medusa.logger.adapters.style import BraceAdapter
+
+from requests.utils import dict_from_cookiejar
+
+from six import viewitems
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
+
+
+def filtered_kwargs(kwargs):
+    """Filter kwargs to only contain arguments accepted by `requests.Session.send`."""
+    return {
+        k: v for k, v in viewitems(kwargs)
+        if k in ('stream', 'timeout', 'verify', 'cert', 'proxies', 'allow_redirects')
+    }
+
+
+def cloudflare(session, resp, **kwargs):
+    """
+    Bypass CloudFlare's anti-bot protection.
+
+    A request handler that retries a request after bypassing CloudFlare anti-bot
+    protection.
+    """
+    if is_cloudflare_challenge(resp):
+
+        log.debug(u'CloudFlare protection detected, trying to bypass it')
+
+        # Get the original request
+        original_request = resp.request
+
+        # Get the CloudFlare tokens and original user-agent
+        tokens, user_agent = cfscrape.get_tokens(original_request.url)
+
+        # Add CloudFlare tokens to the session cookies
+        session.cookies.update(tokens)
+        # Add CloudFlare Tokens to the original request
+        original_cookies = dict_from_cookiejar(original_request._cookies)
+        original_cookies.update(tokens)
+        original_request.prepare_cookies(original_cookies)
+
+        # The same User-Agent must be used for the retry
+        # Update the session with the CloudFlare User-Agent
+        session.headers['User-Agent'] = user_agent
+        # Update the original request with the CloudFlare User-Agent
+        original_request.headers['User-Agent'] = user_agent
+
+        # Resend the request
+        kwargs = filtered_kwargs(kwargs)
+        kwargs['allow_redirects'] = True
+        cf_resp = session.send(
+            original_request,
+            **kwargs
+        )
+        cf_resp.raise_for_status()
+
+        if cf_resp.ok:
+            log.debug('CloudFlare successfully bypassed.')
+        return cf_resp
+    else:
+        return resp
+
+
+def is_cloudflare_challenge(resp):
+    """Check if the response is a Cloudflare challange.
+
+    Source: goo.gl/v8FvnD
+    """
+    return (
+        resp.status_code == 503
+        and resp.headers.get('Server', '').startswith('cloudflare')
+        and b'jschl_vc' in resp.content
+        and b'jschl_answer' in resp.content
+    )

--- a/medusa/session/hooks.py
+++ b/medusa/session/hooks.py
@@ -4,12 +4,7 @@ from __future__ import unicode_literals
 
 import logging
 
-import cfscrape
-
 from medusa.logger.adapters.style import BraceAdapter
-
-import requests
-from requests.utils import dict_from_cookiejar
 
 from six import text_type
 
@@ -56,76 +51,3 @@ def log_url(response, **kwargs):
         else:
             log.warning('Failed to decode post data with {codecs}',
                         {'codecs': codecs})
-
-
-def cloudflare(resp, **kwargs):
-    """
-    Bypass CloudFlare's anti-bot protection.
-
-    A response hook that retries a request after bypassing CloudFlare anti-bot
-    protection.  Use the sessioned hook factory to attach the session to the
-    response to persist CloudFlare authentication at the session level.
-    """
-    if is_cloudflare_challenge(resp):
-
-        log.debug(u'CloudFlare protection detected, trying to bypass it')
-
-        # Get the session used or create a new one
-        session = getattr(resp, 'session', requests.Session())
-
-        # Get the original request
-        original_request = resp.request
-
-        # Avoid recursion by removing the hook from the original request
-        original_request.hooks['response'].remove(cloudflare)
-
-        # Get the CloudFlare tokens and original user-agent
-        tokens, user_agent = cfscrape.get_tokens(original_request.url)
-
-        # Add CloudFlare tokens to the session cookies
-        session.cookies.update(tokens)
-        # Add CloudFlare Tokens to the original request
-        original_cookies = dict_from_cookiejar(original_request._cookies)
-        original_cookies.update(tokens)
-        original_request.prepare_cookies(original_cookies)
-
-        # The same User-Agent must be used for the retry
-        # Update the session with the CloudFlare User-Agent
-        session.headers['User-Agent'] = user_agent
-        # Update the original request with the CloudFlare User-Agent
-        original_request.headers['User-Agent'] = user_agent
-
-        # Resend the request
-        cf_resp = session.send(
-            original_request,
-            allow_redirects=True,
-            **kwargs
-        )
-
-        if cf_resp.ok:
-            log.debug('CloudFlare successfully bypassed.')
-        return cf_resp
-    else:
-        return resp
-
-
-def sessioned(session):
-    """Hooks factory to add a session to a response."""
-    def sessioned_response_hook(response, *args, **kwargs):
-        """Return a sessioned response."""
-        response.session = session
-        return response
-    return sessioned_response_hook
-
-
-def is_cloudflare_challenge(resp):
-    """Check if the response is a Cloudflare challange.
-
-    Source: goo.gl/v8FvnD
-    """
-    return (
-        resp.status_code == 503
-        and resp.headers.get('Server', '').startswith('cloudflare')
-        and b'jschl_vc' in resp.content
-        and b'jschl_answer' in resp.content
-    )


### PR DESCRIPTION
**Issue:** `cloudflare` hook not updating session cookies.
**Cause:** `Response` objects have no `session` attribute so a new session is created within the hook.

**Proposed solution:** Replace hook version with a custom "handler" that can receive a session object.

_Why "Help wanted"?_
I have noticed the following function in `medusa/session/hooks.py`. If we can somehow use it on existing code (before this PR) inside the `MedusaSession` class, then it would probably solve the issue with less code changes.
```py
def sessioned(session):
    """Hooks factory to add a session to a response."""
    def sessioned_response_hook(response, *args, **kwargs):
        """Return a sessioned response."""
        response.session = session
        return response
    return sessioned_response_hook
```