### PR TITLE
Feature/always pp manual searched files

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -828,6 +828,7 @@ class PostProcessor(object):
                     # Check if the last snatch was a manual snatch
                     if history_result[0][b'manually_searched']:
                         self.manually_searched = True
+
                     # Get info hash so we can move torrent if setting is enabled
                     self.info_hash = history_result[0][b'info_hash'] or None
 
@@ -1040,7 +1041,7 @@ class PostProcessor(object):
                    (common.Quality.qualityStrings[new_ep_quality]), logger.DEBUG)
 
         # see if this is a priority download (is it snatched, in history, PROPER, or BEST)
-        priority_download = self._is_priority(old_ep_quality, new_ep_quality)
+        priority_download = self._is_priority(old_ep_quality, new_ep_quality) or self.manually_searched
         self.log(u'This episode is a priority download: {0}'.format(priority_download), logger.DEBUG)
 
         # get the version of the episode we're processing (default is -1)

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -31,13 +31,19 @@ import adba
 
 from medusa import (
     app,
-    common,
     db,
     failed_history,
     helpers,
     history,
     logger,
     notifiers,
+)
+from medusa.common import (
+    DOWNLOADED,
+    Quality,
+    SNATCHED,
+    SNATCHED_BEST,
+    SNATCHED_PROPER,
 )
 from medusa.helper.common import (
     episode_num,
@@ -577,7 +583,7 @@ class PostProcessor(object):
                     continue
 
             if counter < (len(self.item_resources) - 1):
-                if common.Quality.qualityStrings[cur_quality] == 'Unknown':
+                if Quality.qualityStrings[cur_quality] == 'Unknown':
                     continue
             quality = cur_quality
 
@@ -768,21 +774,21 @@ class PostProcessor(object):
             if not cur_name:
                 continue
 
-            ep_quality = common.Quality.name_quality(cur_name, ep_obj.series.is_anime, extend=False)
+            ep_quality = Quality.name_quality(cur_name, ep_obj.series.is_anime, extend=False)
             self.log(u"Looking up quality for '{0}', got {1}".format
-                     (cur_name, common.Quality.qualityStrings[ep_quality]), logger.DEBUG)
-            if ep_quality != common.Quality.UNKNOWN:
+                     (cur_name, Quality.qualityStrings[ep_quality]), logger.DEBUG)
+            if ep_quality != Quality.UNKNOWN:
                 self.log(u"Looks like {0} '{1}' has quality {2}, using that".format
-                         (resource_name, cur_name, common.Quality.qualityStrings[ep_quality]), logger.DEBUG)
+                         (resource_name, cur_name, Quality.qualityStrings[ep_quality]), logger.DEBUG)
                 return ep_quality
 
         # Try using other methods to get the file quality
-        ep_quality = common.Quality.name_quality(self.file_path, ep_obj.series.is_anime)
+        ep_quality = Quality.name_quality(self.file_path, ep_obj.series.is_anime)
         self.log(u"Trying other methods to get quality for '{0}', got {1}".format
-                 (self.file_name, common.Quality.qualityStrings[ep_quality]), logger.DEBUG)
-        if ep_quality != common.Quality.UNKNOWN:
+                 (self.file_name, Quality.qualityStrings[ep_quality]), logger.DEBUG)
+        if ep_quality != Quality.UNKNOWN:
             self.log(u"Looks like '{0}' has quality {1}, using that".format
-                     (self.file_name, common.Quality.qualityStrings[ep_quality]), logger.DEBUG)
+                     (self.file_name, Quality.qualityStrings[ep_quality]), logger.DEBUG)
             return ep_quality
 
         return ep_quality
@@ -790,11 +796,12 @@ class PostProcessor(object):
     def _priority_from_history(self, series_obj, season, episodes, quality):
         """Evaluate if the file should be marked as priority."""
         main_db_con = db.DBConnection()
-        snatched_statuses = [common.SNATCHED, common.SNATCHED_PROPER, common.SNATCHED_BEST]
+        snatched_statuses = [SNATCHED, SNATCHED_PROPER, SNATCHED_BEST]
+
         for episode in episodes:
             # First: check if the episode status is snatched
             tv_episodes_result = main_db_con.select(
-                'SELECT status, quality '
+                'SELECT manually_searched '
                 'FROM tv_episodes '
                 'WHERE indexer = ? '
                 'AND showid = ? '
@@ -806,10 +813,14 @@ class PostProcessor(object):
             )
 
             if tv_episodes_result:
