### PR TITLE
Fix failed Python tests not failing build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,8 @@ install:
   - 'export PATH="$HOME/.yarn/bin:$PATH" && yarn install'
 script:
   - yarn test
-  - "(python .github/check_changes.py && tox -v --recreate) || :"
+  # Skip Python tests if the exit code of `.github/check_changes.py` is 0
+  - python .github/check_changes.py; if [[ $? -eq 0 ]]; then tox -v --recreate; fi
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
Example:
https://travis-ci.org/pymedusa/Medusa/builds/376442637#L3845
`flake8` failed, build succeeded.

~Disable it and always run Python tests for now.
Sorry @OmgImAlexis ...~
Replaced it with a better check.


Current build errors are fixed in #4171 