### PR TITLE
HeBits: Change BS4 parser to html.parser

### DIFF
--- a/medusa/providers/torrent/html/hebits.py
+++ b/medusa/providers/torrent/html/hebits.py
@@ -111,7 +111,7 @@ class HeBitsProvider(TorrentProvider):
         """
         items = []
 
-        with BS4Parser(data, 'html5lib') as html:
+        with BS4Parser(data, 'html.parser') as html:
             torrent_table = html.find('div', class_='browse')
             torrent_rows = torrent_table('div', class_=re.compile('^line')) if torrent_table else []
 


### PR DESCRIPTION
Fixes #3935 
I can't test it, but I do know `html5lib` parser can sometimes not work if the html isn't valid.
