### PR TITLE
Update Emby Notifier

### DIFF
--- a/medusa/notifiers/emby.py
+++ b/medusa/notifiers/emby.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+"""Emby notifier module."""
 from __future__ import unicode_literals
 
 import json
@@ -20,15 +21,14 @@ log.logger.addHandler(logging.NullHandler())
 
 
 class Notifier(object):
+    """Emby notifier class."""
 
     def _notify_emby(self, message, host=None, emby_apikey=None):
-        """Handles notifying Emby host via HTTP API
-
-        Returns:
-            Returns True for no issue or False if there was an error
-
         """
+        Notify Emby host via HTTP API.
 
+        :return: True for no issue or False if there was an error
+        """
         # fill in omitted parameters
         if not host:
             host = app.EMBY_HOST
@@ -61,18 +61,20 @@ class Notifier(object):
 ##############################################################################
 
     def test_notify(self, host, emby_apikey):
+        """
+        Sends a test notification.
+
+        :return: True for no issue or False if there was an error
+        """
         return self._notify_emby('This is a test notification from Medusa', host, emby_apikey)
 
     def update_library(self, show=None):
-        """Handles updating the Emby Media Server host via HTTP API
-
-        Returns:
-            Returns True for no issue or False if there was an error
-
         """
+        Update the Emby Media Server host via HTTP API.
 
+        :return: True for no issue or False if there was an error
+        """
         if app.USE_EMBY:
-
             if not app.EMBY_HOST:
                 log.debug(u'EMBY: No host specified, check your settings')
                 return False

--- a/medusa/notifiers/emby.py
+++ b/medusa/notifiers/emby.py
@@ -47,11 +47,11 @@ class Notifier(object):
             result = response.read()
             response.close()
 
-            log.debug(u'EMBY: HTTP response: {0}', result.replace('\n', ''))
+            log.debug('EMBY: HTTP response: {0}', result.replace('\n', ''))
             return True
 
         except (URLError, IOError) as error:
-            log.warning(u'EMBY: Warning: Unable to contact Emby at {url}: {error}',
+            log.warning('EMBY: Warning: Unable to contact Emby at {url}: {error}',
                         {'url': url, 'error': ex(error)})
             return False
 
@@ -76,17 +76,17 @@ class Notifier(object):
         """
         if app.USE_EMBY:
             if not app.EMBY_HOST:
-                log.debug(u'EMBY: No host specified, check your settings')
+                log.debug('EMBY: No host specified, check your settings')
                 return False
 
             if show:
                 if show.indexer == 1:
                     provider = 'tvdb'
                 elif show.indexer == 2:
-                    log.warning(u'EMBY: TVRage Provider no longer valid')
+                    log.warning('EMBY: TVRage Provider no longer valid')
                     return False
                 else:
-                    log.warning(u'EMBY: Provider unknown')
+                    log.warning('EMBY: Provider unknown')
                     return False
                 query = '?%sid=%s' % (provider, show.indexerid)
             else:
@@ -103,10 +103,10 @@ class Notifier(object):
                 result = response.read()
                 response.close()
 
-                log.debug(u'EMBY: HTTP response: {0}', result.replace('\n', ''))
+                log.debug('EMBY: HTTP response: {0}', result.replace('\n', ''))
                 return True
 
             except (URLError, IOError) as error:
-                log.warning(u'EMBY: Warning: Unable to contact Emby at {url}: {error}',
+                log.warning('EMBY: Warning: Unable to contact Emby at {url}: {error}',
                             {'url': url, 'error': ex(error)})
                 return False

--- a/pytest.ini
+++ b/pytest.ini
@@ -71,7 +71,6 @@ flake8-ignore =
     medusa/network_timezones.py D100 D103 D200 D202 D400
     medusa/notifiers/__init__.py D103 D104
     medusa/notifiers/emailnotify.py D100 D101 D102 D205 D400 N802 N803
-    medusa/notifiers/emby.py D100 D101 D102 D202 D400 D401
     medusa/notifiers/freemobile.py D100 D101 D102 D202 D400 D401 E225 N802 N803 N806
     medusa/notifiers/growl.py D100 D101 D102 N802 N806
     medusa/notifiers/libnotify.py D100 D101 D102 D205 D400 F401


### PR DESCRIPTION
- Add support for indexers other than TVDB by using the show's external ids.
  (Emby's `/Library/Series/Updated` API only supports TVDB IDs) - Should fix https://github.com/pymedusa/Medusa/issues/4141#issuecomment-388614665
- Use `MedusaSession` instead of `urllib`
- Fix flake8 docstring warnings
- Remove `u` prefix from strings.