### PR TITLE
Fix #4246 - No search results in APIv1 sb.searchindexers

### DIFF
--- a/medusa/indexers/indexer_base.py
+++ b/medusa/indexers/indexer_base.py
@@ -2,8 +2,7 @@
 
 """Base class for indexer api's."""
 
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 import getpass
 import logging
@@ -11,8 +10,6 @@ import os
 import tempfile
 import time
 import warnings
-from builtins import object
-from builtins import str
 from operator import itemgetter
 
 from medusa import statistics as stats
@@ -30,7 +27,7 @@ from medusa.statistics import weights
 
 import requests
 
-from six import integer_types, itervalues, string_types, viewitems
+from six import integer_types, itervalues, string_types, text_type, viewitems
 
 
 log = BraceAdapter(logging.getLogger(__name__))
@@ -188,7 +185,7 @@ class BaseIndexer(object):
 
     def __repr__(self):
         """Indexer representation, returning representation of all shows indexed."""
-        return str(self.shows)
+        return text_type(self.shows)
 
     def _set_item(self, sid, seas, ep, attrib, value):  # pylint: disable=too-many-arguments
         """Create a new episode, creating Show(), Season() and Episode()s as required.
@@ -402,7 +399,7 @@ class BaseIndexer(object):
                 self._get_show_data(key, self.config['language'])
             return self.shows[key]
 
-        key = str(key).lower()
+        key = text_type(key).lower()
         self.config['searchterm'] = key
         selected_series = self._get_series(key)
         if isinstance(selected_series, dict):
@@ -500,7 +497,7 @@ class Show(dict):
 
     def aired_on(self, date):
         """Search and return a list of episodes with the airdates."""
-        ret = self.search(str(date), 'firstaired')
+        ret = self.search(text_type(date), 'firstaired')
         if len(ret) == 0:
             raise IndexerEpisodeNotFound('Could not find any episodes that aired on {0}'.format(date))
         return ret
@@ -629,13 +626,13 @@ class Episode(dict):
         if term is None:
             raise TypeError('must supply string to search for (contents)')
 
-        term = str(term).lower()
+        term = text_type(term).lower()
         for cur_key, cur_value in viewitems(self):
-            cur_key, cur_value = str(cur_key).lower(), str(cur_value).lower()
+            cur_key, cur_value = text_type(cur_key).lower(), text_type(cur_value).lower()
             if key is not None and cur_key != key:
                 # Do not search this key
                 continue
-            if cur_value.find(str(term).lower()) > -1:
+            if cur_value.find(text_type(term).lower()) > -1:
                 return self
 
 

--- a/medusa/server/api/v1/core.py
+++ b/medusa/server/api/v1/core.py
@@ -26,7 +26,6 @@ import json
 import logging
 import os
 import time
-from builtins import str
 from collections import OrderedDict
 from datetime import date, datetime
 
@@ -47,7 +46,7 @@ from medusa.helper.common import (
 from medusa.helper.exceptions import CantUpdateShowException, ShowDirectoryNotFoundException
 from medusa.helpers.quality import get_quality_string
 from medusa.indexers.indexer_api import indexerApi
-from medusa.indexers.indexer_config import INDEXER_TVDBV2
+from medusa.indexers.indexer_config import INDEXER_TMDB, INDEXER_TVDBV2, INDEXER_TVMAZE
 from medusa.indexers.indexer_exceptions import IndexerError, IndexerShowIncomplete, IndexerShowNotFound
 from medusa.logger import LOGGING_LEVELS, filter_logline, read_loglines
 from medusa.logger.adapters.style import BraceAdapter
@@ -65,7 +64,7 @@ from medusa.version_checker import CheckVersion
 
 from requests.compat import unquote_plus
 
-from six import iteritems, text_type, viewitems
+from six import binary_type, iteritems, itervalues, string_types, text_type, viewitems
 
 from tornado.web import RequestHandler
 
@@ -75,7 +74,12 @@ standard_library.install_aliases()
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
 
-INDEXER_IDS = ('indexerid', 'tvdbid', 'tvmazeid', 'tmdbid')
+INDEXER_IDS = {
+    0: 'indexerid',
+    INDEXER_TVDBV2: 'tvdbid',
+    INDEXER_TVMAZE: 'tvmazeid',
+    INDEXER_TMDB: 'tmdbid'
+}
 
 # basically everything except RESULT_SUCCESS / success is bad
 RESULT_SUCCESS = 10  # only use inside the run methods
@@ -336,11 +340,11 @@ class ApiCall(ApiHandler):
         """
 
         # auto-select indexer
