### PR TITLE
Fix crash because of an empty theme folder

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -326,6 +326,9 @@ class Application(object):
             if self.console_logging:
                 sys.stdout.write('Restore: restoring DB and config.ini %s!\n' % ('FAILED', 'SUCCESSFUL')[success])
 
+        # Initialize all available themes
+        app.AVAILABLE_THEMES = read_themes()
+
         # Load the config and publish it to the application package
         if self.console_logging and not os.path.isfile(app.CONFIG_FILE):
             sys.stdout.write('Unable to find %s, all settings will be default!\n' % app.CONFIG_FILE)
@@ -386,9 +389,6 @@ class Application(object):
         # start web server
         self.web_server = AppWebServer(self.web_options)
         self.web_server.start()
-
-        # Initialize all available themes
-        app.AVAILABLE_THEMES = read_themes()
 
         # Fire up all our threads
         self.start_threads()

--- a/medusa/themes/base.py
+++ b/medusa/themes/base.py
@@ -32,10 +32,14 @@ def read_themes():
     for theme_path in themes_from_fs:
         # validate the directory structure
         try:
-            validate_theme(theme_path)
+            result = validate_theme(theme_path)
         except Exception as error:
             log.error('Error reading theme {theme}, {error!r}', {'theme': theme_path, 'error': error})
             raise Exception('Error in one of the theme paths. Please fix the error and start medusa.')
+
+        if not result:
+            log.debug('Skipping reading theme {theme}, as the folder is empty', {'theme': theme_path})
+            continue
 
         # validate the package.json
         package_json = json.load(open(os.path.join(theme_path, 'package.json')))
@@ -48,6 +52,15 @@ def read_themes():
 
 def validate_theme(theme_path):
     """Validate theme configuration."""
+    try:
+        dir_list = os.listdir(theme_path)
+    except Exception as err:
+        raise Exception("Unable to list directories in {path}: {err!r}".format(path=theme_path, err=err))
+
+    # If the folder is completely empty, then the theme was probably removed, so just skip it
+    if not dir_list:
+        return False
+
     if not os.path.isdir(os.path.join(theme_path, 'assets')):
         raise Exception('Missing assets folder. Please refer to the medusa theming documentation.')
 


### PR DESCRIPTION
- Fix crash because of an empty theme folder
- Fix valid values for `theme_name` config option
