### PR TITLE
Update internal resources API

### DIFF
--- a/medusa/server/api/v2/internal.py
+++ b/medusa/server/api/v2/internal.py
@@ -12,7 +12,7 @@ from medusa.logger.adapters.style import BraceAdapter
 from medusa.server.api.v2.base import BaseRequestHandler
 from medusa.tv.series import Series, SeriesIdentifier
 
-from six import itervalues, text_type as str
+from six import itervalues
 
 from tornado.escape import json_decode
 

--- a/medusa/server/api/v2/internal.py
+++ b/medusa/server/api/v2/internal.py
@@ -83,7 +83,7 @@ class InternalHandler(BaseRequestHandler):
         root_dirs_tuple = tuple(root_dirs)
         dir_results = [
             series[b'location'] for series in dir_results
-            if series[b'location'].lower().startswith(root_dirs_tuple)
+            if series[b'location'].startswith(root_dirs_tuple)
         ]
 
         for root_dir in root_dirs:

--- a/medusa/server/api/v2/internal.py
+++ b/medusa/server/api/v2/internal.py
@@ -31,8 +31,6 @@ class InternalHandler(BaseRequestHandler):
     #: allowed HTTP methods
     allowed_methods = ('GET', )
 
-    valid_resources = ('existingSeries', )
-
     def get(self, resource, path_param=None):
         """Query internal data.
 
@@ -41,18 +39,21 @@ class InternalHandler(BaseRequestHandler):
         :type path_param: str
         """
         if resource is None:
-            return self._bad_request('You must provider a resource name')
+            return self._bad_request('You must provide a resource name')
 
-        if resource not in self.valid_resources:
+        # Convert 'camelCase' to 'resource_snake_case'
+        resource_function_name = 'resource_' + re.sub('([A-Z]+)', r'_\1', resource).lower()
+        resource_function = getattr(self, resource_function_name, None)
+
+        if resource_function is None:
+            log.error('Unable to get function "{func}" for resource "{resource}"',
+                      {'func': resource_function_name, 'resource': resource})
             return self._bad_request('{key} is a invalid resource'.format(key=resource))
 
-        # Convert 'camelCase' to '_snake_case'
-        resource_function = '_' + re.sub('([A-Z]+)', r'_\1', resource).lower()
-        data = getattr(self, resource_function)()
-
+        data = resource_function()
         return self._ok(data=data)
 
-    def _existing_series(self):
+    def resource_existing_series(self):
         """Generate existing series folders data for adding existing shows."""
         root_dirs = json_decode(self.get_argument('root-dir', '[]'))
 

--- a/medusa/server/api/v2/internal.py
+++ b/medusa/server/api/v2/internal.py
@@ -80,10 +80,10 @@ class InternalHandler(BaseRequestHandler):
             b'SELECT location '
             b'FROM tv_shows'
         )
-        root_dirs_lower = tuple(map(str.lower, root_dirs))
+        root_dirs_tuple = tuple(root_dirs)
         dir_results = [
             series[b'location'] for series in dir_results
-            if series[b'location'].lower().startswith(root_dirs_lower)
+            if series[b'location'].lower().startswith(root_dirs_tuple)
         ]
 
         for root_dir in root_dirs:


### PR DESCRIPTION
- Fix for root dirs containing special chars, also fixes possible XSS
- Update the API handler for internal resources

~**Edit:** I realised I should remove the `root_dirs_lower` part, and just use `tuple(root_dirs)`.~