### PR TITLE
Fix qBittorrent resume/pause command

### DIFF
--- a/medusa/clients/torrent/qbittorrent_client.py
+++ b/medusa/clients/torrent/qbittorrent_client.py
@@ -123,8 +123,9 @@ class QBittorrentAPI(GenericClient):
     def _set_torrent_pause(self, result):
         self.url = '{host}command/{state}'.format(host=self.host,
                                                   state='pause' if app.TORRENT_PAUSED else 'resume')
+        hashes_key = 'hashes' if self.api >= 18 else 'hash'
         data = {
-            'hash': result.hash,
+            hashes_key: result.hash.lower(),
         }
         return self._request(method='post', data=data, cookies=self.session.cookies)
 


### PR DESCRIPTION
`hash` data key was changed to `hashes`

Fixes #4167