-        if key in INDEXER_IDS:
+        if key in itervalues(INDEXER_IDS):
             if 'tvdbid' in kwargs:
                 key = 'tvdbid'
 
-            self.indexer = INDEXER_IDS.index(key)
+            self.indexer = next(k for k, v in iteritems(INDEXER_IDS) if v == key)
 
         missing = True
         org_default = default
@@ -786,7 +790,7 @@ class CMD_EpisodeSearch(ApiCall):
 
         # retrieve the episode object and fail if we can't get one
         ep_obj = show_obj.get_episode(self.s, self.e)
-        if isinstance(ep_obj, str):
+        if isinstance(ep_obj, string_types):
             return _responds(RESULT_FAILURE, msg='Episode not found')
 
         # make a queue item for it and put it on the queue
@@ -842,7 +846,7 @@ class CMD_EpisodeSetStatus(ApiCall):
 
         # convert the string status to a int
         for status in statusStrings:
-            if str(statusStrings[status]).lower() == str(self.status).lower():
+            if text_type(statusStrings[status]).lower() == text_type(self.status).lower():
                 self.status = status
                 break
         else:  # if we don't break out of the for loop we got here.
@@ -960,7 +964,7 @@ class CMD_SubtitleSearch(ApiCall):
 
         # retrieve the episode object and fail if we can't get one
         ep_obj = show_obj.get_episode(self.s, self.e)
-        if isinstance(ep_obj, str):
+        if isinstance(ep_obj, string_types):
             return _responds(RESULT_FAILURE, msg='Episode not found')
 
         try:
@@ -1040,7 +1044,7 @@ class CMD_History(ApiCall):
         # optional
         self.limit, args = self.check_params(args, kwargs, 'limit', 100, False, 'int', [])
         self.type, args = self.check_params(args, kwargs, 'type', None, False, 'string', ['downloaded', 'snatched'])
-        self.type = self.type.lower() if isinstance(self.type, str) else None
+        self.type = self.type.lower() if isinstance(self.type, string_types) else None
 
         # super, missing, help
         ApiCall.__init__(self, args, kwargs)
