### PR TITLE
Fix #3988 - API v2 pagination links

### DIFF
--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -273,12 +273,16 @@ class BaseRequestHandler(RequestHandler):
             if last_page <= arg_page:
                 last_page = None
 
-        # Reconstruct the base URI
-        bare_uri = self.request.protocol + '://' + self.request.host + self.request.path
-        # Reconstruct the query arguments - always use the last value
-        query_args = {arg: values[-1] for arg, values in viewitems(self.request.query_arguments)
-                      if arg not in ('page', 'limit')}
-        bare_uri = url_concat(bare_uri, query_args)
+        # Reconstruct the query parameters
+        query_params = []
+        for arg, values in viewitems(self.request.query_arguments):
+            if arg in ('page', 'limit'):
+                continue
+            if not isinstance(values, list):
+                values = [values]
+            query_params += [(arg, value) for value in values]
+
+        bare_uri = url_concat(self.request.path, query_params)
 
         links = []
         for rel, page in (('next', next_page), ('last', last_page),


### PR DESCRIPTION
Currently:
```http
GET http://localhost:8081/api/v2/series?detailed=true&page=1&limit=20

Link:
	</api/v2/series?detailed=true&page=1&limit=20&page=2&limit=20>; rel="next",
	</api/v2/series?detailed=true&page=1&limit=20&page=2&limit=20>; rel="last",
	</api/v2/series?detailed=true&page=1&limit=20&page=1&limit=20>; rel="first"
```

With the proposed fix:
```http
GET http://localhost:8081/api/v2/series?detailed=true&page=1&limit=20

Link:
	</api/v2/series?detailed=true&page=2&limit=20>; rel="next",
	</api/v2/series?detailed=true&page=2&limit=20>; rel="last",
	</api/v2/series?detailed=true&page=1&limit=20>; rel="first"
```

Fixes #3988 