### PR TITLE
app-link: Fix anonymised webcal and multiple location hashes

### DIFF
--- a/themes-default/slim/views/vue-components/app-link.mako
+++ b/themes-default/slim/views/vue-components/app-link.mako
@@ -53,7 +53,13 @@ Vue.component('app-link', {
                     }
                     const resolvedHref = () => {
                         if (isHashPath(href)) {
-                            return window.location.href + href;
+                            const {location} = window;
+                            if (location.hash.length === 0) {
+                                // current location might be `url#`
+                                const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                                return location.href + newHash;
+                            }
+                            return location.href.replace(location.hash, '') + href;
                         }
                         if (isIRC(href)) {
                             return href;

--- a/themes-default/slim/views/vue-components/app-link.mako
+++ b/themes-default/slim/views/vue-components/app-link.mako
@@ -36,7 +36,7 @@ Vue.component('app-link', {
                 return /^[a-z][a-z0-9+.-]*:/.test(url);
             }
             const isExternal = url => {
-                return !url.startsWith(base);
+                return !url.startsWith(base) && !url.startsWith('webcal://');
             };
             const isHashPath = url => {
                 return url.startsWith('#')

--- a/themes/dark/templates/vue-components/app-link.mako
+++ b/themes/dark/templates/vue-components/app-link.mako
@@ -53,7 +53,13 @@ Vue.component('app-link', {
                     }
                     const resolvedHref = () => {
                         if (isHashPath(href)) {
-                            return window.location.href + href;
+                            const {location} = window;
+                            if (location.hash.length === 0) {
+                                // current location might be `url#`
+                                const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                                return location.href + newHash;
+                            }
+                            return location.href.replace(location.hash, '') + href;
                         }
                         if (isIRC(href)) {
                             return href;

--- a/themes/dark/templates/vue-components/app-link.mako
+++ b/themes/dark/templates/vue-components/app-link.mako
@@ -36,7 +36,7 @@ Vue.component('app-link', {
                 return /^[a-z][a-z0-9+.-]*:/.test(url);
             }
             const isExternal = url => {
-                return !url.startsWith(base);
+                return !url.startsWith(base) && !url.startsWith('webcal://');
             };
             const isHashPath = url => {
                 return url.startsWith('#')

--- a/themes/light/templates/vue-components/app-link.mako
+++ b/themes/light/templates/vue-components/app-link.mako
@@ -53,7 +53,13 @@ Vue.component('app-link', {
                     }
                     const resolvedHref = () => {
                         if (isHashPath(href)) {
-                            return window.location.href + href;
+                            const {location} = window;
+                            if (location.hash.length === 0) {
+                                // current location might be `url#`
+                                const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                                return location.href + newHash;
+                            }
+                            return location.href.replace(location.hash, '') + href;
                         }
                         if (isIRC(href)) {
                             return href;

--- a/themes/light/templates/vue-components/app-link.mako
+++ b/themes/light/templates/vue-components/app-link.mako
@@ -36,7 +36,7 @@ Vue.component('app-link', {
                 return /^[a-z][a-z0-9+.-]*:/.test(url);
             }
             const isExternal = url => {
-                return !url.startsWith(base);
+                return !url.startsWith(base) && !url.startsWith('webcal://');
             };
             const isHashPath = url => {
                 return url.startsWith('#')


### PR DESCRIPTION
- Fixes #4224 
- Fixes an issue when the current location already has a hash in the url. For example click a season jump link, then refresh the page - the hashes in the season jump links are now doubled.