+                # Check if the snatch is a manual snatch
+                if tv_episodes_result[0][b'manually_searched'] == 1:
+                    self.manually_searched = True
+
                 # Second: get the quality of the last snatched epsiode
                 # and compare it to the quality we are post-processing
                 history_result = main_db_con.select(
-                    'SELECT quality, manually_searched, info_hash '
+                    'SELECT quality, info_hash '
                     'FROM history '
                     'WHERE indexer_id = ? '
                     'AND showid = ? '
@@ -825,10 +836,6 @@ class PostProcessor(object):
                     # Third: make sure the file we are post-processing hasn't been
                     # previously processed, as we wouldn't want it in that case
 
-                    # Check if the last snatch was a manual snatch
-                    if history_result[0][b'manually_searched']:
-                        self.manually_searched = True
-
                     # Get info hash so we can move torrent if setting is enabled
                     self.info_hash = history_result[0][b'info_hash'] or None
 
@@ -843,7 +850,7 @@ class PostProcessor(object):
                         'AND action = ? '
                         'ORDER BY date DESC',
                         [series_obj.indexer, series_obj.series_id,
-                         season, episode, quality, common.DOWNLOADED]
+                         season, episode, quality, DOWNLOADED]
                     )
 
                     if download_result:
@@ -875,12 +882,12 @@ class PostProcessor(object):
         self.log(u'Manually snatched: {0}'.format(self.manually_searched), level)
         self.log(u'Info hash: {0}'.format(self.info_hash), level)
         self.log(u'NZB: {0}'.format(bool(self.nzb_name)), level)
-        self.log(u'Current quality: {0}'.format(common.Quality.qualityStrings[old_ep_quality]), level)
-        self.log(u'New quality: {0}'.format(common.Quality.qualityStrings[new_ep_quality]), level)
+        self.log(u'Current quality: {0}'.format(Quality.qualityStrings[old_ep_quality]), level)
+        self.log(u'New quality: {0}'.format(Quality.qualityStrings[new_ep_quality]), level)
         self.log(u'Proper: {0}'.format(self.is_proper), level)
 
         # If in_history is True it must be a priority download
-        return bool(self.in_history or self.is_priority)
+        return any([self.in_history, self.is_priority, self.manually_searched])
 
     @staticmethod
     def _should_process(current_quality, new_quality, allowed, preferred):
@@ -1021,9 +1028,9 @@ class PostProcessor(object):
         old_ep_quality = ep_obj.quality
 
         # get the quality of the episode we're processing
-        if quality and quality != common.Quality.UNKNOWN:
+        if quality and quality != Quality.UNKNOWN:
             self.log(u'The episode file has a quality in it, using that: {0}'.format
-                     (common.Quality.qualityStrings[quality]), logger.DEBUG)
+                     (Quality.qualityStrings[quality]), logger.DEBUG)
             new_ep_quality = quality
         else:
             # Fall back to the episode object's quality
@@ -1034,14 +1041,14 @@ class PostProcessor(object):
         if self.in_history:
             self.log(u'This episode was found in history as SNATCHED.', logger.DEBUG)
 
-        if new_ep_quality == common.Quality.UNKNOWN:
+        if new_ep_quality == Quality.UNKNOWN:
             new_ep_quality = self._get_quality(ep_obj)
 
         logger.log(u'Quality of the episode we are processing: {0}'.format
-                   (common.Quality.qualityStrings[new_ep_quality]), logger.DEBUG)
+                   (Quality.qualityStrings[new_ep_quality]), logger.DEBUG)
 
-        # see if this is a priority download (is it snatched, in history, PROPER, or BEST)
-        priority_download = self._is_priority(old_ep_quality, new_ep_quality) or self.manually_searched
+        # see if this is a priority download
+        priority_download = self._is_priority(old_ep_quality, new_ep_quality)
         self.log(u'This episode is a priority download: {0}'.format(priority_download), logger.DEBUG)
 
         # get the version of the episode we're processing (default is -1)
@@ -1064,8 +1071,8 @@ class PostProcessor(object):
                 else:
                     allowed_qualities, preferred_qualities = series_obj.current_qualities
                     self.log(u'Checking if new quality {0} should replace current quality: {1}'.format
-                             (common.Quality.qualityStrings[new_ep_quality],
-                              common.Quality.qualityStrings[old_ep_quality]))
+                             (Quality.qualityStrings[new_ep_quality],
+                              Quality.qualityStrings[old_ep_quality]))
                     should_process, should_process_reason = self._should_process(old_ep_quality, new_ep_quality,
                                                                                  allowed_qualities, preferred_qualities)
                     if not should_process:
