### PR TITLE
Update enzyme - fixes embedded English subs tagged as undetermined

### DIFF
--- a/ext/enzyme/__init__.py
+++ b/ext/enzyme/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 __title__ = 'enzyme'
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 __author__ = 'Antoine Bertin'
 __license__ = 'Apache 2.0'
 __copyright__ = 'Copyright 2013 Antoine Bertin'

--- a/ext/enzyme/mkv.py
+++ b/ext/enzyme/mkv.py
@@ -157,7 +157,7 @@ class Track(object):
         type = element.get('TrackType')  # @ReservedAssignment
         number = element.get('TrackNumber', 0)
         name = element.get('Name')
-        language = element.get('Language')
+        language = element.get('Language', 'eng')
         enabled = bool(element.get('FlagEnabled', 1))
         default = bool(element.get('FlagDefault', 1))
         forced = bool(element.get('FlagForced', 0))
@@ -201,7 +201,7 @@ class VideoTrack(Track):
         videotrack.width = element['Video'].get('PixelWidth', 0)
         videotrack.height = element['Video'].get('PixelHeight', 0)
         videotrack.interlaced = bool(element['Video'].get('FlagInterlaced', False))
-        videotrack.stereo_mode = element['Video'].get('StereoMode')
+        videotrack.stereo_mode = element['Video'].get('StereoMode', 0)
         videotrack.crop = {}
         if 'PixelCropTop' in element['Video']:
             videotrack.crop['top'] = element['Video']['PixelCropTop']
@@ -211,10 +211,10 @@ class VideoTrack(Track):
             videotrack.crop['left'] = element['Video']['PixelCropLeft']
         if 'PixelCropRight' in element['Video']:
             videotrack.crop['right'] = element['Video']['PixelCropRight']
+        videotrack.display_unit = element['Video'].get('DisplayUnit')
         videotrack.display_width = element['Video'].get('DisplayWidth')
         videotrack.display_height = element['Video'].get('DisplayHeight')
-        videotrack.display_unit = element['Video'].get('DisplayUnit')
-        videotrack.aspect_ratio_type = element['Video'].get('AspectRatioType')
+        videotrack.aspect_ratio_type = element['Video'].get('AspectRatioType', 0)
         return videotrack
 
     def __repr__(self):
@@ -245,7 +245,7 @@ class AudioTrack(Track):
         audiotrack = super(AudioTrack, cls).fromelement(element)
         audiotrack.sampling_frequency = element['Audio'].get('SamplingFrequency', 8000.0)
         audiotrack.channels = element['Audio'].get('Channels', 1)
-        audiotrack.output_sampling_frequency = element['Audio'].get('OutputSamplingFrequency')
+        audiotrack.output_sampling_frequency = element['Audio'].get('OutputSamplingFrequency', audiotrack.sampling_frequency)
         audiotrack.bit_depth = element['Audio'].get('BitDepth')
         return audiotrack
 

--- a/ext/enzyme/tests/test_mkv.py
+++ b/ext/enzyme/tests/test_mkv.py
@@ -21,8 +21,8 @@ def setUpModule():
 
 class MKVTestCase(unittest.TestCase):
     def test_test1(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test1.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test1.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(minutes=1, seconds=27, milliseconds=336))
@@ -44,12 +44,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 854)
         self.assertTrue(mkv.video_tracks[0].height == 480)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width is None)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -64,7 +64,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)
@@ -90,8 +90,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test2(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test2.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test2.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=47, milliseconds=509))
@@ -113,12 +113,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 1024)
         self.assertTrue(mkv.video_tracks[0].height == 576)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width == 1354)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -133,7 +133,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)
@@ -159,8 +159,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test3(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test3.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test3.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=49, milliseconds=64))
@@ -182,18 +182,18 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 1024)
         self.assertTrue(mkv.video_tracks[0].height == 576)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width is None)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
         self.assertTrue(mkv.audio_tracks[0].number == 2)
         self.assertTrue(mkv.audio_tracks[0].name is None)
-        self.assertTrue(mkv.audio_tracks[0].language is None)
+        self.assertTrue(mkv.audio_tracks[0].language == 'eng')
         self.assertTrue(mkv.audio_tracks[0].enabled == True)
         self.assertTrue(mkv.audio_tracks[0].default == True)
         self.assertTrue(mkv.audio_tracks[0].forced == False)
@@ -202,7 +202,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)
@@ -228,8 +228,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test5(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test5.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test5.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=46, milliseconds=665))
@@ -251,12 +251,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 1024)
         self.assertTrue(mkv.video_tracks[0].height == 576)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width == 1024)
         self.assertTrue(mkv.video_tracks[0].display_height == 576)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio tracks
         self.assertTrue(len(mkv.audio_tracks) == 2)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -271,12 +271,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         self.assertTrue(mkv.audio_tracks[1].type == AUDIO_TRACK)
         self.assertTrue(mkv.audio_tracks[1].number == 10)
         self.assertTrue(mkv.audio_tracks[1].name == 'Commentary')
