### PR TITLE
Component prop watchers should fire only once

### DIFF
--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -150,7 +150,7 @@ const startVue = () => {
                 const allowed = this.series.config.qualities.allowed.reduce(reducer, 0);
                 const preferred = this.series.config.qualities.preferred.reduce(reducer, 0);
 
-                return allowed | preferred << 16
+                return allowed | preferred << 16;
             },
             saveButton() {
                 return this.saving === false ? 'Save Changes' : 'Saving...';

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -78,6 +78,8 @@ Vue.component('file-browser', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             files: [],
             currentPath: '',
             lastPath: '',
@@ -119,6 +121,20 @@ Vue.component('file-browser', {
                 this.browse(file.path);
             }
         }
+    },
+    created() {
+        /**
+         * initialDir property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('initialDir', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.currentPath = this.currentPath || newValue;
+            this.$nextTick(() => this.lock = false);
+        });
     },
     mounted() {
         const vm = this;
@@ -295,16 +311,6 @@ Vue.component('file-browser', {
         });
     },
     watch: {
-        /**
-         * initialDir property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        initialDir(newValue, oldValue) {
-            this.lock = true;
-            this.currentPath = this.currentPath || newValue;
-            this.$nextTick(() => this.lock = false);
-        },
         currentPath(newValue, oldValue) {
             if (!this.lock) {
                 this.$emit('update:location', this.currentPath);

--- a/themes-default/slim/views/vue-components/quality-chooser.mako
+++ b/themes-default/slim/views/vue-components/quality-chooser.mako
@@ -100,6 +100,8 @@ Vue.component('quality-chooser', {
 
             // JS only
             lock: false,
+            unwatchProp: null,
+
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
@@ -178,6 +180,21 @@ Vue.component('quality-chooser', {
             return html;
         }
     },
+    created() {
+        /**
+         * overallQuality property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('overallQuality', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
+            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
+            this.$nextTick(() => this.lock = false);
+        });
+    },
     mounted() {
         this.setQualityFromPreset(this.selectedQualityPreset, this.overallQuality);
     },
@@ -217,17 +234,6 @@ Vue.component('quality-chooser', {
         }
     },
     watch: {
-        /**
-         * overallQuality property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        overallQuality(newValue, oldValue) {
-            this.lock = true;
-            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
-            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
-            this.$nextTick(() => this.lock = false);
-        },
         selectedQualityPreset(preset, oldPreset) {
             this.setQualityFromPreset(preset, oldPreset);
         },

--- a/themes-default/slim/views/vue-components/select-list-ui.mako
+++ b/themes-default/slim/views/vue-components/select-list-ui.mako
@@ -97,12 +97,29 @@ Vue.component('select-list', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             editItems: [],
             newItem: '',
             indexCounter: 0,
             csv: '',
             csvEnabled: false
         }
+    },
+    created() {
+        /**
+         * listItems property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('listItems', () => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.editItems = this.sanitize(this.listItems);
+            this.$nextTick(() => this.lock = false);
+            this.csv = this.editItems.map(x => x.value).join(', ');
+        });
     },
     methods: {
         addItem: function(item) {
@@ -173,17 +190,6 @@ Vue.component('select-list', {
         }
     },
     watch: {
-        /**
-         * listItems property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        listItems() {
-            this.lock = true;
-            this.editItems = this.sanitize(this.listItems);
-            this.$nextTick(() => this.lock = false);
-            this.csv = this.editItems.map(x => x.value).join(', ');
-        },
         editItems: {
             handler: function() {
                 if (!this.lock) {

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -150,7 +150,7 @@ const startVue = () => {
                 const allowed = this.series.config.qualities.allowed.reduce(reducer, 0);
                 const preferred = this.series.config.qualities.preferred.reduce(reducer, 0);
 
-                return allowed | preferred << 16
+                return allowed | preferred << 16;
             },
             saveButton() {
                 return this.saving === false ? 'Save Changes' : 'Saving...';

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -78,6 +78,8 @@ Vue.component('file-browser', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             files: [],
             currentPath: '',
             lastPath: '',
@@ -119,6 +121,20 @@ Vue.component('file-browser', {
                 this.browse(file.path);
             }
         }
+    },
+    created() {
+        /**
+         * initialDir property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('initialDir', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.currentPath = this.currentPath || newValue;
+            this.$nextTick(() => this.lock = false);
+        });
     },
     mounted() {
         const vm = this;
@@ -295,16 +311,6 @@ Vue.component('file-browser', {
         });
     },
     watch: {
-        /**
-         * initialDir property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        initialDir(newValue, oldValue) {
-            this.lock = true;
-            this.currentPath = this.currentPath || newValue;
-            this.$nextTick(() => this.lock = false);
-        },
         currentPath(newValue, oldValue) {
             if (!this.lock) {
                 this.$emit('update:location', this.currentPath);

--- a/themes/dark/templates/vue-components/quality-chooser.mako
+++ b/themes/dark/templates/vue-components/quality-chooser.mako
@@ -100,6 +100,8 @@ Vue.component('quality-chooser', {
 
             // JS only
             lock: false,
+            unwatchProp: null,
+
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
@@ -178,6 +180,21 @@ Vue.component('quality-chooser', {
             return html;
         }
     },
+    created() {
+        /**
+         * overallQuality property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('overallQuality', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
+            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
+            this.$nextTick(() => this.lock = false);
+        });
+    },
     mounted() {
         this.setQualityFromPreset(this.selectedQualityPreset, this.overallQuality);
     },
@@ -217,17 +234,6 @@ Vue.component('quality-chooser', {
         }
     },
     watch: {
-        /**
-         * overallQuality property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        overallQuality(newValue, oldValue) {
-            this.lock = true;
-            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
-            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
-            this.$nextTick(() => this.lock = false);
-        },
         selectedQualityPreset(preset, oldPreset) {
             this.setQualityFromPreset(preset, oldPreset);
         },

--- a/themes/dark/templates/vue-components/select-list-ui.mako
+++ b/themes/dark/templates/vue-components/select-list-ui.mako
@@ -97,12 +97,29 @@ Vue.component('select-list', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             editItems: [],
             newItem: '',
             indexCounter: 0,
             csv: '',
             csvEnabled: false
         }
+    },
+    created() {
+        /**
+         * listItems property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('listItems', () => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.editItems = this.sanitize(this.listItems);
+            this.$nextTick(() => this.lock = false);
+            this.csv = this.editItems.map(x => x.value).join(', ');
+        });
     },
     methods: {
         addItem: function(item) {
@@ -173,17 +190,6 @@ Vue.component('select-list', {
         }
     },
     watch: {
-        /**
-         * listItems property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        listItems() {
-            this.lock = true;
-            this.editItems = this.sanitize(this.listItems);
-            this.$nextTick(() => this.lock = false);
-            this.csv = this.editItems.map(x => x.value).join(', ');
-        },
         editItems: {
             handler: function() {
                 if (!this.lock) {

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -150,7 +150,7 @@ const startVue = () => {
                 const allowed = this.series.config.qualities.allowed.reduce(reducer, 0);
                 const preferred = this.series.config.qualities.preferred.reduce(reducer, 0);
 
-                return allowed | preferred << 16
+                return allowed | preferred << 16;
             },
             saveButton() {
                 return this.saving === false ? 'Save Changes' : 'Saving...';

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -78,6 +78,8 @@ Vue.component('file-browser', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             files: [],
             currentPath: '',
             lastPath: '',
@@ -119,6 +121,20 @@ Vue.component('file-browser', {
                 this.browse(file.path);
             }
         }
+    },
+    created() {
+        /**
+         * initialDir property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('initialDir', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.currentPath = this.currentPath || newValue;
+            this.$nextTick(() => this.lock = false);
+        });
     },
     mounted() {
         const vm = this;
@@ -295,16 +311,6 @@ Vue.component('file-browser', {
         });
     },
     watch: {
-        /**
-         * initialDir property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        initialDir(newValue, oldValue) {
-            this.lock = true;
-            this.currentPath = this.currentPath || newValue;
-            this.$nextTick(() => this.lock = false);
-        },
         currentPath(newValue, oldValue) {
             if (!this.lock) {
                 this.$emit('update:location', this.currentPath);

--- a/themes/light/templates/vue-components/quality-chooser.mako
+++ b/themes/light/templates/vue-components/quality-chooser.mako
@@ -100,6 +100,8 @@ Vue.component('quality-chooser', {
 
             // JS only
             lock: false,
+            unwatchProp: null,
+
             allowedQualities: [],
             preferredQualities: [],
             seriesSlug: $('#series-slug').attr('value'), // This should be moved to medusa-lib
@@ -178,6 +180,21 @@ Vue.component('quality-chooser', {
             return html;
         }
     },
+    created() {
+        /**
+         * overallQuality property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('overallQuality', (newValue, oldValue) => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
+            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
+            this.$nextTick(() => this.lock = false);
+        });
+    },
     mounted() {
         this.setQualityFromPreset(this.selectedQualityPreset, this.overallQuality);
     },
@@ -217,17 +234,6 @@ Vue.component('quality-chooser', {
         }
     },
     watch: {
-        /**
-         * overallQuality property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        overallQuality(newValue, oldValue) {
-            this.lock = true;
-            this.selectedQualityPreset = this.keep === 'keep' ? 'keep' : (this.qualityPresets.includes(newValue) ? newValue : 0),
-            this.setQualityFromPreset(this.selectedQualityPreset, newValue);
-            this.$nextTick(() => this.lock = false);
-        },
         selectedQualityPreset(preset, oldPreset) {
             this.setQualityFromPreset(preset, oldPreset);
         },

--- a/themes/light/templates/vue-components/select-list-ui.mako
+++ b/themes/light/templates/vue-components/select-list-ui.mako
@@ -97,12 +97,29 @@ Vue.component('select-list', {
     data() {
         return {
             lock: false,
+            unwatchProp: null,
+
             editItems: [],
             newItem: '',
             indexCounter: 0,
             csv: '',
             csvEnabled: false
         }
+    },
+    created() {
+        /**
+         * listItems property might receive values originating from the API,
+         * that are sometimes not avaiable when rendering.
+         * @TODO: Maybe we can remove this in the future.
+         */
+        this.unwatchProp = this.$watch('listItems', () => {
+            this.unwatchProp();
+
+            this.lock = true;
+            this.editItems = this.sanitize(this.listItems);
+            this.$nextTick(() => this.lock = false);
+            this.csv = this.editItems.map(x => x.value).join(', ');
+        });
     },
     methods: {
         addItem: function(item) {
@@ -173,17 +190,6 @@ Vue.component('select-list', {
         }
     },
     watch: {
-        /**
-         * listItems property might receive values originating from the API,
-         * that are sometimes not avaiable when rendering.
-         * @TODO: Maybe we can remove this in the future.
-         */
-        listItems() {
-            this.lock = true;
-            this.editItems = this.sanitize(this.listItems);
-            this.$nextTick(() => this.lock = false);
-            this.csv = this.editItems.map(x => x.value).join(', ');
-        },
         editItems: {
             handler: function() {
                 if (!this.lock) {


### PR DESCRIPTION
This was causing the quality-chooser to not $emit
an event for preferred qualities (this.lock was set to true)
(Thanks @medariox)

I tested quality chooser and it seems to work ok now.
Steps to reproduce:
- Edit a show with any preferred qualities (preset is Custom)
- Change preset from Custom to anything else and save show - preferred qualities are not saved.