@@ -1156,7 +1163,7 @@ class PostProcessor(object):
                 else:
                     cur_ep.release_name = u''
 
-                cur_ep.status = common.DOWNLOADED
+                cur_ep.status = DOWNLOADED
                 cur_ep.quality = new_ep_quality
 
                 cur_ep.subtitles = u''

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -498,13 +498,14 @@ class ProcessResult(object):
         """
         main_db_con = db.DBConnection()
         history_result = main_db_con.select(
-            'SELECT * FROM history '
+            'SELECT * FROM history, manually_searched'
             'WHERE action = ? '
-            'AND resource LIKE ?',
+            'AND resource LIKE ? '
+            'AND manually_searched = 0',
             [DOWNLOADED, '%' + video_file])
 
         if history_result:
-            self.log("You're trying to post-process a file that has already "
+            self.log("You're trying to post-process an automated searched file that has already "
                      "been processed, skipping: {0}".format(video_file), logger.DEBUG)
             return True
 

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -504,8 +504,8 @@ class ProcessResult(object):
 
         if all(
             [history_result,
-            history_result['manually_searched'],
-            history_result['action'] in (SNATCHED, SNATCHED_BEST, SNATCHED_PROPER)]
+             history_result['manually_searched'] == '1',
+             history_result['action'] in (SNATCHED, SNATCHED_BEST, SNATCHED_PROPER)]
         ):
             self.log("You're trying to post-process a manual searched file that has already: {0}".format(
                 video_file

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -523,7 +523,7 @@ class ProcessResult(object):
         history_result = main_db_con.select(
             'SELECT * FROM history '
             'WHERE action = ? '
-            'AND resource LIKE ? ',
+            'AND resource LIKE ?',
             [DOWNLOADED, '%' + video_file])
 
         if history_result:

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -498,7 +498,8 @@ class ProcessResult(object):
         """
         main_db_con = db.DBConnection()
         history_result = main_db_con.select(
-            'SELECT showid, season, episode, indexer_id FROM history '
+            'SELECT showid, season, episode, indexer_id '
+            'FROM history '
             'WHERE action = ? '
             'AND resource LIKE ?'
             'ORDER BY date DESC',
@@ -521,9 +522,10 @@ class ProcessResult(object):
                  history_result[0][b'episode']
                  ] + snatched_statuses
             )
-            if tv_episodes_result and tv_episodes_result[0][b'manually_searched'] == 0:
-                self.log("You're trying to post-process an automated searched file that has already"
-                         " been processed, skipping: {0}".format(video_file), logger.DEBUG)
+
+            if not tv_episodes_result or tv_episodes_result[0][b'manually_searched'] == 0:
+                self.log("You're trying to post-process an automatically searched file that has"
+                         " already been processed, skipping: {0}".format(video_file), logger.DEBUG)
                 return True
 
     def process_media(self, path, video_files, force=False, is_priority=None, ignore_subs=False):

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -499,15 +499,15 @@ class ProcessResult(object):
         main_db_con = db.DBConnection()
         history_result = main_db_con.select(
             'SELECT resource LIKE ? '
-            'ORDER BY date DESC',
+            'ORDER BY date DESC LIMIT 1',
             ['%' + video_file])
 
         if all(
             [history_result,
-             history_result['manually_searched'] == '1',
-             history_result['action'] in (SNATCHED, SNATCHED_BEST, SNATCHED_PROPER)]
+             history_result[0]['manually_searched'] == '1',
+             history_result[0]['action'] in (SNATCHED, SNATCHED_BEST, SNATCHED_PROPER)]
         ):
-            self.log("You're trying to post-process a manual searched file that has already: {0}".format(
+            self.log('Last snatch for this video was manual searched: {0}'.format(
                 video_file
             ), logger.DEBUG)
             return True

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -498,7 +498,7 @@ class ProcessResult(object):
         """
         main_db_con = db.DBConnection()
         history_result = main_db_con.select(
-            'SELECT * FROM history, manually_searched'
+            'SELECT * FROM history '
             'WHERE action = ? '
             'AND resource LIKE ? '
             'AND manually_searched = 0',


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR will make sure that snatches done through a manual search, are always considered "priority" download. Meaning that although they might have already been downloaded in the past. A manual search result will always be post-processed.