### PR TITLE
Update imdbpie to 5.4.5 + builds failing

### DIFF
--- a/ext/imdbpie/__init__.py
+++ b/ext/imdbpie/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-from .imdbpie import Imdb
-from .exceptions import ImdbAPIError
+from .imdbpie import Imdb  # noqa
+from .exceptions import ImdbAPIError  # noqa

--- a/ext/imdbpie/auth.py
+++ b/ext/imdbpie/auth.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import base64
 import json
 import requests
 import tempfile

--- a/ext/imdbpie/constants.py
+++ b/ext/imdbpie/constants.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
-import hashlib
-
 HOST = 'api.imdbws.com'
 BASE_URI = 'https://{0}'.format(HOST)
 SEARCH_BASE_URI = 'https://v2.sg.media-imdb.com'

--- a/ext/imdbpie/imdbpie.py
+++ b/ext/imdbpie/imdbpie.py
@@ -103,9 +103,9 @@ class Imdb(Auth):
 
     def title_exists(self, imdb_id):
         self.validate_imdb_id(imdb_id)
-        page_url = 'http://www.imdb.com/title/{0}/'.format(imdb_id)
+        page_url = 'https://www.imdb.com/title/{0}/'.format(imdb_id)
 
-        response = self.session.head(page_url)
+        response = self.session.get(page_url, allow_redirects=False)
 
         if response.status_code == httplib.OK:
             return True
@@ -207,20 +207,17 @@ class Imdb(Auth):
 
     def get_title_top_crew(self, imdb_id):
         """
-        Request detailed information about title's top crew (ie: directors, writters, etc.).
+        Request detailed information about title's top crew
+        (ie: directors, writters, etc.).
 
         :param imdb_id: The imdb id including the TT prefix.
         """
         logger.info('called get_title_top_crew %s', imdb_id)
-
         self.validate_imdb_id(imdb_id)
-
-        params = {
-            'tconst': imdb_id,
-        }
-
+        params = {'tconst': imdb_id}
         return self._get(urljoin(
-            BASE_URI, '/template/imdb-android-writable/7.3.top-crew.jstl/render'
+            BASE_URI,
+            '/template/imdb-android-writable/7.3.top-crew.jstl/render'
         ), params=params)
 
     @staticmethod
@@ -291,7 +288,6 @@ class Imdb(Auth):
 
         if resp_dict.get('error'):
             return None
-
         return resp_dict
 
     def _redirection_title_check(self, imdb_id):
@@ -302,8 +298,8 @@ class Imdb(Auth):
 
     def is_redirection_title(self, imdb_id):
         self.validate_imdb_id(imdb_id)
-        page_url = 'http://www.imdb.com/title/{0}/'.format(imdb_id)
-        response = self.session.head(page_url)
+        page_url = 'https://www.imdb.com/title/{0}/'.format(imdb_id)
+        response = self.session.get(page_url, allow_redirects=False)
         if response.status_code == httplib.MOVED_PERMANENTLY:
             return True
         else:

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1527,7 +1527,13 @@ class Series(TV):
         self.imdb_info['countries'] = self.imdb_info.get('countries', '')
         self.imdb_info['country_codes'] = self.imdb_info.get('country_codes', '')
 
-        imdb_info = imdb_api.get_title(self.imdb_id)
+        try:
+            imdb_info = imdb_api.get_title(self.imdb_id)
+        except LookupError as error:
+            log.warning(u"{id}: IMDbPie error while loading show info: {error}",
+                        {'id': self.series_id, 'error': error})
+            imdb_info = None
+
         if not imdb_info:
             log.debug(u"{id}: IMDb didn't return any info for {imdb_id}, skipping update.",
                       {'id': self.series_id, 'imdb_id': self.imdb_id})

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ futures==3.2.0
 gntp==1.0.3
 guessit==2.1.4
 html5lib==1.0.1
-imdbpie==5.4.0
+imdbpie==5.4.5
 jsonrpclib-pelix==0.3.1
 knowit==0.2.4
 lockfile==0.12.2


### PR DESCRIPTION
Should fix warnings like:
`123456: Error loading IMDb info: Title not found. tt1234567 is a redirection imdb id`

Also fixes a `LookupError` exception raised by `imdbpie` while adding a show.
This caused the builds to fail because adding a show via API v2 returned an internal server error.