### PR TITLE
Fix changing status to Downloaded

### DIFF
--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -1973,7 +1973,7 @@ class Home(WebRoot):
 
                     if status == DOWNLOADED and not (
                             ep_obj.status in snatched_qualities + [DOWNLOADED]
-                            and os.path.isfile(ep_obj.location)):
+                            or os.path.isfile(ep_obj.location)):
                         logger.log('Refusing to change status of {series} {episode} to DOWNLOADED'
                                    ' because it\'s not SNATCHED/DOWNLOADED or the file is missing'.format(
                                        series=series_obj.name, episode=cur_ep), logger.WARNING)


### PR DESCRIPTION
Previous logic was:
```py
if all([status in Quality.DOWNLOADED,
        ep_obj.status not in snatched_qualities + Quality.DOWNLOADED + [IGNORED],
        not os.path.isfile(ep_obj.location)]):
```
(which is not the same)