### PR TITLE
Fixes for indexer show searching

### DIFF
--- a/lib/tvdbapiv2/__init__.py
+++ b/lib/tvdbapiv2/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # import models into sdk package
 from .models.token import Token

--- a/lib/tvdbapiv2/api_client.py
+++ b/lib/tvdbapiv2/api_client.py
@@ -18,30 +18,27 @@ Copyright 2015 SmartBear Software
    ref: https://github.com/swagger-api/swagger-codegen
 """
 
-from __future__ import absolute_import
-
-from requests.exceptions import RequestException
-from . import models  # Used through eval.
-from .rest import RESTClientObject
-from .exceptions import AuthError
+from __future__ import absolute_import, unicode_literals
 
 import os
 import re
-import sys
 import json
 import mimetypes
 import tempfile
 import threading
-import requests
+from datetime import date, datetime
 
-from datetime import datetime
-from datetime import date
+import requests
+from requests.compat import urljoin
 
 # python 2 and python 3 compatibility library
-from six import iteritems, text_type
+from six import binary_type, iteritems, text_type
+
+from . import models  # noqa: F401 -- Used through eval.
 from .auth.tvdb import TVDBAuth
 from .configuration import Configuration
-from .exceptions import ApiException
+from .exceptions import ApiException, AuthError
+from .rest import RESTClientObject
 
 
 class ApiClient(object):
@@ -95,15 +92,13 @@ class ApiClient(object):
         if path_params:
             path_params = self.sanitize_for_serialization(path_params)
             for k, v in iteritems(path_params):
-                replacement = text_type(self.to_path_value(v))
-                resource_path = resource_path.\
-                    replace('{' + k + '}', replacement)
+                replacement = self.to_path_value(v)
+                resource_path = resource_path.replace('{' + k + '}', replacement)
 
         # query parameters
         if query_params:
             query_params = self.sanitize_for_serialization(query_params)
-            query_params = {k: self.to_path_value(v)
-                            for k, v in iteritems(query_params)}
+            query_params = {k: self.to_path_value(v) for k, v in iteritems(query_params)}
 
         # post parameters
         if post_params or files:
@@ -118,7 +113,7 @@ class ApiClient(object):
             body = self.sanitize_for_serialization(body)
 
         # request url
-        url = self.host + resource_path
+        url = urljoin(self.host, resource_path)
 
         # perform request and return response
         response_data = self.request(method, url,
@@ -146,12 +141,13 @@ class ApiClient(object):
 
         :param obj: object or string value.
 
-        :return string: quoted value.
+        :return text_type: quoted value.
         """
         if type(obj) == list:
             return ','.join(obj)
-        else:
-            return str(obj)
+        if isinstance(obj, binary_type):
+            return obj.decode('utf-8')
+        return text_type(obj)
 
     def sanitize_for_serialization(self, obj):
         """
@@ -168,9 +164,7 @@ class ApiClient(object):
         :param obj: The data to serialize.
         :return: The serialized form of data.
         """
-        types = (str, int, float, bool, tuple)
-        if sys.version_info < (3, 0):
-            types = types + (unicode,)
+        types = (text_type, binary_type, int, float, bool, tuple)
         if isinstance(obj, type(None)):
             return None
         elif isinstance(obj, types):
@@ -232,7 +226,7 @@ class ApiClient(object):
         if data is None:
             return None
 