@@ -1066,7 +1070,7 @@ class CMD_History(ApiCall):
                 :return: a formatted date string
                 """
                 return datetime.strptime(
-                    str(history_date),
+                    text_type(history_date),
                     History.date_format
                 ).strftime(dateTimeFormat)
 
@@ -1220,7 +1224,7 @@ class CMD_Logs(ApiCall):
     def run(self):
         """ Get the logs """
         # 10 = Debug / 20 = Info / 30 = Warning / 40 = Error
-        min_level = LOGGING_LEVELS[str(self.min_level).upper()]
+        min_level = LOGGING_LEVELS[text_type(self.min_level).upper()]
         data = [line for line in read_loglines(formatter=text_type, max_lines=50,
                                                predicate=lambda l: filter_logline(l, min_level=min_level,
                                                                                   thread_name=lambda
@@ -1658,9 +1662,9 @@ class CMD_SearchIndexers(ApiCall):
                 indexer_api = indexerApi(_indexer).indexer(**indexer_api_params)
 
                 try:
-                    api_data = indexer_api[str(self.name).encode()]
+                    api_data = indexer_api[binary_type(self.name).encode()]
                 except (IndexerShowNotFound, IndexerShowIncomplete, IndexerError):
-                    log.warning(u'API :: Unable to find show with id {0}', self.indexerid)
+                    log.warning(u'API :: Unable to find show with name {0}', self.name)
                     continue
 
                 for cur_series in api_data:
@@ -1792,7 +1796,7 @@ class CMD_SetDefaults(ApiCall):
         if self.status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.status).lower():
+                if statusStrings[status].lower() == text_type(self.status).lower():
                     self.status = status
                     break
             # this should be obsolete because of the above
@@ -1907,7 +1911,7 @@ class CMD_Show(ApiCall):
         show_dict['season_folders'] = (0, 1)[show_obj.season_folders]
         show_dict['sports'] = (0, 1)[show_obj.sports]
         show_dict['anime'] = (0, 1)[show_obj.anime]
-        show_dict['airs'] = str(show_obj.airs).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
+        show_dict['airs'] = text_type(show_obj.airs).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
         show_dict['dvdorder'] = (0, 1)[show_obj.dvd_order]
 
         if show_obj.rls_require_words:
@@ -2118,7 +2122,7 @@ class CMD_ShowAddNew(ApiCall):
         if self.status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.status).lower():
+                if statusStrings[status].lower() == text_type(self.status).lower():
                     self.status = status
                     break
 
@@ -2135,7 +2139,7 @@ class CMD_ShowAddNew(ApiCall):
         if self.future_status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.future_status).lower():
+                if statusStrings[status].lower() == text_type(self.future_status).lower():
                     self.future_status = status
                     break
 

--- a/medusa/server/api/v1/core.py
+++ b/medusa/server/api/v1/core.py
@@ -64,7 +64,7 @@ from medusa.version_checker import CheckVersion
 
 from requests.compat import unquote_plus
 
-from six import binary_type, iteritems, itervalues, string_types, text_type, viewitems
+from six import iteritems, itervalues, string_types, text_type, viewitems
 
 from tornado.web import RequestHandler
 
@@ -883,7 +883,8 @@ class CMD_EpisodeSetStatus(ApiCall):
 
                 # don't let them mess up UN-AIRED episodes
                 if ep_obj.status == UNAIRED:
-                    if self.e is not None:  # setting the status of an un-aired is only considered a failure if we directly wanted this episode, but is ignored on a season request
+                    # setting the status of an un-aired is only considered a failure if we directly wanted this episode, but is ignored on a season request
+                    if self.e is not None:
                         ep_results.append(
                             _ep_result(RESULT_FAILURE, ep_obj, 'Refusing to change status because it is UN-AIRED'))
                         failure = True
@@ -1662,7 +1663,7 @@ class CMD_SearchIndexers(ApiCall):
                 indexer_api = indexerApi(_indexer).indexer(**indexer_api_params)
 
                 try:
-                    api_data = indexer_api[binary_type(self.name).encode()]
+                    api_data = indexer_api[self.name]
                 except (IndexerShowNotFound, IndexerShowIncomplete, IndexerError):
                     log.warning(u'API :: Unable to find show with name {0}', self.name)
                     continue

--- a/pytest.ini
+++ b/pytest.ini
@@ -100,7 +100,7 @@ flake8-ignore =
     medusa/server/__init__.py D104
     medusa/server/api/__init__.py D104
     medusa/server/api/v1/__init__.py D104
-    medusa/server/api/v1/core.py D100 D101 D102 D200 D201 D202 D204 D205 D208 D210 D400 D401 D403 E501 N801
+    medusa/server/api/v1/core.py D100 D101 D102 D200 D201 D202 D204 D205 D208 D210 D400 D401 D403 N801
     medusa/server/core.py D100 D101 D102 N802
     medusa/server/web/__init__.py D104 F401
     medusa/server/web/config/__init__.py D104 F401


### PR DESCRIPTION
Fixes #4246 - No search results from API v1 `sb.searchindexers`
Also fixes #1895 - `tuple index out of range` (when searching tvmaze, tmdb or all indexers)

:heavy_check_mark: Tested.