### PR TITLE
Fix travis build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description="Automatic Video Library Manager for TV Shows",
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['tornado==5.0.1', 'six', 'profilehooks', 'contextlib2', 'gi', ],
+    install_requires=['tornado==5.0.1', 'six', 'profilehooks', 'contextlib2', ],
     cmdclass={'test': PyTest},
     tests_require=[
         'dredd_hooks',

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     description="Automatic Video Library Manager for TV Shows",
     long_description=long_description,
     packages=find_packages(),
-    install_requires=['tornado==5.0.1', 'six', 'profilehooks', 'contextlib2', ],
+    install_requires=['tornado==5.0.2', 'six', 'profilehooks', 'contextlib2', ],
     cmdclass={'test': PyTest},
     tests_require=[
         'dredd_hooks',


### PR DESCRIPTION
The `gi` package was removed from GitHub and PyPI :man_shrugging:.

This is used by the notifier `libnotify`.
The [PyGObject](https://pypi.org/project/PyGObject) package ([git](https://gitlab.gnome.org/GNOME/pygobject)) might be a good replacement package (looks maintained),
but I don't have any way to test if that works currently.