-        if type(klass) in (str, unicode):
+        if type(klass) in (binary_type, text_type):
             if klass.startswith('list['):
                 sub_kls = re.match('list\[(.*)\]', klass).group(1)
                 return [self.__deserialize(sub_data, sub_kls)
@@ -245,14 +239,14 @@ class ApiClient(object):
 
             # convert str to class
             # for native types
-            if klass in ['int', 'float', 'str', 'bool',
-                         'date', 'datetime', 'object', 'unicode']:
+            if klass in ['int', 'float', 'binary_type', 'bool',
+                         'date', 'datetime', 'object', 'text_type']:
                 klass = eval(klass)
             # for model types
             else:
                 klass = eval('models.' + klass)
 
-        if klass in [int, float, str, bool, unicode]:
+        if klass in [int, float, binary_type, bool, text_type]:
             return self.__deserialize_primitive(data, klass)
         elif klass == object:
             return self.__deserialize_object(data)
@@ -378,7 +372,7 @@ class ApiClient(object):
                 with open(v, 'rb') as f:
                     filename = os.path.basename(f.name)
                     filedata = f.read()
-                    mimetype = mimetypes.\
+                    mimetype = mimetypes. \
                         guess_type(filename)[0] or 'application/octet-stream'
                     params[k] = tuple([filename, filedata, mimetype])
 
@@ -461,8 +455,8 @@ class ApiClient(object):
 
         content_disposition = response.getheader("Content-Disposition")
         if content_disposition:
-            filename = re.\
-                search(r'filename=[\'"]?([^\'"\s]+)[\'"]?', content_disposition).\
+            filename = re. \
+                search(r'filename=[\'"]?([^\'"\s]+)[\'"]?', content_disposition). \
                 group(1)
             path = os.path.join(os.path.dirname(path), filename)
 
@@ -483,7 +477,7 @@ class ApiClient(object):
         try:
             value = klass(data)
         except UnicodeEncodeError:
-            value = unicode(data)
+            value = text_type(data)
         except TypeError:
             value = data
         except ValueError:
@@ -550,7 +544,7 @@ class ApiClient(object):
 
         for attr, attr_type in iteritems(instance.swagger_types):
             if data is not None \
-               and instance.attribute_map[attr] in data\
+               and instance.attribute_map[attr] in data \
                and isinstance(data, (list, dict)):
                 value = data[instance.attribute_map[attr]]
                 setattr(instance, attr, self.__deserialize(value, attr_type))

--- a/lib/tvdbapiv2/apis/__init__.py
+++ b/lib/tvdbapiv2/apis/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # import apis into api package
 from .users_api import UsersApi

--- a/lib/tvdbapiv2/apis/authentication_api.py
+++ b/lib/tvdbapiv2/apis/authentication_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class AuthenticationApi(object):
@@ -48,7 +44,9 @@ class AuthenticationApi(object):
     def login_post(self, authentication_string, **kwargs):
         """
 
-        Returns a session token to be included in the rest of the requests. Note that API key authentication is required for all subsequent requests and user auth is required for routes in the `User` section
+        Returns a session token to be included in the rest of the requests.
+        Note that API key authentication is required for all subsequent requests
+        and user auth is required for routes in the `User` section
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -82,7 +80,7 @@ class AuthenticationApi(object):
         if ('authentication_string' not in params) or (params['authentication_string'] is None):
             raise ValueError("Missing the required parameter `authentication_string` when calling `login_post`")
 
-        resource_path = '/login'.replace('{format}', 'json')
+        resource_path = '/login'
         method = 'POST'
 
         path_params = {}
@@ -126,7 +124,9 @@ class AuthenticationApi(object):
     def refresh_token_get(self, **kwargs):
         """
 
-        Refreshes your current, valid JWT token and returns a new token. Hit this route so that you do not have to post to `/login` with your API key and credentials once you have already been authenticated.
+        Refreshes your current, valid JWT token and returns a new token.
+        Hit this route so that you do not have to post to `/login` with your API key and credentials
+        once you have already been authenticated.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -155,7 +155,7 @@ class AuthenticationApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/refresh_token'.replace('{format}', 'json')
+        resource_path = '/refresh_token'
         method = 'GET'
 
         path_params = {}

--- a/lib/tvdbapiv2/apis/episodes_api.py
+++ b/lib/tvdbapiv2/apis/episodes_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class EpisodesApi(object):
@@ -60,7 +56,9 @@ class EpisodesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the episode (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: EpisodeData
                  If the method is called asynchronously,
                  returns the request thread.
@@ -82,7 +80,7 @@ class EpisodesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `episodes_id_get`")
 
-        resource_path = '/episodes/{id}'.replace('{format}', 'json')
+        resource_path = '/episodes/{id}'
         method = 'GET'
 
         path_params = {}
@@ -101,13 +99,13 @@ class EpisodesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting

--- a/lib/tvdbapiv2/apis/languages_api.py
+++ b/lib/tvdbapiv2/apis/languages_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class LanguagesApi(object):
@@ -48,7 +44,10 @@ class LanguagesApi(object):
     def languages_get(self, **kwargs):
         """
 
-        All available languages. These language abbreviations can be used in the `Accept-Language` header for routes that return translation records.
+        All available languages.
+
+        These language abbreviations can be used in the `Accept-Language` header
+        for routes that return translation records.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -77,7 +76,7 @@ class LanguagesApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/languages'.replace('{format}', 'json')
+        resource_path = '/languages'
         method = 'GET'
 
         path_params = {}
@@ -153,7 +152,7 @@ class LanguagesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `languages_id_get`")
 
-        resource_path = '/languages/{id}'.replace('{format}', 'json')
+        resource_path = '/languages/{id}'
         method = 'GET'
 
         path_params = {}

--- a/lib/tvdbapiv2/apis/search_api.py
+++ b/lib/tvdbapiv2/apis/search_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class SearchApi(object):
@@ -63,8 +59,10 @@ class SearchApi(object):
         :param str name: Name of the series to search for.
         :param str imdb_id: IMDB id of the episode
         :param str zap2it_id: Zap2it ID of the series to search for.
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
-        :return: EpisodeData
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
+        :return: SearchSeries
                  If the method is called asynchronously,
                  returns the request thread.
         """
@@ -81,7 +79,7 @@ class SearchApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/search/series'.replace('{format}', 'json')
+        resource_path = '/search/series'
         method = 'GET'
 
         path_params = {}
@@ -159,7 +157,7 @@ class SearchApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/search/series/params'.replace('{format}', 'json')
+        resource_path = '/search/series/params'
         method = 'GET'
 
         path_params = {}

--- a/lib/tvdbapiv2/apis/series_api.py
+++ b/lib/tvdbapiv2/apis/series_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class SeriesApi(object):
@@ -60,7 +56,9 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: Series
                  If the method is called asynchronously,
                  returns the request thread.
@@ -82,7 +80,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_get`")
 
-        resource_path = '/series/{id}'.replace('{format}', 'json')
+        resource_path = '/series/{id}'
         method = 'GET'
 
         path_params = {}
@@ -101,13 +99,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -140,7 +138,9 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: None
                  If the method is called asynchronously,
                  returns the request thread.
@@ -162,7 +162,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_head`")
 
-        resource_path = '/series/{id}'.replace('{format}', 'json')
+        resource_path = '/series/{id}'
         method = 'HEAD'
 
         path_params = {}
@@ -181,13 +181,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -241,7 +241,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_actors_get`")
 
-        resource_path = '/series/{id}/actors'.replace('{format}', 'json')
+        resource_path = '/series/{id}/actors'
         method = 'GET'
 
         path_params = {}
@@ -258,13 +258,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -320,7 +320,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_episodes_get`")
 
-        resource_path = '/series/{id}/episodes'.replace('{format}', 'json')
+        resource_path = '/series/{id}/episodes'
         method = 'GET'
 
         path_params = {}
@@ -339,13 +339,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -365,7 +365,8 @@ class SeriesApi(object):
 
     def series_id_episodes_query_get(self, id, **kwargs):
         """
-        This route allows the user to query against episodes for the given series. The response is a paginated array of episode records that have been filtered down to basic information.
+        This route allows the user to query against episodes for the given series.
+        The response is a paginated array of episode records that have been filtered down to basic information.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -385,13 +386,16 @@ class SeriesApi(object):
         :param str dvd_episode: DVD episode number
         :param str imdb_id: IMDB id of the episode
         :param str page: Page of results to fetch. Defaults to page 1 if not provided.
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: SeriesEpisodesQuery
                  If the method is called asynchronously,
                  returns the request thread.
         """
 
-        all_params = ['id', 'absolute_number', 'aired_season', 'aired_episode', 'dvd_season', 'dvd_episode', 'imdb_id', 'page', 'accept_language', 'callback']
+        all_params = ['id', 'absolute_number', 'aired_season', 'aired_episode', 'dvd_season',
+                      'dvd_episode', 'imdb_id', 'page', 'accept_language', 'callback']
 
         params = locals()
         for key, val in iteritems(params['kwargs']):
@@ -407,7 +411,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_episodes_query_get`")
 
-        resource_path = '/series/{id}/episodes/query'.replace('{format}', 'json')
+        resource_path = '/series/{id}/episodes/query'
         method = 'GET'
 
         path_params = {}
@@ -440,13 +444,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -500,7 +504,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_episodes_query_params_get`")
 
-        resource_path = '/series/{id}/episodes/query/params'.replace('{format}', 'json')
+        resource_path = '/series/{id}/episodes/query/params'
         method = 'GET'
 
         path_params = {}
@@ -517,13 +521,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -543,7 +547,9 @@ class SeriesApi(object):
 
     def series_id_episodes_summary_get(self, id, **kwargs):
         """
-        Returns a summary of the episodes and seasons available for the series.\n\n__Note__: Season \"0\" is for all episodes that are considered to be specials.
+        Returns a summary of the episodes and seasons available for the series.
+
+        Note: Season "0" is for all episodes that are considered to be specials.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -577,7 +583,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_episodes_summary_get`")
 
-        resource_path = '/series/{id}/episodes/summary'.replace('{format}', 'json')
+        resource_path = '/series/{id}/episodes/summary'
         method = 'GET'
 
         path_params = {}
@@ -594,13 +600,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -621,7 +627,8 @@ class SeriesApi(object):
     def series_id_filter_get(self, id, keys, **kwargs):
         """
 
-        Returns a series records, filtered by the supplied comma-separated list of keys. Query keys can be found at the `/series/{id}/filter/params` route.
+        Returns a series records, filtered by the supplied comma-separated list of keys.
+        Query keys can be found at the `/series/{id}/filter/params` route.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -635,7 +642,9 @@ class SeriesApi(object):
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
         :param str keys: Comma-separated list of keys to filter by (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: Series
                  If the method is called asynchronously,
                  returns the request thread.
@@ -660,7 +669,7 @@ class SeriesApi(object):
         if ('keys' not in params) or (params['keys'] is None):
             raise ValueError("Missing the required parameter `keys` when calling `series_id_filter_get`")
 
-        resource_path = '/series/{id}/filter'.replace('{format}', 'json')
+        resource_path = '/series/{id}/filter'
         method = 'GET'
 
         path_params = {}
@@ -681,13 +690,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -721,7 +730,9 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: FilterKeys
                  If the method is called asynchronously,
                  returns the request thread.
@@ -743,7 +754,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_filter_params_get`")
 
-        resource_path = '/series/{id}/filter/params'.replace('{format}', 'json')
+        resource_path = '/series/{id}/filter/params'
         method = 'GET'
 
         path_params = {}
@@ -762,13 +773,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -802,7 +813,9 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: SeriesImagesCounts
                  If the method is called asynchronously,
                  returns the request thread.
@@ -824,7 +837,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_images_get`")
 
-        resource_path = '/series/{id}/images'.replace('{format}', 'json')
+        resource_path = '/series/{id}/images'
         method = 'GET'
 
         path_params = {}
@@ -843,13 +856,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -883,10 +896,13 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str key_type: Type of image you're querying for (fanart, poster, etc. See ../images/query/params for more details).
+        :param str key_type: Type of image you're querying for
+                             (fanart, poster, etc. See ../images/query/params for more details).
         :param str resolution: Resolution to filter by (1280x1024, for example)
         :param str sub_key: Subkey for the above query keys. See /series/{id}/images/query/params for more information
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: SeriesImageQueryResults
                  If the method is called asynchronously,
                  returns the request thread.
@@ -908,7 +924,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_images_query_get`")
 
-        resource_path = '/series/{id}/images/query'.replace('{format}', 'json')
+        resource_path = '/series/{id}/images/query'
         method = 'GET'
 
         path_params = {}
@@ -933,13 +949,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting
@@ -960,7 +976,8 @@ class SeriesApi(object):
     def series_id_images_query_params_get(self, id, **kwargs):
         """
 
-        Returns the allowed query keys for the `/series/{id}/images/query` route. Contains a parameter record for each unique `keyType`, listing values that will return results.
+        Returns the allowed query keys for the `/series/{id}/images/query` route.
+        Contains a parameter record for each unique `keyType`, listing values that will return results.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -973,7 +990,9 @@ class SeriesApi(object):
         :param callback function: The callback function
             for asynchronous request. (optional)
         :param int id: ID of the series (required)
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: SeriesImagesQueryParams
                  If the method is called asynchronously,
                  returns the request thread.
@@ -995,7 +1014,7 @@ class SeriesApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `series_id_images_query_params_get`")
 
-        resource_path = '/series/{id}/images/query/params'.replace('{format}', 'json')
+        resource_path = '/series/{id}/images/query/params'
         method = 'GET'
 
         path_params = {}
@@ -1014,13 +1033,13 @@ class SeriesApi(object):
         body_params = None
 
         # HTTP header `Accept`
-        header_params['Accept'] = self.api_client.\
+        header_params['Accept'] = self.api_client. \
             select_header_accept(['application/json'])
         if not header_params['Accept']:
             del header_params['Accept']
 
         # HTTP header `Content-Type`
-        header_params['Content-Type'] = self.api_client.\
+        header_params['Content-Type'] = self.api_client. \
             select_header_content_type(['application/json'])
 
         # Authentication setting

--- a/lib/tvdbapiv2/apis/updates_api.py
+++ b/lib/tvdbapiv2/apis/updates_api.py
@@ -17,16 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-import sys
-import os
-
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class UpdatesApi(object):
@@ -48,7 +44,10 @@ class UpdatesApi(object):
     def updated_query_get(self, from_time, **kwargs):
         """
 
-        Returns an array of series that have changed in a maximum of one week blocks since the provided `fromTime`.\n\n\nThe user may specify a `toTime` to grab results for less than a week. Any timespan larger than a week will be reduced down to one week automatically.
+        Returns an array of series that have changed in a maximum of one week blocks since the provided `fromTime`.
+
+        The user may specify a `toTime` to grab results for less than a week.
+        Any timespan larger than a week will be reduced down to one week automatically.
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please define a `callback` function
@@ -62,7 +61,9 @@ class UpdatesApi(object):
             for asynchronous request. (optional)
         :param str from_time: Epoch time to start your date range. (required)
         :param str to_time: Epoch time to end your date range. Must be one week from `fromTime`.
-        :param str accept_language: Records are returned with the Episode name and Overview in the desired language, if it exists. If there is no translation for the given language, then the record is still returned but with empty values for the translated fields.
+        :param str accept_language: Records are returned with the Episode name and Overview in the desired language,
+                                    if it exists. If there is no translation for the given language, then the record
+                                    is still returned but with empty values for the translated fields.
         :return: UpdateData
                  If the method is called asynchronously,
                  returns the request thread.
@@ -84,7 +85,7 @@ class UpdatesApi(object):
         if ('from_time' not in params) or (params['from_time'] is None):
             raise ValueError("Missing the required parameter `from_time` when calling `updated_query_get`")
 
-        resource_path = '/updated/query'.replace('{format}', 'json')
+        resource_path = '/updated/query'
         method = 'GET'
 
         path_params = {}
@@ -161,7 +162,7 @@ class UpdatesApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/updated/query/params'.replace('{format}', 'json')
+        resource_path = '/updated/query/params'
         method = 'GET'
 
         path_params = {}

--- a/lib/tvdbapiv2/apis/users_api.py
+++ b/lib/tvdbapiv2/apis/users_api.py
@@ -17,13 +17,12 @@ Copyright 2015 SmartBear Software
    limitations under the License.
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
-# python 2 and python 3 compatibility library
 from six import iteritems
 
-from ..configuration import Configuration
 from ..api_client import ApiClient
+from ..configuration import Configuration
 
 
 class UsersApi(object):
@@ -74,7 +73,7 @@ class UsersApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/user'.replace('{format}', 'json')
+        resource_path = '/user'
         method = 'GET'
 
         path_params = {}
@@ -145,7 +144,7 @@ class UsersApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/user/favorites'.replace('{format}', 'json')
+        resource_path = '/user/favorites'
         method = 'GET'
 
         path_params = {}
@@ -221,7 +220,7 @@ class UsersApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `user_favorites_id_put`")
 
-        resource_path = '/user/favorites/{id}'.replace('{format}', 'json')
+        resource_path = '/user/favorites/{id}'
         method = 'PUT'
 
         path_params = {}
@@ -299,7 +298,7 @@ class UsersApi(object):
         if ('id' not in params) or (params['id'] is None):
             raise ValueError("Missing the required parameter `id` when calling `user_favorites_id_delete`")
 
-        resource_path = '/user/favorites/{id}'.replace('{format}', 'json')
+        resource_path = '/user/favorites/{id}'
         method = 'DELETE'
 
         path_params = {}
@@ -372,7 +371,7 @@ class UsersApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/user/ratings'.replace('{format}', 'json')
+        resource_path = '/user/ratings'
         method = 'GET'
 
         path_params = {}
@@ -444,7 +443,7 @@ class UsersApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/user/ratings/query'.replace('{format}', 'json')
+        resource_path = '/user/ratings/query'
         method = 'GET'
 
         path_params = {}
@@ -517,7 +516,7 @@ class UsersApi(object):
             params[key] = val
         del params['kwargs']
 
-        resource_path = '/user/ratings/query/params'.replace('{format}', 'json')
+        resource_path = '/user/ratings/query/params'
         method = 'GET'
 
         path_params = {}
@@ -592,12 +591,14 @@ class UsersApi(object):
 
         # verify the required parameter 'item_type' is set
         if ('item_type' not in params) or (params['item_type'] is None):
-            raise ValueError("Missing the required parameter `item_type` when calling `user_ratings_item_type_item_id_delete`")
+            raise ValueError("Missing the required parameter `item_type`"
+                             " when calling `user_ratings_item_type_item_id_delete`")
         # verify the required parameter 'item_id' is set
         if ('item_id' not in params) or (params['item_id'] is None):
-            raise ValueError("Missing the required parameter `item_id` when calling `user_ratings_item_type_item_id_delete`")
+            raise ValueError("Missing the required parameter `item_id`"
+                             " when calling `user_ratings_item_type_item_id_delete`")
 
-        resource_path = '/user/ratings/{itemType}/{itemId}'.replace('{format}', 'json')
+        resource_path = '/user/ratings/{itemType}/{itemId}'
         method = 'DELETE'
 
         path_params = {}
@@ -651,7 +652,8 @@ class UsersApi(object):
         >>> def callback_function(response):
         >>>     pprint(response)
         >>>
-        >>> thread = api.user_ratings_item_type_item_id_item_rating_put(item_type, item_id, item_rating, callback=callback_function)
+        >>> thread = api.user_ratings_item_type_item_id_item_rating_put(
+                item_type, item_id, item_rating, callback=callback_function)
 
         :param callback function: The callback function
             for asynchronous request. (optional)
@@ -677,15 +679,18 @@ class UsersApi(object):
 
         # verify the required parameter 'item_type' is set
         if ('item_type' not in params) or (params['item_type'] is None):
-            raise ValueError("Missing the required parameter `item_type` when calling `user_ratings_item_type_item_id_item_rating_put`")
+            raise ValueError("Missing the required parameter `item_type`"
+                             " when calling `user_ratings_item_type_item_id_item_rating_put`")
         # verify the required parameter 'item_id' is set
         if ('item_id' not in params) or (params['item_id'] is None):
-            raise ValueError("Missing the required parameter `item_id` when calling `user_ratings_item_type_item_id_item_rating_put`")
+            raise ValueError("Missing the required parameter `item_id`"
+                             " when calling `user_ratings_item_type_item_id_item_rating_put`")
         # verify the required parameter 'item_rating' is set
         if ('item_rating' not in params) or (params['item_rating'] is None):
-            raise ValueError("Missing the required parameter `item_rating` when calling `user_ratings_item_type_item_id_item_rating_put`")
+            raise ValueError("Missing the required parameter `item_rating`"
+                             " when calling `user_ratings_item_type_item_id_item_rating_put`")
 
-        resource_path = '/user/ratings/{itemType}/{itemId}/{itemRating}'.replace('{format}', 'json')
+        resource_path = '/user/ratings/{itemType}/{itemId}/{itemRating}'
         method = 'PUT'
 
         path_params = {}

--- a/lib/tvdbapiv2/auth/__init__.py
+++ b/lib/tvdbapiv2/auth/__init__.py
@@ -3,3 +3,5 @@
 """
 The sessions.auth package contains custom authentication handlers for Requests.
 """
+
+from __future__ import absolute_import, unicode_literals

--- a/lib/tvdbapiv2/auth/jwt.py
+++ b/lib/tvdbapiv2/auth/jwt.py
@@ -7,11 +7,14 @@ See:
     https://jwt.io/introduction/
 """
 
+from __future__ import absolute_import, unicode_literals
+
 import json
 import logging
-
 from base64 import urlsafe_b64decode
+
 import requests.auth
+
 from six import text_type
 
 log = logging.getLogger(__name__)

--- a/lib/tvdbapiv2/auth/tvdb.py
+++ b/lib/tvdbapiv2/auth/tvdb.py
@@ -4,9 +4,11 @@
 This module provides authentication to TheTVDB API v2.
 """
 
-import logging
+from __future__ import absolute_import, unicode_literals
 
+import logging
 from time import time
+
 import requests
 from requests.compat import urljoin
 

--- a/lib/tvdbapiv2/configuration.py
+++ b/lib/tvdbapiv2/configuration.py
@@ -18,14 +18,15 @@ Copyright 2015 SmartBear Software
    ref: https://github.com/swagger-api/swagger-codegen
 """
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
+
+import logging
+import sys
 
 from requests.packages.urllib3.util import make_headers
-from six.moves.http_client import HTTPConnection
-import sys
-import logging
 
 from six import iteritems
+from six.moves.http_client import HTTPConnection
 
 
 def singleton(cls, *args, **kw):

--- a/lib/tvdbapiv2/exceptions.py
+++ b/lib/tvdbapiv2/exceptions.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+from __future__ import absolute_import, unicode_literals
+
 
 class ApiException(Exception):
 
@@ -19,7 +21,7 @@ class ApiException(Exception):
         """
         Custom error messages for exception
         """
-        error_message = "({0})\n"\
+        error_message = "({0})\n" \
                         "Reason: {1}\n".format(self.status, self.reason)
         if self.headers:
             error_message += "HTTP response headers: {0}\n".format(self.headers)

--- a/lib/tvdbapiv2/models/__init__.py
+++ b/lib/tvdbapiv2/models/__init__.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 # import models into model package
 from .token import Token

--- a/lib/tvdbapiv2/models/auth.py
+++ b/lib/tvdbapiv2/models/auth.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,9 +40,9 @@ class Auth(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'apikey': 'str',
-            'username': 'str',
-            'userpass': 'str'
+            'apikey': 'text_type',
+            'username': 'text_type',
+            'userpass': 'text_type'
         }
 
         self.attribute_map = {
@@ -59,7 +62,7 @@ class Auth(object):
 
 
         :return: The apikey of this Auth.
-        :rtype: str
+        :rtype: text_type
         """
         return self._apikey
 
@@ -70,7 +73,7 @@ class Auth(object):
 
 
         :param apikey: The apikey of this Auth.
-        :type: str
+        :type: text_type
         """
         self._apikey = apikey
 
@@ -81,7 +84,7 @@ class Auth(object):
 
 
         :return: The username of this Auth.
-        :rtype: str
+        :rtype: text_type
         """
         return self._username
 
@@ -92,7 +95,7 @@ class Auth(object):
 
 
         :param username: The username of this Auth.
-        :type: str
+        :type: text_type
         """
         self._username = username
 
@@ -103,7 +106,7 @@ class Auth(object):
 
 
         :return: The userpass of this Auth.
-        :rtype: str
+        :rtype: text_type
         """
         return self._userpass
 
@@ -114,7 +117,7 @@ class Auth(object):
 
 
         :param userpass: The userpass of this Auth.
-        :type: str
+        :type: text_type
         """
         self._userpass = userpass
 
@@ -150,7 +153,7 @@ class Auth(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -161,4 +164,3 @@ class Auth(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/basic_episode.py
+++ b/lib/tvdbapiv2/models/basic_episode.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -42,9 +45,9 @@ class BasicEpisode(object):
             'aired_season': 'int',
             'dvd_episode_number': 'int',
             'dvd_season': 'int',
-            'episode_name': 'str',
+            'episode_name': 'text_type',
             'id': 'int',
-            'overview': 'str'
+            'overview': 'text_type'
         }
 
         self.attribute_map = {
@@ -184,7 +187,7 @@ class BasicEpisode(object):
 
 
         :return: The episode_name of this BasicEpisode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._episode_name
 
@@ -195,7 +198,7 @@ class BasicEpisode(object):
 
 
         :param episode_name: The episode_name of this BasicEpisode.
-        :type: str
+        :type: text_type
         """
         self._episode_name = episode_name
 
@@ -228,7 +231,7 @@ class BasicEpisode(object):
 
 
         :return: The overview of this BasicEpisode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._overview
 
@@ -239,7 +242,7 @@ class BasicEpisode(object):
 
 
         :param overview: The overview of this BasicEpisode.
-        :type: str
+        :type: text_type
         """
         self._overview = overview
 
@@ -275,7 +278,7 @@ class BasicEpisode(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -286,4 +289,3 @@ class BasicEpisode(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/conflict.py
+++ b/lib/tvdbapiv2/models/conflict.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class Conflict(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'error': 'str'
+            'error': 'text_type'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class Conflict(object):
 
 
         :return: The error of this Conflict.
-        :rtype: str
+        :rtype: text_type
         """
         return self._error
 
@@ -64,7 +67,7 @@ class Conflict(object):
 
 
         :param error: The error of this Conflict.
-        :type: str
+        :type: text_type
         """
         self._error = error
 
@@ -100,7 +103,7 @@ class Conflict(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class Conflict(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/episode.py
+++ b/lib/tvdbapiv2/models/episode.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -40,31 +43,31 @@ class Episode(object):
             'id': 'int',
             'aired_season': 'int',
             'aired_episode_number': 'int',
-            'episode_name': 'str',
-            'first_aired': 'str',
-            'guest_stars': 'str',
-            'director': 'str',
-            'writers': 'list[str]',
-            'overview': 'str',
-            'production_code': 'str',
-            'show_url': 'str',
+            'episode_name': 'text_type',
+            'first_aired': 'text_type',
+            'guest_stars': 'text_type',
+            'director': 'text_type',
+            'writers': 'list[text_type]',
+            'overview': 'text_type',
+            'production_code': 'text_type',
+            'show_url': 'text_type',
             'last_updated': 'int',
-            'dvd_discid': 'str',
+            'dvd_discid': 'text_type',
             'dvd_season': 'int',
             'dvd_episode_number': 'float',
             'dvd_chapter': 'float',
             'absolute_number': 'int',
-            'filename': 'str',
-            'series_id': 'str',
-            'last_updated_by': 'str',
+            'filename': 'text_type',
+            'series_id': 'text_type',
+            'last_updated_by': 'text_type',
             'airs_after_season': 'int',
             'airs_before_season': 'int',
             'airs_before_episode': 'int',
-            'thumb_author': 'str',
-            'thumb_added': 'str',
-            'thumb_width': 'str',
-            'thumb_height': 'str',
-            'imdb_id': 'str',
+            'thumb_author': 'text_type',
+            'thumb_added': 'text_type',
+            'thumb_width': 'text_type',
+            'thumb_height': 'text_type',
+            'imdb_id': 'text_type',
             'site_rating': 'float'
         }
 
@@ -203,7 +206,7 @@ class Episode(object):
 
 
         :return: The episode_name of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._episode_name
 
@@ -214,7 +217,7 @@ class Episode(object):
 
 
         :param episode_name: The episode_name of this Episode.
-        :type: str
+        :type: text_type
         """
         self._episode_name = episode_name
 
@@ -225,7 +228,7 @@ class Episode(object):
 
 
         :return: The first_aired of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._first_aired
 
@@ -236,7 +239,7 @@ class Episode(object):
 
 
         :param first_aired: The first_aired of this Episode.
-        :type: str
+        :type: text_type
         """
         self._first_aired = first_aired
 
@@ -247,7 +250,7 @@ class Episode(object):
 
 
         :return: The guest_stars of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._guest_stars
 
@@ -258,7 +261,7 @@ class Episode(object):
 
 
         :param guest_stars: The guest_stars of this Episode.
-        :type: str
+        :type: text_type
         """
         self._guest_stars = guest_stars
 
@@ -269,7 +272,7 @@ class Episode(object):
 
 
         :return: The director of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._director
 
@@ -280,7 +283,7 @@ class Episode(object):
 
 
         :param director: The director of this Episode.
-        :type: str
+        :type: text_type
         """
         self._director = director
 
@@ -291,7 +294,7 @@ class Episode(object):
 
 
         :return: The writers of this Episode.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._writers
 
@@ -302,7 +305,7 @@ class Episode(object):
 
 
         :param writers: The writers of this Episode.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._writers = writers
 
@@ -313,7 +316,7 @@ class Episode(object):
 
 
         :return: The overview of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._overview
 
@@ -324,7 +327,7 @@ class Episode(object):
 
 
         :param overview: The overview of this Episode.
-        :type: str
+        :type: text_type
         """
         self._overview = overview
 
@@ -335,7 +338,7 @@ class Episode(object):
 
 
         :return: The production_code of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._production_code
 
@@ -346,7 +349,7 @@ class Episode(object):
 
 
         :param production_code: The production_code of this Episode.
-        :type: str
+        :type: text_type
         """
         self._production_code = production_code
 
@@ -357,7 +360,7 @@ class Episode(object):
 
 
         :return: The show_url of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._show_url
 
@@ -368,7 +371,7 @@ class Episode(object):
 
 
         :param show_url: The show_url of this Episode.
-        :type: str
+        :type: text_type
         """
         self._show_url = show_url
 
@@ -401,7 +404,7 @@ class Episode(object):
 
 
         :return: The dvd_discid of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._dvd_discid
 
@@ -412,7 +415,7 @@ class Episode(object):
 
 
         :param dvd_discid: The dvd_discid of this Episode.
-        :type: str
+        :type: text_type
         """
         self._dvd_discid = dvd_discid
 
@@ -511,7 +514,7 @@ class Episode(object):
 
 
         :return: The filename of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._filename
 
@@ -522,7 +525,7 @@ class Episode(object):
 
 
         :param filename: The filename of this Episode.
-        :type: str
+        :type: text_type
         """
         self._filename = filename
 
@@ -533,7 +536,7 @@ class Episode(object):
 
 
         :return: The series_id of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._series_id
 
@@ -544,7 +547,7 @@ class Episode(object):
 
 
         :param series_id: The series_id of this Episode.
-        :type: str
+        :type: text_type
         """
         self._series_id = series_id
 
@@ -555,7 +558,7 @@ class Episode(object):
 
 
         :return: The last_updated_by of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._last_updated_by
 
@@ -566,7 +569,7 @@ class Episode(object):
 
 
         :param last_updated_by: The last_updated_by of this Episode.
-        :type: str
+        :type: text_type
         """
         self._last_updated_by = last_updated_by
 
@@ -643,7 +646,7 @@ class Episode(object):
 
 
         :return: The thumb_author of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._thumb_author
 
@@ -654,7 +657,7 @@ class Episode(object):
 
 
         :param thumb_author: The thumb_author of this Episode.
-        :type: str
+        :type: text_type
         """
         self._thumb_author = thumb_author
 
@@ -665,7 +668,7 @@ class Episode(object):
 
 
         :return: The thumb_added of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._thumb_added
 
@@ -676,7 +679,7 @@ class Episode(object):
 
 
         :param thumb_added: The thumb_added of this Episode.
-        :type: str
+        :type: text_type
         """
         self._thumb_added = thumb_added
 
@@ -687,7 +690,7 @@ class Episode(object):
 
 
         :return: The thumb_width of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._thumb_width
 
@@ -698,7 +701,7 @@ class Episode(object):
 
 
         :param thumb_width: The thumb_width of this Episode.
-        :type: str
+        :type: text_type
         """
         self._thumb_width = thumb_width
 
@@ -709,7 +712,7 @@ class Episode(object):
 
 
         :return: The thumb_height of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._thumb_height
 
@@ -720,7 +723,7 @@ class Episode(object):
 
 
         :param thumb_height: The thumb_height of this Episode.
-        :type: str
+        :type: text_type
         """
         self._thumb_height = thumb_height
 
@@ -731,7 +734,7 @@ class Episode(object):
 
 
         :return: The imdb_id of this Episode.
-        :rtype: str
+        :rtype: text_type
         """
         return self._imdb_id
 
@@ -742,7 +745,7 @@ class Episode(object):
 
 
         :param imdb_id: The imdb_id of this Episode.
-        :type: str
+        :type: text_type
         """
         self._imdb_id = imdb_id
 
@@ -800,7 +803,7 @@ class Episode(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -811,4 +814,3 @@ class Episode(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/episode_data.py
+++ b/lib/tvdbapiv2/models/episode_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class EpisodeData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """

--- a/lib/tvdbapiv2/models/episode_data_query_params.py
+++ b/lib/tvdbapiv2/models/episode_data_query_params.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class EpisodeDataQueryParams(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'data': 'list[str]'
+            'data': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class EpisodeDataQueryParams(object):
 
 
         :return: The data of this EpisodeDataQueryParams.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._data
 
@@ -64,7 +67,7 @@ class EpisodeDataQueryParams(object):
 
 
         :param data: The data of this EpisodeDataQueryParams.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._data = data
 
@@ -100,7 +103,7 @@ class EpisodeDataQueryParams(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class EpisodeDataQueryParams(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/filter_keys.py
+++ b/lib/tvdbapiv2/models/filter_keys.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class FilterKeys(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'data': 'list[str]'
+            'data': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class FilterKeys(object):
 
 
         :return: The data of this FilterKeys.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._data
 
@@ -64,7 +67,7 @@ class FilterKeys(object):
 
 
         :param data: The data of this FilterKeys.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._data = data
 
@@ -100,7 +103,7 @@ class FilterKeys(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class FilterKeys(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/language.py
+++ b/lib/tvdbapiv2/models/language.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -38,9 +41,9 @@ class Language(object):
         """
         self.swagger_types = {
             'id': 'int',
-            'abbreviation': 'str',
-            'name': 'str',
-            'english_name': 'str'
+            'abbreviation': 'text_type',
+            'name': 'text_type',
+            'english_name': 'text_type'
         }
 
         self.attribute_map = {
@@ -84,7 +87,7 @@ class Language(object):
 
 
         :return: The abbreviation of this Language.
-        :rtype: str
+        :rtype: text_type
         """
         return self._abbreviation
 
@@ -95,7 +98,7 @@ class Language(object):
 
 
         :param abbreviation: The abbreviation of this Language.
-        :type: str
+        :type: text_type
         """
         self._abbreviation = abbreviation
 
@@ -106,7 +109,7 @@ class Language(object):
 
 
         :return: The name of this Language.
-        :rtype: str
+        :rtype: text_type
         """
         return self._name
 
@@ -117,7 +120,7 @@ class Language(object):
 
 
         :param name: The name of this Language.
-        :type: str
+        :type: text_type
         """
         self._name = name
 
@@ -128,7 +131,7 @@ class Language(object):
 
 
         :return: The english_name of this Language.
-        :rtype: str
+        :rtype: text_type
         """
         return self._english_name
 
@@ -139,7 +142,7 @@ class Language(object):
 
 
         :param english_name: The english_name of this Language.
-        :type: str
+        :type: text_type
         """
         self._english_name = english_name
 
@@ -175,7 +178,7 @@ class Language(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -186,4 +189,3 @@ class Language(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/language_data.py
+++ b/lib/tvdbapiv2/models/language_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class LanguageData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class LanguageData(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/links.py
+++ b/lib/tvdbapiv2/models/links.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -175,7 +178,7 @@ class Links(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -186,4 +189,3 @@ class Links(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/not_authorized.py
+++ b/lib/tvdbapiv2/models/not_authorized.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class NotAuthorized(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'error': 'str'
+            'error': 'text_type'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class NotAuthorized(object):
 
 
         :return: The error of this NotAuthorized.
-        :rtype: str
+        :rtype: text_type
         """
         return self._error
 
@@ -64,7 +67,7 @@ class NotAuthorized(object):
 
 
         :param error: The error of this NotAuthorized.
-        :type: str
+        :type: text_type
         """
         self._error = error
 
@@ -100,7 +103,7 @@ class NotAuthorized(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class NotAuthorized(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/not_found.py
+++ b/lib/tvdbapiv2/models/not_found.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class NotFound(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'error': 'str'
+            'error': 'text_type'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class NotFound(object):
 
 
         :return: The error of this NotFound.
-        :rtype: str
+        :rtype: text_type
         """
         return self._error
 
@@ -64,7 +67,7 @@ class NotFound(object):
 
 
         :param error: The error of this NotFound.
-        :type: str
+        :type: text_type
         """
         self._error = error
 
@@ -100,7 +103,7 @@ class NotFound(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class NotFound(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/search_series.py
+++ b/lib/tvdbapiv2/models/search_series.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SearchSeries(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """

--- a/lib/tvdbapiv2/models/series.py
+++ b/lib/tvdbapiv2/models/series.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -38,24 +41,24 @@ class Series(object):
         """
         self.swagger_types = {
             'id': 'int',
-            'series_name': 'unicode',
-            'aliases': 'list[unicode]',
-            'banner': 'unicode',
-            'series_id': 'unicode',
-            'status': 'unicode',
-            'first_aired': 'unicode',
-            'network': 'unicode',
-            'network_id': 'unicode',
-            'runtime': 'unicode',
-            'genre': 'list[unicode]',
-            'overview': 'unicode',
+            'series_name': 'text_type',
+            'aliases': 'list[text_type]',
+            'banner': 'text_type',
+            'series_id': 'text_type',
+            'status': 'text_type',
+            'first_aired': 'text_type',
+            'network': 'text_type',
+            'network_id': 'text_type',
+            'runtime': 'text_type',
+            'genre': 'list[text_type]',
+            'overview': 'text_type',
             'last_updated': 'int',
-            'airs_day_of_week': 'unicode',
-            'airs_time': 'unicode',
-            'rating': 'unicode',
-            'imdb_id': 'unicode',
-            'zap2it_id': 'unicode',
-            'added': 'unicode',
+            'airs_day_of_week': 'text_type',
+            'airs_time': 'text_type',
+            'rating': 'text_type',
+            'imdb_id': 'text_type',
+            'zap2it_id': 'text_type',
+            'added': 'text_type',
             'site_rating': 'float'
         }
 
@@ -132,7 +135,7 @@ class Series(object):
 
 
         :return: The series_name of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._series_name
 
@@ -143,7 +146,7 @@ class Series(object):
 
 
         :param series_name: The series_name of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._series_name = series_name
 
@@ -154,7 +157,7 @@ class Series(object):
 
 
         :return: The aliases of this Series.
-        :rtype: list[unicode]
+        :rtype: list[text_type]
         """
         return self._aliases
 
@@ -165,7 +168,7 @@ class Series(object):
 
 
         :param aliases: The aliases of this Series.
-        :type: list[unicode]
+        :type: list[text_type]
         """
         self._aliases = aliases
 
@@ -176,7 +179,7 @@ class Series(object):
 
 
         :return: The banner of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._banner
 
@@ -187,7 +190,7 @@ class Series(object):
 
 
         :param banner: The banner of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._banner = banner
 
@@ -198,7 +201,7 @@ class Series(object):
 
 
         :return: The series_id of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._series_id
 
@@ -209,7 +212,7 @@ class Series(object):
 
 
         :param series_id: The series_id of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._series_id = series_id
 
@@ -220,7 +223,7 @@ class Series(object):
 
 
         :return: The status of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._status
 
@@ -231,7 +234,7 @@ class Series(object):
 
 
         :param status: The status of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._status = status
 
@@ -242,7 +245,7 @@ class Series(object):
 
 
         :return: The first_aired of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._first_aired
 
@@ -253,7 +256,7 @@ class Series(object):
 
 
         :param first_aired: The first_aired of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._first_aired = first_aired
 
@@ -264,7 +267,7 @@ class Series(object):
 
 
         :return: The network of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._network
 
@@ -275,7 +278,7 @@ class Series(object):
 
 
         :param network: The network of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._network = network
 
@@ -286,7 +289,7 @@ class Series(object):
 
 
         :return: The network_id of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._network_id
 
@@ -297,7 +300,7 @@ class Series(object):
 
 
         :param network_id: The network_id of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._network_id = network_id
 
@@ -308,7 +311,7 @@ class Series(object):
 
 
         :return: The runtime of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._runtime
 
@@ -319,7 +322,7 @@ class Series(object):
 
 
         :param runtime: The runtime of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._runtime = runtime
 
@@ -330,7 +333,7 @@ class Series(object):
 
 
         :return: The genre of this Series.
-        :rtype: list[unicode]
+        :rtype: list[text_type]
         """
         return self._genre
 
@@ -341,7 +344,7 @@ class Series(object):
 
 
         :param genre: The genre of this Series.
-        :type: list[unicode]
+        :type: list[text_type]
         """
         self._genre = genre
 
@@ -352,7 +355,7 @@ class Series(object):
 
 
         :return: The overview of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._overview
 
@@ -363,7 +366,7 @@ class Series(object):
 
 
         :param overview: The overview of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._overview = overview
 
@@ -396,7 +399,7 @@ class Series(object):
 
 
         :return: The airs_day_of_week of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._airs_day_of_week
 
@@ -407,7 +410,7 @@ class Series(object):
 
 
         :param airs_day_of_week: The airs_day_of_week of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._airs_day_of_week = airs_day_of_week
 
@@ -418,7 +421,7 @@ class Series(object):
 
 
         :return: The airs_time of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._airs_time
 
@@ -429,7 +432,7 @@ class Series(object):
 
 
         :param airs_time: The airs_time of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._airs_time = airs_time
 
@@ -440,7 +443,7 @@ class Series(object):
 
 
         :return: The rating of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._rating
 
@@ -451,7 +454,7 @@ class Series(object):
 
 
         :param rating: The rating of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._rating = rating
 
@@ -462,7 +465,7 @@ class Series(object):
 
 
         :return: The imdb_id of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._imdb_id
 
@@ -473,7 +476,7 @@ class Series(object):
 
 
         :param imdb_id: The imdb_id of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._imdb_id = imdb_id
 
@@ -484,7 +487,7 @@ class Series(object):
 
 
         :return: The zap2it_id of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._zap2it_id
 
@@ -495,7 +498,7 @@ class Series(object):
 
 
         :param zap2it_id: The zap2it_id of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._zap2it_id = zap2it_id
 
@@ -506,7 +509,7 @@ class Series(object):
 
 
         :return: The added of this Series.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._added
 
@@ -517,7 +520,7 @@ class Series(object):
 
 
         :param added: The added of this Series.
-        :type: unicode
+        :type: text_type
         """
         self._added = added
 
@@ -586,4 +589,3 @@ class Series(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_actors.py
+++ b/lib/tvdbapiv2/models/series_actors.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SeriesActors(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class SeriesActors(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_actors_data.py
+++ b/lib/tvdbapiv2/models/series_actors_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -39,13 +42,13 @@ class SeriesActorsData(object):
         self.swagger_types = {
             'id': 'int',
             'series_id': 'int',
-            'name': 'str',
-            'role': 'str',
+            'name': 'text_type',
+            'role': 'text_type',
             'sort_order': 'int',
-            'image': 'str',
+            'image': 'text_type',
             'image_author': 'int',
-            'image_added': 'str',
-            'last_updated': 'str'
+            'image_added': 'text_type',
+            'last_updated': 'text_type'
         }
 
         self.attribute_map = {
@@ -121,7 +124,7 @@ class SeriesActorsData(object):
 
 
         :return: The name of this SeriesActorsData.
-        :rtype: str
+        :rtype: text_type
         """
         return self._name
 
@@ -132,7 +135,7 @@ class SeriesActorsData(object):
 
 
         :param name: The name of this SeriesActorsData.
-        :type: str
+        :type: text_type
         """
         self._name = name
 
@@ -143,7 +146,7 @@ class SeriesActorsData(object):
 
 
         :return: The role of this SeriesActorsData.
-        :rtype: str
+        :rtype: text_type
         """
         return self._role
 
@@ -154,7 +157,7 @@ class SeriesActorsData(object):
 
 
         :param role: The role of this SeriesActorsData.
-        :type: str
+        :type: text_type
         """
         self._role = role
 
@@ -187,7 +190,7 @@ class SeriesActorsData(object):
 
 
         :return: The image of this SeriesActorsData.
-        :rtype: str
+        :rtype: text_type
         """
         return self._image
 
@@ -198,7 +201,7 @@ class SeriesActorsData(object):
 
 
         :param image: The image of this SeriesActorsData.
-        :type: str
+        :type: text_type
         """
         self._image = image
 
@@ -231,7 +234,7 @@ class SeriesActorsData(object):
 
 
         :return: The image_added of this SeriesActorsData.
-        :rtype: str
+        :rtype: text_type
         """
         return self._image_added
 
@@ -242,7 +245,7 @@ class SeriesActorsData(object):
 
 
         :param image_added: The image_added of this SeriesActorsData.
-        :type: str
+        :type: text_type
         """
         self._image_added = image_added
 
@@ -253,7 +256,7 @@ class SeriesActorsData(object):
 
 
         :return: The last_updated of this SeriesActorsData.
-        :rtype: str
+        :rtype: text_type
         """
         return self._last_updated
 
@@ -264,7 +267,7 @@ class SeriesActorsData(object):
 
 
         :param last_updated: The last_updated of this SeriesActorsData.
-        :type: str
+        :type: text_type
         """
         self._last_updated = last_updated
 
@@ -300,7 +303,7 @@ class SeriesActorsData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -311,4 +314,3 @@ class SeriesActorsData(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_data.py
+++ b/lib/tvdbapiv2/models/series_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SeriesData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """

--- a/lib/tvdbapiv2/models/series_episodes.py
+++ b/lib/tvdbapiv2/models/series_episodes.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -125,7 +128,7 @@ class SeriesEpisodes(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -136,4 +139,3 @@ class SeriesEpisodes(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_episodes_query.py
+++ b/lib/tvdbapiv2/models/series_episodes_query.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -125,7 +128,7 @@ class SeriesEpisodesQuery(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -136,4 +139,3 @@ class SeriesEpisodesQuery(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_episodes_query_params.py
+++ b/lib/tvdbapiv2/models/series_episodes_query_params.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class SeriesEpisodesQueryParams(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'data': 'list[str]'
+            'data': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class SeriesEpisodesQueryParams(object):
 
 
         :return: The data of this SeriesEpisodesQueryParams.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._data
 
@@ -64,7 +67,7 @@ class SeriesEpisodesQueryParams(object):
 
 
         :param data: The data of this SeriesEpisodesQueryParams.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._data = data
 
@@ -100,7 +103,7 @@ class SeriesEpisodesQueryParams(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class SeriesEpisodesQueryParams(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_episodes_summary.py
+++ b/lib/tvdbapiv2/models/series_episodes_summary.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,10 +40,10 @@ class SeriesEpisodesSummary(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'aired_seasons': 'list[str]',
-            'aired_episodes': 'str',
-            'dvd_seasons': 'list[str]',
-            'dvd_episodes': 'str'
+            'aired_seasons': 'list[text_type]',
+            'aired_episodes': 'text_type',
+            'dvd_seasons': 'list[text_type]',
+            'dvd_episodes': 'text_type'
         }
 
         self.attribute_map = {
@@ -62,7 +65,7 @@ class SeriesEpisodesSummary(object):
 
 
         :return: The aired_seasons of this SeriesEpisodesSummary.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._aired_seasons
 
@@ -73,7 +76,7 @@ class SeriesEpisodesSummary(object):
 
 
         :param aired_seasons: The aired_seasons of this SeriesEpisodesSummary.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._aired_seasons = aired_seasons
 
@@ -84,7 +87,7 @@ class SeriesEpisodesSummary(object):
         Number of all aired episodes for this series
 
         :return: The aired_episodes of this SeriesEpisodesSummary.
-        :rtype: str
+        :rtype: text_type
         """
         return self._aired_episodes
 
@@ -95,7 +98,7 @@ class SeriesEpisodesSummary(object):
         Number of all aired episodes for this series
 
         :param aired_episodes: The aired_episodes of this SeriesEpisodesSummary.
-        :type: str
+        :type: text_type
         """
         self._aired_episodes = aired_episodes
 
@@ -106,7 +109,7 @@ class SeriesEpisodesSummary(object):
 
 
         :return: The dvd_seasons of this SeriesEpisodesSummary.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._dvd_seasons
 
@@ -117,7 +120,7 @@ class SeriesEpisodesSummary(object):
 
 
         :param dvd_seasons: The dvd_seasons of this SeriesEpisodesSummary.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._dvd_seasons = dvd_seasons
 
@@ -128,7 +131,7 @@ class SeriesEpisodesSummary(object):
         Number of all dvd episodes for this series
 
         :return: The dvd_episodes of this SeriesEpisodesSummary.
-        :rtype: str
+        :rtype: text_type
         """
         return self._dvd_episodes
 
@@ -139,7 +142,7 @@ class SeriesEpisodesSummary(object):
         Number of all dvd episodes for this series
 
         :param dvd_episodes: The dvd_episodes of this SeriesEpisodesSummary.
-        :type: str
+        :type: text_type
         """
         self._dvd_episodes = dvd_episodes
 
@@ -175,7 +178,7 @@ class SeriesEpisodesSummary(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -186,4 +189,3 @@ class SeriesEpisodesSummary(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_image_query_result.py
+++ b/lib/tvdbapiv2/models/series_image_query_result.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -38,13 +41,13 @@ class SeriesImageQueryResult(object):
         """
         self.swagger_types = {
             'id': 'int',
-            'key_type': 'str',
-            'sub_key': 'str',
-            'file_name': 'str',
+            'key_type': 'text_type',
+            'sub_key': 'text_type',
+            'file_name': 'text_type',
             'language_id': 'int',
-            'resolution': 'str',
+            'resolution': 'text_type',
             'ratings_info': 'int',
-            'thumbnail': 'str'
+            'thumbnail': 'text_type'
         }
 
         self.attribute_map = {
@@ -96,7 +99,7 @@ class SeriesImageQueryResult(object):
 
 
         :return: The key_type of this SeriesImageQueryResult.
-        :rtype: str
+        :rtype: text_type
         """
         return self._key_type
 
@@ -107,7 +110,7 @@ class SeriesImageQueryResult(object):
 
 
         :param key_type: The key_type of this SeriesImageQueryResult.
-        :type: str
+        :type: text_type
         """
         self._key_type = key_type
 
@@ -118,7 +121,7 @@ class SeriesImageQueryResult(object):
 
 
         :return: The sub_key of this SeriesImageQueryResult.
-        :rtype: str
+        :rtype: text_type
         """
         return self._sub_key
 
@@ -129,7 +132,7 @@ class SeriesImageQueryResult(object):
 
 
         :param sub_key: The sub_key of this SeriesImageQueryResult.
-        :type: str
+        :type: text_type
         """
         self._sub_key = sub_key
 
@@ -140,7 +143,7 @@ class SeriesImageQueryResult(object):
 
 
         :return: The file_name of this SeriesImageQueryResult.
-        :rtype: str
+        :rtype: text_type
         """
         return self._file_name
 
@@ -151,7 +154,7 @@ class SeriesImageQueryResult(object):
 
 
         :param file_name: The file_name of this SeriesImageQueryResult.
-        :type: str
+        :type: text_type
         """
         self._file_name = file_name
 
@@ -184,7 +187,7 @@ class SeriesImageQueryResult(object):
 
 
         :return: The resolution of this SeriesImageQueryResult.
-        :rtype: str
+        :rtype: text_type
         """
         return self._resolution
 
@@ -195,7 +198,7 @@ class SeriesImageQueryResult(object):
 
 
         :param resolution: The resolution of this SeriesImageQueryResult.
-        :type: str
+        :type: text_type
         """
         self._resolution = resolution
 
@@ -228,7 +231,7 @@ class SeriesImageQueryResult(object):
 
 
         :return: The thumbnail of this SeriesImageQueryResult.
-        :rtype: str
+        :rtype: text_type
         """
         return self._thumbnail
 
@@ -239,7 +242,7 @@ class SeriesImageQueryResult(object):
 
 
         :param thumbnail: The thumbnail of this SeriesImageQueryResult.
-        :type: str
+        :type: text_type
         """
         self._thumbnail = thumbnail
 
@@ -275,7 +278,7 @@ class SeriesImageQueryResult(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -286,4 +289,3 @@ class SeriesImageQueryResult(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_image_query_results.py
+++ b/lib/tvdbapiv2/models/series_image_query_results.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SeriesImageQueryResults(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class SeriesImageQueryResults(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_images_count.py
+++ b/lib/tvdbapiv2/models/series_images_count.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -200,7 +203,7 @@ class SeriesImagesCount(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -211,4 +214,3 @@ class SeriesImagesCount(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_images_counts.py
+++ b/lib/tvdbapiv2/models/series_images_counts.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SeriesImagesCounts(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class SeriesImagesCounts(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_images_query_param.py
+++ b/lib/tvdbapiv2/models/series_images_query_param.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,10 +40,10 @@ class SeriesImagesQueryParam(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'key_type': 'str',
-            'language_id': 'str',
-            'resolution': 'list[str]',
-            'sub_key': 'list[str]'
+            'key_type': 'text_type',
+            'language_id': 'text_type',
+            'resolution': 'list[text_type]',
+            'sub_key': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -62,7 +65,7 @@ class SeriesImagesQueryParam(object):
 
 
         :return: The key_type of this SeriesImagesQueryParam.
-        :rtype: str
+        :rtype: text_type
         """
         return self._key_type
 
@@ -73,7 +76,7 @@ class SeriesImagesQueryParam(object):
 
 
         :param key_type: The key_type of this SeriesImagesQueryParam.
-        :type: str
+        :type: text_type
         """
         self._key_type = key_type
 
@@ -84,7 +87,7 @@ class SeriesImagesQueryParam(object):
 
 
         :return: The language_id of this SeriesImagesQueryParam.
-        :rtype: str
+        :rtype: text_type
         """
         return self._language_id
 
@@ -95,7 +98,7 @@ class SeriesImagesQueryParam(object):
 
 
         :param language_id: The language_id of this SeriesImagesQueryParam.
-        :type: str
+        :type: text_type
         """
         self._language_id = language_id
 
@@ -106,7 +109,7 @@ class SeriesImagesQueryParam(object):
 
 
         :return: The resolution of this SeriesImagesQueryParam.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._resolution
 
@@ -117,7 +120,7 @@ class SeriesImagesQueryParam(object):
 
 
         :param resolution: The resolution of this SeriesImagesQueryParam.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._resolution = resolution
 
@@ -128,7 +131,7 @@ class SeriesImagesQueryParam(object):
 
 
         :return: The sub_key of this SeriesImagesQueryParam.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._sub_key
 
@@ -139,7 +142,7 @@ class SeriesImagesQueryParam(object):
 
 
         :param sub_key: The sub_key of this SeriesImagesQueryParam.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._sub_key = sub_key
 
@@ -175,7 +178,7 @@ class SeriesImagesQueryParam(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -186,4 +189,3 @@ class SeriesImagesQueryParam(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/series_images_query_params.py
+++ b/lib/tvdbapiv2/models/series_images_query_params.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class SeriesImagesQueryParams(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class SeriesImagesQueryParams(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/token.py
+++ b/lib/tvdbapiv2/models/token.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class Token(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'token': 'unicode'
+            'token': 'text_type'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class Token(object):
 
 
         :return: The token of this Token.
-        :rtype: unicode
+        :rtype: text_type
         """
         return self._token
 
@@ -64,7 +67,7 @@ class Token(object):
 
 
         :param token: The token of this Token.
-        :type: unicode
+        :type: text_type
         """
         self._token = token
 
@@ -111,4 +114,3 @@ class Token(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/update.py
+++ b/lib/tvdbapiv2/models/update.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -125,7 +128,7 @@ class Update(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -136,4 +139,3 @@ class Update(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/update_data.py
+++ b/lib/tvdbapiv2/models/update_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class UpdateData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UpdateData(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/update_data_query_params.py
+++ b/lib/tvdbapiv2/models/update_data_query_params.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class UpdateDataQueryParams(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'data': 'list[str]'
+            'data': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class UpdateDataQueryParams(object):
 
 
         :return: The data of this UpdateDataQueryParams.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._data
 
@@ -64,7 +67,7 @@ class UpdateDataQueryParams(object):
 
 
         :param data: The data of this UpdateDataQueryParams.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._data = data
 
@@ -100,7 +103,7 @@ class UpdateDataQueryParams(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UpdateDataQueryParams(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user.py
+++ b/lib/tvdbapiv2/models/user.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,9 +40,9 @@ class User(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'user_name': 'str',
-            'language': 'str',
-            'favorites_displaymode': 'str'
+            'user_name': 'text_type',
+            'language': 'text_type',
+            'favorites_displaymode': 'text_type'
         }
 
         self.attribute_map = {
@@ -59,7 +62,7 @@ class User(object):
 
 
         :return: The user_name of this User.
-        :rtype: str
+        :rtype: text_type
         """
         return self._user_name
 
@@ -70,7 +73,7 @@ class User(object):
 
 
         :param user_name: The user_name of this User.
-        :type: str
+        :type: text_type
         """
         self._user_name = user_name
 
@@ -81,7 +84,7 @@ class User(object):
 
 
         :return: The language of this User.
-        :rtype: str
+        :rtype: text_type
         """
         return self._language
 
@@ -92,7 +95,7 @@ class User(object):
 
 
         :param language: The language of this User.
-        :type: str
+        :type: text_type
         """
         self._language = language
 
@@ -103,7 +106,7 @@ class User(object):
 
 
         :return: The favorites_displaymode of this User.
-        :rtype: str
+        :rtype: text_type
         """
         return self._favorites_displaymode
 
@@ -114,7 +117,7 @@ class User(object):
 
 
         :param favorites_displaymode: The favorites_displaymode of this User.
-        :type: str
+        :type: text_type
         """
         self._favorites_displaymode = favorites_displaymode
 
@@ -150,7 +153,7 @@ class User(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -161,4 +164,3 @@ class User(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_data.py
+++ b/lib/tvdbapiv2/models/user_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class UserData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """

--- a/lib/tvdbapiv2/models/user_favorites.py
+++ b/lib/tvdbapiv2/models/user_favorites.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class UserFavorites(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'favorites': 'list[str]'
+            'favorites': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class UserFavorites(object):
 
 
         :return: The favorites of this UserFavorites.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._favorites
 
@@ -64,7 +67,7 @@ class UserFavorites(object):
 
 
         :param favorites: The favorites of this UserFavorites.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._favorites = favorites
 
@@ -100,7 +103,7 @@ class UserFavorites(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UserFavorites(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_favorites_data.py
+++ b/lib/tvdbapiv2/models/user_favorites_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class UserFavoritesData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UserFavoritesData(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_ratings.py
+++ b/lib/tvdbapiv2/models/user_ratings.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class UserRatings(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'rating_type': 'str',
+            'rating_type': 'text_type',
             'rating_item_id': 'int',
             'rating': 'int'
         }
@@ -59,7 +62,7 @@ class UserRatings(object):
 
 
         :return: The rating_type of this UserRatings.
-        :rtype: str
+        :rtype: text_type
         """
         return self._rating_type
 
@@ -70,7 +73,7 @@ class UserRatings(object):
 
 
         :param rating_type: The rating_type of this UserRatings.
-        :type: str
+        :type: text_type
         """
         self._rating_type = rating_type
 
@@ -150,7 +153,7 @@ class UserRatings(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -161,4 +164,3 @@ class UserRatings(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_ratings_data.py
+++ b/lib/tvdbapiv2/models/user_ratings_data.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -125,7 +128,7 @@ class UserRatingsData(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -136,4 +139,3 @@ class UserRatingsData(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_ratings_data_no_links.py
+++ b/lib/tvdbapiv2/models/user_ratings_data_no_links.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class UserRatingsDataNoLinks(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UserRatingsDataNoLinks(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_ratings_data_no_links_empty_array.py
+++ b/lib/tvdbapiv2/models/user_ratings_data_no_links_empty_array.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -100,7 +103,7 @@ class UserRatingsDataNoLinksEmptyArray(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UserRatingsDataNoLinksEmptyArray(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/models/user_ratings_query_params.py
+++ b/lib/tvdbapiv2/models/user_ratings_query_params.py
@@ -18,7 +18,10 @@ Copyright 2015 SmartBear Software
     Ref: https://github.com/swagger-api/swagger-codegen
 """
 
+from __future__ import absolute_import, unicode_literals
+
 from pprint import pformat
+
 from six import iteritems
 
 
@@ -37,7 +40,7 @@ class UserRatingsQueryParams(object):
                                   and the value is json key in definition.
         """
         self.swagger_types = {
-            'data': 'list[str]'
+            'data': 'list[text_type]'
         }
 
         self.attribute_map = {
@@ -53,7 +56,7 @@ class UserRatingsQueryParams(object):
 
 
         :return: The data of this UserRatingsQueryParams.
-        :rtype: list[str]
+        :rtype: list[text_type]
         """
         return self._data
 
@@ -64,7 +67,7 @@ class UserRatingsQueryParams(object):
 
 
         :param data: The data of this UserRatingsQueryParams.
-        :type: list[str]
+        :type: list[text_type]
         """
         self._data = data
 
@@ -100,7 +103,7 @@ class UserRatingsQueryParams(object):
         """
         return self.to_str()
 
-    def __eq__(self, other): 
+    def __eq__(self, other):
         """
         Returns true if both objects are equal
         """
@@ -111,4 +114,3 @@ class UserRatingsQueryParams(object):
         Returns true if both objects are not equal
         """
         return not self == other
-

--- a/lib/tvdbapiv2/rest.py
+++ b/lib/tvdbapiv2/rest.py
@@ -18,11 +18,16 @@ Copyright 2015 SmartBear Software
 Credit: this file (rest.py) is modified based on rest.py in Dropbox Python SDK:
 https://www.dropbox.com/developers/core/sdks/python
 """
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import logging
+
 from contextlib2 import suppress
+
 from requests.exceptions import RequestException
+
+from six import text_type
+
 from .exceptions import ApiException
 
 logger = logging.getLogger(__name__)
@@ -52,7 +57,7 @@ class RESTClientObject(object):
 
         except RequestException as error:
             status = 0
-            msg = "{0}\n{1}".format(type(error).__name__, str(error))
+            msg = "{0}\n{1}".format(type(error).__name__, text_type(error))
             with suppress(AttributeError):
                 status = error.response.status_code
             raise ApiException(status=status, reason=msg)

--- a/medusa/helpers/externals.py
+++ b/medusa/helpers/externals.py
@@ -113,7 +113,7 @@ def get_externals(show=None, indexer=None, indexed_show=None):
                 log.warning(
                     u'Error getting external ids for other'
                     u' indexer {name}: {reason}',
-                    {'name': indexerApi(show.indexer).name, 'reason': error.message})
+                    {'name': indexerApi(other_indexer).name, 'reason': error.message})
 
     # Try to update with the Trakt externals.
     if app.USE_TRAKT:

--- a/medusa/indexers/indexer_base.py
+++ b/medusa/indexers/indexer_base.py
@@ -2,8 +2,7 @@
 
 """Base class for indexer api's."""
 
-from __future__ import division
-from __future__ import unicode_literals
+from __future__ import division, unicode_literals
 
 import getpass
 import logging
@@ -11,8 +10,6 @@ import os
 import tempfile
 import time
 import warnings
-from builtins import object
-from builtins import str
 from operator import itemgetter
 
 from medusa import statistics as stats
@@ -30,7 +27,7 @@ from medusa.statistics import weights
 
 import requests
 
-from six import integer_types, itervalues, string_types, viewitems
+from six import integer_types, itervalues, string_types, text_type, viewitems
 
 
 log = BraceAdapter(logging.getLogger(__name__))
@@ -188,7 +185,7 @@ class BaseIndexer(object):
 
     def __repr__(self):
         """Indexer representation, returning representation of all shows indexed."""
-        return str(self.shows)
+        return text_type(self.shows)
 
     def _set_item(self, sid, seas, ep, attrib, value):  # pylint: disable=too-many-arguments
         """Create a new episode, creating Show(), Season() and Episode()s as required.
@@ -402,7 +399,7 @@ class BaseIndexer(object):
                 self._get_show_data(key, self.config['language'])
             return self.shows[key]
 
-        key = str(key).lower()
+        key = text_type(key).lower()
         self.config['searchterm'] = key
         selected_series = self._get_series(key)
         if isinstance(selected_series, dict):
@@ -500,7 +497,7 @@ class Show(dict):
 
     def aired_on(self, date):
         """Search and return a list of episodes with the airdates."""
-        ret = self.search(str(date), 'firstaired')
+        ret = self.search(text_type(date), 'firstaired')
         if len(ret) == 0:
             raise IndexerEpisodeNotFound('Could not find any episodes that aired on {0}'.format(date))
         return ret
@@ -629,13 +626,13 @@ class Episode(dict):
         if term is None:
             raise TypeError('must supply string to search for (contents)')
 
-        term = str(term).lower()
+        term = text_type(term).lower()
         for cur_key, cur_value in viewitems(self):
-            cur_key, cur_value = str(cur_key).lower(), str(cur_value).lower()
+            cur_key, cur_value = text_type(cur_key).lower(), text_type(cur_value).lower()
             if key is not None and cur_key != key:
                 # Do not search this key
                 continue
-            if cur_value.find(str(term).lower()) > -1:
+            if cur_value.find(text_type(term).lower()) > -1:
                 return self
 
 

--- a/medusa/indexers/tmdb/tmdb.py
+++ b/medusa/indexers/tmdb/tmdb.py
@@ -158,7 +158,7 @@ class Tmdb(BaseIndexer):
             results = []
             while page <= last:
                 search_result = self.tmdb.Search().tv(query=show,
-                                                      language='request_language',
+                                                      language=request_language,
                                                       page=page)
                 last = search_result.get('total_pages', 0)
                 results += search_result.get('results')
@@ -178,7 +178,6 @@ class Tmdb(BaseIndexer):
         :param series: The query for the series name
         :return: An ordered dict with the show searched for. In the format of OrderedDict{"series": [list of shows]}
         """
-        series = series.encode('utf-8')
         log.debug('Searching for show: {0}', series)
 
         results = self._show_search(series, request_language=self.config['language'])

--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -161,7 +161,6 @@ class TVDBv2(BaseIndexer):
         :param series: the query for the series name
         :return: An ordered dict with the show searched for. In the format of OrderedDict{"series": [list of shows]}
         """
-        series = series.encode('utf-8')
         log.debug('Searching for show: {0}', series)
 
         results = self._show_search(series, request_language=self.config['language'])

--- a/medusa/indexers/tvmaze/tvmaze_api.py
+++ b/medusa/indexers/tvmaze/tvmaze_api.py
@@ -166,8 +166,9 @@ class TVmaze(BaseIndexer):
         try:
             results = self.tvmaze_api.get_show_list(show)
         except ShowNotFound as error:
+            # Use error.value because TVMaze API exceptions may be utf-8 encoded when using __str__
             raise IndexerShowNotFound(
-                'Show search failed in getting a result with reason: {0}'.format(error)
+                'Show search failed in getting a result with reason: {0}'.format(error.value)
             )
         except BaseError as error:
             raise IndexerException('Show search failed in getting a result with error: {0!r}'.format(error))
@@ -184,7 +185,6 @@ class TVmaze(BaseIndexer):
         :param series: the query for the series name
         :return: An ordered dict with the show searched for. In the format of OrderedDict{"series": [list of shows]}
         """
-        series = series.encode('utf-8')
         log.debug('Searching for show {0}', series)
 
         results = self._show_search(series, request_language=self.config['language'])

--- a/medusa/server/api/v1/core.py
+++ b/medusa/server/api/v1/core.py
@@ -26,7 +26,6 @@ import json
 import logging
 import os
 import time
-from builtins import str
 from collections import OrderedDict
 from datetime import date, datetime
 
@@ -47,7 +46,7 @@ from medusa.helper.common import (
 from medusa.helper.exceptions import CantUpdateShowException, ShowDirectoryNotFoundException
 from medusa.helpers.quality import get_quality_string
 from medusa.indexers.indexer_api import indexerApi
-from medusa.indexers.indexer_config import INDEXER_TVDBV2
+from medusa.indexers.indexer_config import INDEXER_TMDB, INDEXER_TVDBV2, INDEXER_TVMAZE
 from medusa.indexers.indexer_exceptions import IndexerError, IndexerShowIncomplete, IndexerShowNotFound
 from medusa.logger import LOGGING_LEVELS, filter_logline, read_loglines
 from medusa.logger.adapters.style import BraceAdapter
@@ -65,7 +64,7 @@ from medusa.version_checker import CheckVersion
 
 from requests.compat import unquote_plus
 
-from six import iteritems, text_type, viewitems
+from six import binary_type, iteritems, itervalues, string_types, text_type, viewitems
 
 from tornado.web import RequestHandler
 
@@ -75,7 +74,12 @@ standard_library.install_aliases()
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
 
-INDEXER_IDS = ('indexerid', 'tvdbid', 'tvmazeid', 'tmdbid')
+INDEXER_IDS = {
+    0: 'indexerid',
+    INDEXER_TVDBV2: 'tvdbid',
+    INDEXER_TVMAZE: 'tvmazeid',
+    INDEXER_TMDB: 'tmdbid'
+}
 
 # basically everything except RESULT_SUCCESS / success is bad
 RESULT_SUCCESS = 10  # only use inside the run methods
@@ -336,11 +340,11 @@ class ApiCall(ApiHandler):
         """
 
         # auto-select indexer
-        if key in INDEXER_IDS:
+        if key in itervalues(INDEXER_IDS):
             if 'tvdbid' in kwargs:
                 key = 'tvdbid'
 
-            self.indexer = INDEXER_IDS.index(key)
+            self.indexer = next(k for k, v in iteritems(INDEXER_IDS) if v == key)
 
         missing = True
         org_default = default
@@ -786,7 +790,7 @@ class CMD_EpisodeSearch(ApiCall):
 
         # retrieve the episode object and fail if we can't get one
         ep_obj = show_obj.get_episode(self.s, self.e)
-        if isinstance(ep_obj, str):
+        if isinstance(ep_obj, string_types):
             return _responds(RESULT_FAILURE, msg='Episode not found')
 
         # make a queue item for it and put it on the queue
@@ -842,7 +846,7 @@ class CMD_EpisodeSetStatus(ApiCall):
 
         # convert the string status to a int
         for status in statusStrings:
-            if str(statusStrings[status]).lower() == str(self.status).lower():
+            if text_type(statusStrings[status]).lower() == text_type(self.status).lower():
                 self.status = status
                 break
         else:  # if we don't break out of the for loop we got here.
@@ -960,7 +964,7 @@ class CMD_SubtitleSearch(ApiCall):
 
         # retrieve the episode object and fail if we can't get one
         ep_obj = show_obj.get_episode(self.s, self.e)
-        if isinstance(ep_obj, str):
+        if isinstance(ep_obj, string_types):
             return _responds(RESULT_FAILURE, msg='Episode not found')
 
         try:
@@ -1040,7 +1044,7 @@ class CMD_History(ApiCall):
         # optional
         self.limit, args = self.check_params(args, kwargs, 'limit', 100, False, 'int', [])
         self.type, args = self.check_params(args, kwargs, 'type', None, False, 'string', ['downloaded', 'snatched'])
-        self.type = self.type.lower() if isinstance(self.type, str) else None
+        self.type = self.type.lower() if isinstance(self.type, string_types) else None
 
         # super, missing, help
         ApiCall.__init__(self, args, kwargs)
@@ -1066,7 +1070,7 @@ class CMD_History(ApiCall):
                 :return: a formatted date string
                 """
                 return datetime.strptime(
-                    str(history_date),
+                    text_type(history_date),
                     History.date_format
                 ).strftime(dateTimeFormat)
 
@@ -1220,7 +1224,7 @@ class CMD_Logs(ApiCall):
     def run(self):
         """ Get the logs """
         # 10 = Debug / 20 = Info / 30 = Warning / 40 = Error
-        min_level = LOGGING_LEVELS[str(self.min_level).upper()]
+        min_level = LOGGING_LEVELS[text_type(self.min_level).upper()]
         data = [line for line in read_loglines(formatter=text_type, max_lines=50,
                                                predicate=lambda l: filter_logline(l, min_level=min_level,
                                                                                   thread_name=lambda
@@ -1658,9 +1662,9 @@ class CMD_SearchIndexers(ApiCall):
                 indexer_api = indexerApi(_indexer).indexer(**indexer_api_params)
 
                 try:
-                    api_data = indexer_api[str(self.name).encode()]
+                    api_data = indexer_api[binary_type(self.name).encode()]
                 except (IndexerShowNotFound, IndexerShowIncomplete, IndexerError):
-                    log.warning(u'API :: Unable to find show with id {0}', self.indexerid)
+                    log.warning(u'API :: Unable to find show with name {0}', self.name)
                     continue
 
                 for cur_series in api_data:
@@ -1792,7 +1796,7 @@ class CMD_SetDefaults(ApiCall):
         if self.status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.status).lower():
+                if statusStrings[status].lower() == text_type(self.status).lower():
                     self.status = status
                     break
             # this should be obsolete because of the above
@@ -1907,7 +1911,7 @@ class CMD_Show(ApiCall):
         show_dict['season_folders'] = (0, 1)[show_obj.season_folders]
         show_dict['sports'] = (0, 1)[show_obj.sports]
         show_dict['anime'] = (0, 1)[show_obj.anime]
-        show_dict['airs'] = str(show_obj.airs).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
+        show_dict['airs'] = text_type(show_obj.airs).replace('am', ' AM').replace('pm', ' PM').replace('  ', ' ')
         show_dict['dvdorder'] = (0, 1)[show_obj.dvd_order]
 
         if show_obj.rls_require_words:
@@ -2118,7 +2122,7 @@ class CMD_ShowAddNew(ApiCall):
         if self.status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.status).lower():
+                if statusStrings[status].lower() == text_type(self.status).lower():
                     self.status = status
                     break
 
@@ -2135,7 +2139,7 @@ class CMD_ShowAddNew(ApiCall):
         if self.future_status:
             # convert the string status to a int
             for status in statusStrings:
-                if statusStrings[status].lower() == str(self.future_status).lower():
+                if statusStrings[status].lower() == text_type(self.future_status).lower():
                     self.future_status = status
                     break
 

--- a/medusa/server/api/v1/core.py
+++ b/medusa/server/api/v1/core.py
@@ -883,7 +883,8 @@ class CMD_EpisodeSetStatus(ApiCall):
 
                 # don't let them mess up UN-AIRED episodes
                 if ep_obj.status == UNAIRED:
-                    if self.e is not None:  # setting the status of an un-aired is only considered a failure if we directly wanted this episode, but is ignored on a season request
+                    # setting the status of an un-aired is only considered a failure if we directly wanted this episode, but is ignored on a season request
+                    if self.e is not None:
                         ep_results.append(
                             _ep_result(RESULT_FAILURE, ep_obj, 'Refusing to change status because it is UN-AIRED'))
                         failure = True
@@ -1649,6 +1650,9 @@ class CMD_SearchIndexers(ApiCall):
         results = []
         lang_id = self.valid_languages[self.lang]
 
+        if isinstance(self.name, binary_type):
+            self.name = self.name.decode('utf-8')
+
         if self.name and not self.indexerid:  # only name was given
             for _indexer in indexerApi().indexers if self.indexer == 0 else [int(self.indexer)]:
                 indexer_api_params = indexerApi(_indexer).api_params.copy()
@@ -1662,7 +1666,7 @@ class CMD_SearchIndexers(ApiCall):
                 indexer_api = indexerApi(_indexer).indexer(**indexer_api_params)
 
                 try:
-                    api_data = indexer_api[binary_type(self.name).encode()]
+                    api_data = indexer_api[self.name]
                 except (IndexerShowNotFound, IndexerShowIncomplete, IndexerError):
                     log.warning(u'API :: Unable to find show with name {0}', self.name)
                     continue

--- a/pytest.ini
+++ b/pytest.ini
@@ -100,7 +100,7 @@ flake8-ignore =
     medusa/server/__init__.py D104
     medusa/server/api/__init__.py D104
     medusa/server/api/v1/__init__.py D104
-    medusa/server/api/v1/core.py D100 D101 D102 D200 D201 D202 D204 D205 D208 D210 D400 D401 D403 E501 N801
+    medusa/server/api/v1/core.py D100 D101 D102 D200 D201 D202 D204 D205 D208 D210 D400 D401 D403 N801
     medusa/server/core.py D100 D101 D102 N802
     medusa/server/web/__init__.py D104 F401
     medusa/server/web/config/__init__.py D104 F401


### PR DESCRIPTION
This PR combines #4251 and #4255.

----

- `tvdbapiv2` lib updated (see https://github.com/pymedusa/tvdbv2/pull/2 for a more details)
    Fixes #4248 - In short - the response from the API wrapper wasn't unicode.
	Steps to reproduce the issue:
	- Add the show `The Crossing` from TVDB (id: 328631)
	- After the show is fully loaded, restart Medusa. Try and edit the show - works.
	- "Force Full Update" of the show.
	- After the show is fully updated, try and edit the show - error.
	  With the proposed fix - it works.
- Fixes #4246 - No search results in APIv1 sb.searchindexers 
	Also fixes #1895 (#1890) - tuple index out of range (when searching tvmaze, tmdb or all indexers)
- Fix searching indexers for shows in other languages.
	Fixes #3720

Tested using the new show form, API v1 command, and the edit show form.
Also tested the `tvdbapiv2` library separately.