-        self.assertTrue(mkv.audio_tracks[1].language is None)
+        self.assertTrue(mkv.audio_tracks[1].language == 'eng')
         self.assertTrue(mkv.audio_tracks[1].enabled == True)
         self.assertTrue(mkv.audio_tracks[1].default == False)
         self.assertTrue(mkv.audio_tracks[1].forced == False)
@@ -292,7 +292,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.subtitle_tracks[0].type == SUBTITLE_TRACK)
         self.assertTrue(mkv.subtitle_tracks[0].number == 3)
         self.assertTrue(mkv.subtitle_tracks[0].name is None)
-        self.assertTrue(mkv.subtitle_tracks[0].language is None)
+        self.assertTrue(mkv.subtitle_tracks[0].language == 'eng')
         self.assertTrue(mkv.subtitle_tracks[0].enabled == True)
         self.assertTrue(mkv.subtitle_tracks[0].default == True)
         self.assertTrue(mkv.subtitle_tracks[0].forced == False)
@@ -391,8 +391,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test6(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test6.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test6.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=87, milliseconds=336))
@@ -414,12 +414,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 854)
         self.assertTrue(mkv.video_tracks[0].height == 480)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width is None)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -434,7 +434,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)
@@ -460,8 +460,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test7(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test7.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test7.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=37, milliseconds=43))
@@ -483,12 +483,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 1024)
         self.assertTrue(mkv.video_tracks[0].height == 576)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width is None)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -503,7 +503,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)
@@ -529,8 +529,8 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.tags[0].simpletags[2].binary is None)
 
     def test_test8(self):
-        stream = io.open(os.path.join(TEST_DIR, 'test8.mkv'), 'rb')
-        mkv = MKV(stream)
+        with io.open(os.path.join(TEST_DIR, 'test8.mkv'), 'rb') as stream:
+            mkv = MKV(stream)
         # info
         self.assertTrue(mkv.info.title is None)
         self.assertTrue(mkv.info.duration == timedelta(seconds=47, milliseconds=341))
@@ -552,12 +552,12 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.video_tracks[0].width == 1024)
         self.assertTrue(mkv.video_tracks[0].height == 576)
         self.assertTrue(mkv.video_tracks[0].interlaced == False)
-        self.assertTrue(mkv.video_tracks[0].stereo_mode is None)
+        self.assertTrue(mkv.video_tracks[0].stereo_mode == 0)
         self.assertTrue(mkv.video_tracks[0].crop == {})
         self.assertTrue(mkv.video_tracks[0].display_width is None)
         self.assertTrue(mkv.video_tracks[0].display_height is None)
         self.assertTrue(mkv.video_tracks[0].display_unit is None)
-        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type is None)
+        self.assertTrue(mkv.video_tracks[0].aspect_ratio_type == 0)
         # audio track
         self.assertTrue(len(mkv.audio_tracks) == 1)
         self.assertTrue(mkv.audio_tracks[0].type == AUDIO_TRACK)
@@ -572,7 +572,7 @@ class MKVTestCase(unittest.TestCase):
         self.assertTrue(mkv.audio_tracks[0].codec_name is None)
         self.assertTrue(mkv.audio_tracks[0].sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].channels == 2)
-        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency is None)
+        self.assertTrue(mkv.audio_tracks[0].output_sampling_frequency == 48000.0)
         self.assertTrue(mkv.audio_tracks[0].bit_depth is None)
         # subtitle track
         self.assertTrue(len(mkv.subtitle_tracks) == 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ git+https://github.com/pymedusa/cloudflare-scrape.git@320456e8b28cedb807363a7a89
 configobj==5.0.6
 contextlib2==0.5.5
 dogpile.cache==0.6.5
+git+https://github.com/pymedusa/enzyme.git@665cf6948aab1c249dcc99bd9624a81d17b3302a#egg=enzyme
 git+https://github.com/kurtmckee/feedparser.git@f1dd1bb923ebfe6482fc2521c1f150b4032289ec#egg=feedparser
 future==0.16.0
 futures==3.2.0


### PR DESCRIPTION
Update enzyme (use [pymedusa/enzyme](https://github.com/pymedusa/enzyme))
This fixes `enzyme` to use the correct default values from the Matroska format specification.
For example, default language for the subtitle track is English, not None.
Should fix embedded **English** subtitle tracks getting tagged as `undetermined`, because MKVToolNix drops the element if the value is the default value.
Tested using `knowit`, it wasn't working before, and with this fix it does.