### PR TITLE
Refactor file-browser component and use in select pages

### DIFF
--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -82,7 +82,7 @@ const startVue = () => {
                             Select the folder you wish to save your backup file to:
                             <br><br>
                             <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -99,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -81,7 +81,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select backup folder to save to" local-storage-key="backupPath" @update="backup.dir = $event"></file-browser>
+                            <br>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +98,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select backup file to restore" local-storage-key="backupFile" include-files @update="restore.file = $event"></file-browser>
+                            <br>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -14,41 +14,29 @@ const startVue = () => {
                 backup: {
                     disabled: false,
                     status: '',
-                    // dir: ''
+                    dir: ''
                 },
                 restore: {
                     disabled: false,
                     status: '',
-                    // file: ''
+                    file: ''
                 }
             };
         },
         mounted() {
-            /** $('#backupDir').fileBrowser({
-                title: 'Select backup folder to save to',
-                key: 'backupPath'
-            });
-            $('#backupFile').fileBrowser({
-                title: 'Select backup files to restore',
-                key: 'backupFile',
-                includeFiles: 1
-            }); 
-            */
-
             $('#config-components').tabs();
         },
         methods: {
             runBackup() {
                 const { backup } = this;
-                const dir = $('#backupDir').val();
 
-                if (!dir) return;
+                if (!backup.dir) return;
 
                 backup.disabled = true;
                 backup.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/backup', {
-                    backupDir: dir
+                    backupDir: backup.dir
                 }).done(data => {
                     backup.status = data;
                     backup.disabled = false;
@@ -56,15 +44,14 @@ const startVue = () => {
             },
             runRestore() {
                 const { restore } = this;
-                const dir = $('#backupFile').val();
 
-                if (!dir) return;
+                if (!restore.file) return;
 
                 restore.disabled = true;
                 restore.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/restore', {
-                    backupFile: dir
+                    backupFile: restore.file
                 }).done(data => {
                     restore.status = data;
                     restore.disabled = false;
@@ -112,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -24,12 +24,7 @@ const startVue = () => {
             };
         },
         mounted() {
-            /*
-            @FIXME: Can't convert these to use the file-browser component
-                    because it can't handle more than one file browser per page.
-                    file-browser needs to be pure JavaScript / Vue, without any jQuery.
-            */
-            $('#backupDir').fileBrowser({
+            /** $('#backupDir').fileBrowser({
                 title: 'Select backup folder to save to',
                 key: 'backupPath'
             });
@@ -37,7 +32,9 @@ const startVue = () => {
                 title: 'Select backup files to restore',
                 key: 'backupFile',
                 includeFiles: 1
-            });
+            }); 
+            */
+
             $('#config-components').tabs();
         },
         methods: {
@@ -97,7 +94,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <input type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>
+                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -113,7 +111,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <input type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/>
+                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -81,7 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_backuprestore.mako
+++ b/themes-default/slim/views/config_backuprestore.mako
@@ -81,8 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -98,8 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -115,8 +115,8 @@ const startVue = () => {
                     password: '${app.TORRENT_PASSWORD}',
                     label: '${app.TORRENT_LABEL}',
                     labelAnime: '${app.TORRENT_LABEL_ANIME}',
-                    path: '${app.TORRENT_PATH}',
-                    seedLocation: '${app.TORRENT_SEED_LOCATION}',
+                    path: ${json.dumps(app.TORRENT_PATH)},
+                    seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
                     seedTime: '${app.TORRENT_SEED_TIME}',
                     testStatus: 'Click below to test',
                     authType: '${app.TORRENT_AUTH_TYPE}',
@@ -203,10 +203,6 @@ const startVue = () => {
         },
         mounted() {
             $('#config-components').tabs();
-            $('#nzb_dir').fileBrowser({ title: 'Select .nzb black hole/watch location' });
-            $('#torrent_dir').fileBrowser({ title: 'Select .torrent black hole/watch location' });
-            $('#torrent_path').fileBrowser({ title: 'Select .torrent download location' });
-            $('#torrent_seed_location').fileBrowser({ title: 'Select Post-Processed seeding torrents location' });
         },
         methods: {
             async testTorrentClient() {
@@ -582,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="nzb_dir" id="nzb_dir" v-model="nzb.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -802,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_dir" id="torrent_dir" v-model="torrent.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -913,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_path" id="torrent_path" v-model="torrent.path" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -924,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_seed_location" id="torrent_seed_location" v-model="torrent.seedLocation" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -108,18 +108,18 @@ const startVue = () => {
                 torrent: {
                     enabled: ${js_bool(app.USE_TORRENTS)},
                     dir: ${json.dumps(app.TORRENT_DIR)},
-                    method: '${app.TORRENT_METHOD}',
-                    host: '${app.TORRENT_HOST}',
-                    rpcUrl: '${app.TORRENT_RPCURL}',
-                    username: '${app.TORRENT_USERNAME}',
-                    password: '${app.TORRENT_PASSWORD}',
-                    label: '${app.TORRENT_LABEL}',
-                    labelAnime: '${app.TORRENT_LABEL_ANIME}',
+                    method: ${json.dumps(app.TORRENT_METHOD)},
+                    host: ${json.dumps(app.TORRENT_HOST)},
+                    rpcUrl: ${json.dumps(app.TORRENT_RPCURL)},
+                    username: ${json.dumps(app.TORRENT_USERNAME)},
+                    password: ${json.dumps(app.TORRENT_PASSWORD)},
+                    label: ${json.dumps(app.TORRENT_LABEL)},
+                    labelAnime: ${json.dumps(app.TORRENT_LABEL_ANIME)},
                     path: ${json.dumps(app.TORRENT_PATH)},
                     seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
-                    seedTime: '${app.TORRENT_SEED_TIME}',
+                    seedTime: ${json.dumps(app.TORRENT_SEED_TIME)},
                     testStatus: 'Click below to test',
-                    authType: '${app.TORRENT_AUTH_TYPE}',
+                    authType: ${json.dumps(app.TORRENT_AUTH_TYPE)},
                     verifyCert: ${js_bool(app.TORRENT_VERIFY_CERT)},
                     paused: ${js_bool(app.TORRENT_PAUSED)},
                     highBandwidth: ${js_bool(app.TORRENT_HIGH_BANDWIDTH)},
@@ -127,17 +127,17 @@ const startVue = () => {
                 nzb: {
                     enabled: ${js_bool(app.USE_NZBS)},
                     dir: ${json.dumps(app.NZB_DIR)},
-                    method: '${app.NZB_METHOD}',
+                    method: ${json.dumps(app.NZB_METHOD)},
                     nzbget: {
                         useHttps: ${js_bool(app.NZBGET_USE_HTTPS)},
-                        host: '${app.NZBGET_HOST}',
-                        username: '${app.NZBGET_USERNAME}',
-                        password: '${app.NZBGET_PASSWORD}',
+                        host: ${json.dumps(app.NZBGET_HOST)},
+                        username: ${json.dumps(app.NZBGET_USERNAME)},
+                        password: ${json.dumps(app.NZBGET_PASSWORD)},
                         testStatus: 'Click below to test',
-                        category: '${app.NZBGET_CATEGORY}',
-                        categoryBacklog: '${app.NZBGET_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.NZBGET_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.NZBGET_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.NZBGET_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.NZBGET_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.NZBGET_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.NZBGET_CATEGORY_ANIME_BACKLOG)},
                         priority: ${app.NZBGET_PRIORITY},
                         priorityOptions: {
                             'Very low': -100,
@@ -149,15 +149,15 @@ const startVue = () => {
                         }
                     },
                     sabnzbd: {
-                        host: '${app.SAB_HOST}',
-                        username: '${app.SAB_USERNAME}',
-                        password: '${app.SAB_PASSWORD}',
-                        apiKey: '${app.SAB_APIKEY}',
+                        host: ${json.dumps(app.SAB_HOST)},
+                        username: ${json.dumps(app.SAB_USERNAME)},
+                        password: ${json.dumps(app.SAB_PASSWORD)},
+                        apiKey: ${json.dumps(app.SAB_APIKEY)},
                         testStatus: 'Click below to test',
-                        category: '${app.SAB_CATEGORY}',
-                        categoryBacklog: '${app.SAB_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.SAB_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.SAB_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.SAB_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.SAB_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.SAB_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.SAB_CATEGORY_ANIME_BACKLOG)},
                         forced: ${js_bool(app.SAB_FORCED)}
                     }
                 },
@@ -170,8 +170,8 @@ const startVue = () => {
                 // Episode Search: General Config
                 randomizeProviders: ${js_bool(app.RANDOMIZE_PROVIDERS)},
                 downloadPropers: ${js_bool(app.DOWNLOAD_PROPERS)},
-                checkPropersInterval: '${app.CHECK_PROPERS_INTERVAL}',
-                propersIntervalLabels: JSON.parse('${json.dumps(app.PROPERS_INTERVAL_LABELS)}'),
+                checkPropersInterval: ${json.dumps(app.CHECK_PROPERS_INTERVAL)},
+                propersIntervalLabels: ${json.dumps(app.PROPERS_INTERVAL_LABELS)},
                 propersSearchDays: ${app.PROPERS_SEARCH_DAYS},
                 backlogDays: ${app.BACKLOG_DAYS},
                 backlogFrequency: ${app.BACKLOG_FREQUENCY},
@@ -182,7 +182,7 @@ const startVue = () => {
                 torrentCheckerFrequency: ${app.TORRENT_CHECKER_FREQUENCY},
                 minTorrentCheckerFrequency: ${app.MIN_TORRENT_CHECKER_FREQUENCY},
                 usenetRetention: ${app.USENET_RETENTION},
-                trackersList: JSON.parse('${json.dumps(app.TRACKERS_LIST)}').join(', '),
+                trackersList: ${json.dumps(app.TRACKERS_LIST)}.join(', '),
                 allowHighPriority: ${js_bool(app.ALLOW_HIGH_PRIORITY)},
                 useFailedDownloads: ${js_bool(app.USE_FAILED_DOWNLOADS)},
                 deleteFailed: ${js_bool(app.DELETE_FAILED)},
@@ -190,11 +190,11 @@ const startVue = () => {
                 maxCacheAge: ${app.MAX_CACHE_AGE},
 
                 // Episode Search: Search Filters
-                ignoreWords: JSON.parse('${json.dumps(app.IGNORE_WORDS)}').join(', '),
-                undesiredWords: JSON.parse('${json.dumps(app.UNDESIRED_WORDS)}').join(', '),
-                preferredWords: JSON.parse('${json.dumps(app.PREFERRED_WORDS)}').join(', '),
-                requireWords: JSON.parse('${json.dumps(app.REQUIRE_WORDS)}').join(', '),
-                ignoredSubsList: JSON.parse('${json.dumps(app.IGNORED_SUBS_LIST)}').join(', '),
+                ignoreWords: ${json.dumps(app.IGNORE_WORDS)}.join(', '),
+                undesiredWords: ${json.dumps(app.UNDESIRED_WORDS)}.join(', '),
+                preferredWords: ${json.dumps(app.PREFERRED_WORDS)}.join(', '),
+                requireWords: ${json.dumps(app.REQUIRE_WORDS)}.join(', '),
+                ignoredSubsList: ${json.dumps(app.IGNORED_SUBS_LIST)}.join(', '),
                 ignoreUndSubs: ${js_bool(app.IGNORE_UND_SUBS)},
 
                 // Global
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select .nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select .torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select downloaded files location" :initial-dir="torrent.path" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed location" :initial-dir="torrent.seedLocation" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes-default/slim/views/config_search.mako
+++ b/themes-default/slim/views/config_search.mako
@@ -224,7 +224,7 @@ const startVue = () => {
             async testNzbget() {
                 const { nzb } = this;
                 const { nzbget } = nzb;
-                const { host, username, password } = nzbget;
+                const { host, username, password, useHttps } = nzbget;
 
                 this.nzb.nzbget.testStatus = MEDUSA.config.loading;
 
@@ -232,7 +232,7 @@ const startVue = () => {
                     host,
                     username,
                     password,
-                    user_https: useHttps
+                    use_https: useHttps
                 };
                 const resp = await apiRoute.get('home/testNZBget', { params });
 
@@ -241,7 +241,7 @@ const startVue = () => {
             async testSabnzbd() {
                 const { nzb } = this;
                 const { sabnzbd } = nzb;
-                const { host, username, password, apiKey } = nzbget;
+                const { host, username, password, apiKey } = sabnzbd;
 
                 this.nzb.sabnzbd.testStatus = MEDUSA.config.loading;
 
@@ -670,7 +670,7 @@ const startVue = () => {
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.sabnzbd.testStatus" v-html="nzb.sabnzbd.testStatus"></div>
-                                <input type="button" value="Test SABnzbd" id="testSABnzbd" class="btn-medusa test-button"/>
+                                <input @click="testSabnzbd" type="button" value="Test SABnzbd" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div>
                             <div v-show="nzb.method === 'nzbget'" id="nzbget_settings">
@@ -753,14 +753,14 @@ const startVue = () => {
                                         <span class="component-title">NZBget priority</span>
                                         <span class="component-desc">
                                             <select name="nzbget_priority" id="nzbget_priority" v-model="nzb.nzbget.priority" class="form-control input-sm">
-                                                <option v-for="(title, value) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
+                                                <option v-for="(value, title) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
                                             </select>
                                             <span>priority for daily snatches (no backlog)</span>
                                         </span>
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.nzbget.testStatus" v-html="nzb.nzbget.testStatus"></div>
-                                <input @click="testNzbget" type="button" value="Test NZBget" id="testNZBget" class="btn-medusa test-button"/>
+                                <input @click="testNzbget" type="button" value="Test NZBget" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div><!-- /nzb.enabled //-->
                         </div>

--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
+                                <file-browser name="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes-default/slim/views/editShow.mako
+++ b/themes-default/slim/views/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"/>
+                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -316,7 +316,7 @@ Vue.component('file-browser', {
     watch: {
         currentPath(newValue, oldValue) {
             if (!this.lock) {
-                this.$emit('update:location', this.currentPath);
+                this.$emit('update', this.currentPath);
             }
         }
     }

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -92,7 +92,9 @@ Vue.component('file-browser', {
                 localStorageKey: '',
                 initialDir: ''
             },
-            browse: null
+            browse: null,
+            fileBrowserDialog: null,
+            nFileBrowser: null
         };
     },
     computed: {
@@ -116,7 +118,7 @@ Vue.component('file-browser', {
             // Otherwise browse to dir
             if (file.isFile) {
                 this.currentPath = file.path;
-                $('.browserDialog .ui-button:contains("Ok")').click();
+                $(this.$el).find('.browserDialog .ui-button:contains("Ok")').click();
             } else {
                 this.browse(file.path);
             }
@@ -138,7 +140,6 @@ Vue.component('file-browser', {
     },
     mounted() {
         const vm = this;
-
         let fileBrowserDialog;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
@@ -157,7 +158,7 @@ Vue.component('file-browser', {
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 
-        $.fn.nFileBrowser = function(callback, options) {
+        vm.nFileBrowser = function(callback, options) {
             const {browse} = vm;
             options = Object.assign({}, vm.defaults, options);
 
@@ -167,7 +168,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserDialog').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -183,7 +184,7 @@ Vue.component('file-browser', {
                     autoOpen: false
                 });
 
-                $('.fileBrowserSearchBox')
+                $(vm.$el).find('.fileBrowserSearchBox')
                     .removeAttr('style')
                     .appendTo(fileBrowserDialog)
                     .fileBrowser({ showBrowseButton: false })
@@ -215,7 +216,7 @@ Vue.component('file-browser', {
             // Set lastPath so we can reset currentPath if we cancel dialog
             vm.lastPath = vm.currentPath;
 
-            const list = $('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
+            const list = $(vm.$el).find('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
 
             return false;
         };
@@ -250,7 +251,7 @@ Vue.component('file-browser', {
                         });
                     },
                     open() {
-                        $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
+                        $(vm.$el).find('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
                     }
                 }).data('ui-autocomplete')._renderItem = function(ul, item) {
                     // Highlight the matched search term from the item -- note that this is global and will match anywhere
@@ -294,14 +295,16 @@ Vue.component('file-browser', {
                     $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
-                        $(this).nFileBrowser(callback, optionsWithInitialDir);
+                        vm.nFileBrowser(callback, optionsWithInitialDir);
                         return false;
                     })
                 );
             }
+            
             return resultField;
         };
 
+        // Initialize the fileBrowser.
         const { title, localStorageKey } = this;
         $(this.$refs.locationInput).fileBrowser({
             title: title,

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -81,7 +81,7 @@ Vue.component('file-browser', {
             unwatchProp: null,
 
             files: [],
-            currentPath: '',
+            currentPath: this.initialDir,
             lastPath: '',
             defaults: {
                 title: 'Choose Directory',
@@ -141,7 +141,6 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
-        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -301,7 +300,7 @@ Vue.component('file-browser', {
                     })
                 );
             }
-            
+
             return resultField;
         };
 

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -134,7 +134,7 @@ Vue.component('file-browser', {
             this.unwatchProp();
 
             this.lock = true;
-            this.currentPath = this.currentPath || newValue;
+            this.currentPath = newValue;
             this.$nextTick(() => this.lock = false);
         });
     },
@@ -173,12 +173,12 @@ Vue.component('file-browser', {
                     title: options.title,
                     position: {
                         my: 'center top',
-                        at: 'center top+60',
+                        at: 'center top+100',
                         of: window
                     },
                     minWidth: Math.min($(document).width() - 80, 650),
-                    height: Math.min($(document).height() - 80, $(window).height() - 80),
-                    maxHeight: Math.min($(document).height() - 80, $(window).height() - 80),
+                    height: Math.min($(document).height() - 120, $(window).height() - 120),
+                    maxHeight: Math.min($(document).height() - 120, $(window).height() - 120),
                     maxWidth: $(document).width() - 80,
                     modal: true,
                     autoOpen: false

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -141,6 +141,7 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
+        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -153,8 +154,8 @@ Vue.component('file-browser', {
                 includeFiles: Number(includeFiles)
             });
 
-            this.currentPath = data.shift().currentPath;
-            this.files = data;
+            vm.currentPath = data.shift().currentPath;
+            vm.files = data;
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 

--- a/themes-default/slim/views/vue-components/file-browser.mako
+++ b/themes-default/slim/views/vue-components/file-browser.mako
@@ -167,7 +167,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $('.fileBrowserDialog').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -291,7 +291,7 @@ Vue.component('file-browser', {
             if (options.showBrowseButton) {
                 // Append the browse button and give it a click behaviour
                 resultField.after(
-                    $('.fileBrowserButton').on('click', function() {
+                    $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
                         $(this).nFileBrowser(callback, optionsWithInitialDir);

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -82,7 +82,7 @@ const startVue = () => {
                             Select the folder you wish to save your backup file to:
                             <br><br>
                             <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -99,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -81,7 +81,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select backup folder to save to" local-storage-key="backupPath" @update="backup.dir = $event"></file-browser>
+                            <br>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +98,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select backup file to restore" local-storage-key="backupFile" include-files @update="restore.file = $event"></file-browser>
+                            <br>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -14,41 +14,29 @@ const startVue = () => {
                 backup: {
                     disabled: false,
                     status: '',
-                    // dir: ''
+                    dir: ''
                 },
                 restore: {
                     disabled: false,
                     status: '',
-                    // file: ''
+                    file: ''
                 }
             };
         },
         mounted() {
-            /** $('#backupDir').fileBrowser({
-                title: 'Select backup folder to save to',
-                key: 'backupPath'
-            });
-            $('#backupFile').fileBrowser({
-                title: 'Select backup files to restore',
-                key: 'backupFile',
-                includeFiles: 1
-            }); 
-            */
-
             $('#config-components').tabs();
         },
         methods: {
             runBackup() {
                 const { backup } = this;
-                const dir = $('#backupDir').val();
 
-                if (!dir) return;
+                if (!backup.dir) return;
 
                 backup.disabled = true;
                 backup.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/backup', {
-                    backupDir: dir
+                    backupDir: backup.dir
                 }).done(data => {
                     backup.status = data;
                     backup.disabled = false;
@@ -56,15 +44,14 @@ const startVue = () => {
             },
             runRestore() {
                 const { restore } = this;
-                const dir = $('#backupFile').val();
 
-                if (!dir) return;
+                if (!restore.file) return;
 
                 restore.disabled = true;
                 restore.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/restore', {
-                    backupFile: dir
+                    backupFile: restore.file
                 }).done(data => {
                     restore.status = data;
                     restore.disabled = false;
@@ -112,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -24,12 +24,7 @@ const startVue = () => {
             };
         },
         mounted() {
-            /*
-            @FIXME: Can't convert these to use the file-browser component
-                    because it can't handle more than one file browser per page.
-                    file-browser needs to be pure JavaScript / Vue, without any jQuery.
-            */
-            $('#backupDir').fileBrowser({
+            /** $('#backupDir').fileBrowser({
                 title: 'Select backup folder to save to',
                 key: 'backupPath'
             });
@@ -37,7 +32,9 @@ const startVue = () => {
                 title: 'Select backup files to restore',
                 key: 'backupFile',
                 includeFiles: 1
-            });
+            }); 
+            */
+
             $('#config-components').tabs();
         },
         methods: {
@@ -97,7 +94,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <input type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>
+                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -113,7 +111,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <input type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/>
+                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -81,7 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_backuprestore.mako
+++ b/themes/dark/templates/config_backuprestore.mako
@@ -81,8 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -98,8 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -115,8 +115,8 @@ const startVue = () => {
                     password: '${app.TORRENT_PASSWORD}',
                     label: '${app.TORRENT_LABEL}',
                     labelAnime: '${app.TORRENT_LABEL_ANIME}',
-                    path: '${app.TORRENT_PATH}',
-                    seedLocation: '${app.TORRENT_SEED_LOCATION}',
+                    path: ${json.dumps(app.TORRENT_PATH)},
+                    seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
                     seedTime: '${app.TORRENT_SEED_TIME}',
                     testStatus: 'Click below to test',
                     authType: '${app.TORRENT_AUTH_TYPE}',
@@ -203,10 +203,6 @@ const startVue = () => {
         },
         mounted() {
             $('#config-components').tabs();
-            $('#nzb_dir').fileBrowser({ title: 'Select .nzb black hole/watch location' });
-            $('#torrent_dir').fileBrowser({ title: 'Select .torrent black hole/watch location' });
-            $('#torrent_path').fileBrowser({ title: 'Select .torrent download location' });
-            $('#torrent_seed_location').fileBrowser({ title: 'Select Post-Processed seeding torrents location' });
         },
         methods: {
             async testTorrentClient() {
@@ -582,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="nzb_dir" id="nzb_dir" v-model="nzb.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select Show Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -802,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_dir" id="torrent_dir" v-model="torrent.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select Show Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -913,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_path" id="torrent_path" v-model="torrent.path" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" local-storage-key="torrent-path" @update:location="torrent.path = $event"/>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -924,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_seed_location" id="torrent_seed_location" v-model="torrent.seedLocation" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select Show Location" :initial-dir="torrent.seedLocation" local-storage-key="seed-location" @update:location="torrent.seedLocation = $event"/>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -108,18 +108,18 @@ const startVue = () => {
                 torrent: {
                     enabled: ${js_bool(app.USE_TORRENTS)},
                     dir: ${json.dumps(app.TORRENT_DIR)},
-                    method: '${app.TORRENT_METHOD}',
-                    host: '${app.TORRENT_HOST}',
-                    rpcUrl: '${app.TORRENT_RPCURL}',
-                    username: '${app.TORRENT_USERNAME}',
-                    password: '${app.TORRENT_PASSWORD}',
-                    label: '${app.TORRENT_LABEL}',
-                    labelAnime: '${app.TORRENT_LABEL_ANIME}',
+                    method: ${json.dumps(app.TORRENT_METHOD)},
+                    host: ${json.dumps(app.TORRENT_HOST)},
+                    rpcUrl: ${json.dumps(app.TORRENT_RPCURL)},
+                    username: ${json.dumps(app.TORRENT_USERNAME)},
+                    password: ${json.dumps(app.TORRENT_PASSWORD)},
+                    label: ${json.dumps(app.TORRENT_LABEL)},
+                    labelAnime: ${json.dumps(app.TORRENT_LABEL_ANIME)},
                     path: ${json.dumps(app.TORRENT_PATH)},
                     seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
-                    seedTime: '${app.TORRENT_SEED_TIME}',
+                    seedTime: ${json.dumps(app.TORRENT_SEED_TIME)},
                     testStatus: 'Click below to test',
-                    authType: '${app.TORRENT_AUTH_TYPE}',
+                    authType: ${json.dumps(app.TORRENT_AUTH_TYPE)},
                     verifyCert: ${js_bool(app.TORRENT_VERIFY_CERT)},
                     paused: ${js_bool(app.TORRENT_PAUSED)},
                     highBandwidth: ${js_bool(app.TORRENT_HIGH_BANDWIDTH)},
@@ -127,17 +127,17 @@ const startVue = () => {
                 nzb: {
                     enabled: ${js_bool(app.USE_NZBS)},
                     dir: ${json.dumps(app.NZB_DIR)},
-                    method: '${app.NZB_METHOD}',
+                    method: ${json.dumps(app.NZB_METHOD)},
                     nzbget: {
                         useHttps: ${js_bool(app.NZBGET_USE_HTTPS)},
-                        host: '${app.NZBGET_HOST}',
-                        username: '${app.NZBGET_USERNAME}',
-                        password: '${app.NZBGET_PASSWORD}',
+                        host: ${json.dumps(app.NZBGET_HOST)},
+                        username: ${json.dumps(app.NZBGET_USERNAME)},
+                        password: ${json.dumps(app.NZBGET_PASSWORD)},
                         testStatus: 'Click below to test',
-                        category: '${app.NZBGET_CATEGORY}',
-                        categoryBacklog: '${app.NZBGET_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.NZBGET_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.NZBGET_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.NZBGET_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.NZBGET_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.NZBGET_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.NZBGET_CATEGORY_ANIME_BACKLOG)},
                         priority: ${app.NZBGET_PRIORITY},
                         priorityOptions: {
                             'Very low': -100,
@@ -149,15 +149,15 @@ const startVue = () => {
                         }
                     },
                     sabnzbd: {
-                        host: '${app.SAB_HOST}',
-                        username: '${app.SAB_USERNAME}',
-                        password: '${app.SAB_PASSWORD}',
-                        apiKey: '${app.SAB_APIKEY}',
+                        host: ${json.dumps(app.SAB_HOST)},
+                        username: ${json.dumps(app.SAB_USERNAME)},
+                        password: ${json.dumps(app.SAB_PASSWORD)},
+                        apiKey: ${json.dumps(app.SAB_APIKEY)},
                         testStatus: 'Click below to test',
-                        category: '${app.SAB_CATEGORY}',
-                        categoryBacklog: '${app.SAB_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.SAB_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.SAB_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.SAB_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.SAB_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.SAB_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.SAB_CATEGORY_ANIME_BACKLOG)},
                         forced: ${js_bool(app.SAB_FORCED)}
                     }
                 },
@@ -170,8 +170,8 @@ const startVue = () => {
                 // Episode Search: General Config
                 randomizeProviders: ${js_bool(app.RANDOMIZE_PROVIDERS)},
                 downloadPropers: ${js_bool(app.DOWNLOAD_PROPERS)},
-                checkPropersInterval: '${app.CHECK_PROPERS_INTERVAL}',
-                propersIntervalLabels: JSON.parse('${json.dumps(app.PROPERS_INTERVAL_LABELS)}'),
+                checkPropersInterval: ${json.dumps(app.CHECK_PROPERS_INTERVAL)},
+                propersIntervalLabels: ${json.dumps(app.PROPERS_INTERVAL_LABELS)},
                 propersSearchDays: ${app.PROPERS_SEARCH_DAYS},
                 backlogDays: ${app.BACKLOG_DAYS},
                 backlogFrequency: ${app.BACKLOG_FREQUENCY},
@@ -182,7 +182,7 @@ const startVue = () => {
                 torrentCheckerFrequency: ${app.TORRENT_CHECKER_FREQUENCY},
                 minTorrentCheckerFrequency: ${app.MIN_TORRENT_CHECKER_FREQUENCY},
                 usenetRetention: ${app.USENET_RETENTION},
-                trackersList: JSON.parse('${json.dumps(app.TRACKERS_LIST)}').join(', '),
+                trackersList: ${json.dumps(app.TRACKERS_LIST)}.join(', '),
                 allowHighPriority: ${js_bool(app.ALLOW_HIGH_PRIORITY)},
                 useFailedDownloads: ${js_bool(app.USE_FAILED_DOWNLOADS)},
                 deleteFailed: ${js_bool(app.DELETE_FAILED)},
@@ -190,11 +190,11 @@ const startVue = () => {
                 maxCacheAge: ${app.MAX_CACHE_AGE},
 
                 // Episode Search: Search Filters
-                ignoreWords: JSON.parse('${json.dumps(app.IGNORE_WORDS)}').join(', '),
-                undesiredWords: JSON.parse('${json.dumps(app.UNDESIRED_WORDS)}').join(', '),
-                preferredWords: JSON.parse('${json.dumps(app.PREFERRED_WORDS)}').join(', '),
-                requireWords: JSON.parse('${json.dumps(app.REQUIRE_WORDS)}').join(', '),
-                ignoredSubsList: JSON.parse('${json.dumps(app.IGNORED_SUBS_LIST)}').join(', '),
+                ignoreWords: ${json.dumps(app.IGNORE_WORDS)}.join(', '),
+                undesiredWords: ${json.dumps(app.UNDESIRED_WORDS)}.join(', '),
+                preferredWords: ${json.dumps(app.PREFERRED_WORDS)}.join(', '),
+                requireWords: ${json.dumps(app.REQUIRE_WORDS)}.join(', '),
+                ignoredSubsList: ${json.dumps(app.IGNORED_SUBS_LIST)}.join(', '),
                 ignoreUndSubs: ${js_bool(app.IGNORE_UND_SUBS)},
 
                 // Global
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select .nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select .torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select downloaded files location" :initial-dir="torrent.path" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed location" :initial-dir="torrent.seedLocation" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select Show Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select Show Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" local-storage-key="torrent-path" @update:location="torrent.path = $event"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select Show Location" :initial-dir="torrent.seedLocation" local-storage-key="seed-location" @update:location="torrent.seedLocation = $event"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/dark/templates/config_search.mako
+++ b/themes/dark/templates/config_search.mako
@@ -224,7 +224,7 @@ const startVue = () => {
             async testNzbget() {
                 const { nzb } = this;
                 const { nzbget } = nzb;
-                const { host, username, password } = nzbget;
+                const { host, username, password, useHttps } = nzbget;
 
                 this.nzb.nzbget.testStatus = MEDUSA.config.loading;
 
@@ -232,7 +232,7 @@ const startVue = () => {
                     host,
                     username,
                     password,
-                    user_https: useHttps
+                    use_https: useHttps
                 };
                 const resp = await apiRoute.get('home/testNZBget', { params });
 
@@ -241,7 +241,7 @@ const startVue = () => {
             async testSabnzbd() {
                 const { nzb } = this;
                 const { sabnzbd } = nzb;
-                const { host, username, password, apiKey } = nzbget;
+                const { host, username, password, apiKey } = sabnzbd;
 
                 this.nzb.sabnzbd.testStatus = MEDUSA.config.loading;
 
@@ -670,7 +670,7 @@ const startVue = () => {
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.sabnzbd.testStatus" v-html="nzb.sabnzbd.testStatus"></div>
-                                <input type="button" value="Test SABnzbd" id="testSABnzbd" class="btn-medusa test-button"/>
+                                <input @click="testSabnzbd" type="button" value="Test SABnzbd" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div>
                             <div v-show="nzb.method === 'nzbget'" id="nzbget_settings">
@@ -753,14 +753,14 @@ const startVue = () => {
                                         <span class="component-title">NZBget priority</span>
                                         <span class="component-desc">
                                             <select name="nzbget_priority" id="nzbget_priority" v-model="nzb.nzbget.priority" class="form-control input-sm">
-                                                <option v-for="(title, value) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
+                                                <option v-for="(value, title) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
                                             </select>
                                             <span>priority for daily snatches (no backlog)</span>
                                         </span>
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.nzbget.testStatus" v-html="nzb.nzbget.testStatus"></div>
-                                <input @click="testNzbget" type="button" value="Test NZBget" id="testNZBget" class="btn-medusa test-button"/>
+                                <input @click="testNzbget" type="button" value="Test NZBget" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div><!-- /nzb.enabled //-->
                         </div>

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
+                                <file-browser name="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/dark/templates/editShow.mako
+++ b/themes/dark/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"/>
+                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -316,7 +316,7 @@ Vue.component('file-browser', {
     watch: {
         currentPath(newValue, oldValue) {
             if (!this.lock) {
-                this.$emit('update:location', this.currentPath);
+                this.$emit('update', this.currentPath);
             }
         }
     }

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -92,7 +92,9 @@ Vue.component('file-browser', {
                 localStorageKey: '',
                 initialDir: ''
             },
-            browse: null
+            browse: null,
+            fileBrowserDialog: null,
+            nFileBrowser: null
         };
     },
     computed: {
@@ -116,7 +118,7 @@ Vue.component('file-browser', {
             // Otherwise browse to dir
             if (file.isFile) {
                 this.currentPath = file.path;
-                $('.browserDialog .ui-button:contains("Ok")').click();
+                $(this.$el).find('.browserDialog .ui-button:contains("Ok")').click();
             } else {
                 this.browse(file.path);
             }
@@ -138,7 +140,6 @@ Vue.component('file-browser', {
     },
     mounted() {
         const vm = this;
-
         let fileBrowserDialog;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
@@ -157,7 +158,7 @@ Vue.component('file-browser', {
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 
-        $.fn.nFileBrowser = function(callback, options) {
+        vm.nFileBrowser = function(callback, options) {
             const {browse} = vm;
             options = Object.assign({}, vm.defaults, options);
 
@@ -167,7 +168,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserDialog').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -183,7 +184,7 @@ Vue.component('file-browser', {
                     autoOpen: false
                 });
 
-                $('.fileBrowserSearchBox')
+                $(vm.$el).find('.fileBrowserSearchBox')
                     .removeAttr('style')
                     .appendTo(fileBrowserDialog)
                     .fileBrowser({ showBrowseButton: false })
@@ -215,7 +216,7 @@ Vue.component('file-browser', {
             // Set lastPath so we can reset currentPath if we cancel dialog
             vm.lastPath = vm.currentPath;
 
-            const list = $('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
+            const list = $(vm.$el).find('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
 
             return false;
         };
@@ -250,7 +251,7 @@ Vue.component('file-browser', {
                         });
                     },
                     open() {
-                        $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
+                        $(vm.$el).find('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
                     }
                 }).data('ui-autocomplete')._renderItem = function(ul, item) {
                     // Highlight the matched search term from the item -- note that this is global and will match anywhere
@@ -294,14 +295,16 @@ Vue.component('file-browser', {
                     $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
-                        $(this).nFileBrowser(callback, optionsWithInitialDir);
+                        vm.nFileBrowser(callback, optionsWithInitialDir);
                         return false;
                     })
                 );
             }
+            
             return resultField;
         };
 
+        // Initialize the fileBrowser.
         const { title, localStorageKey } = this;
         $(this.$refs.locationInput).fileBrowser({
             title: title,

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -81,7 +81,7 @@ Vue.component('file-browser', {
             unwatchProp: null,
 
             files: [],
-            currentPath: '',
+            currentPath: this.initialDir,
             lastPath: '',
             defaults: {
                 title: 'Choose Directory',
@@ -141,7 +141,6 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
-        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -301,7 +300,7 @@ Vue.component('file-browser', {
                     })
                 );
             }
-            
+
             return resultField;
         };
 

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -134,7 +134,7 @@ Vue.component('file-browser', {
             this.unwatchProp();
 
             this.lock = true;
-            this.currentPath = this.currentPath || newValue;
+            this.currentPath = newValue;
             this.$nextTick(() => this.lock = false);
         });
     },
@@ -173,12 +173,12 @@ Vue.component('file-browser', {
                     title: options.title,
                     position: {
                         my: 'center top',
-                        at: 'center top+60',
+                        at: 'center top+100',
                         of: window
                     },
                     minWidth: Math.min($(document).width() - 80, 650),
-                    height: Math.min($(document).height() - 80, $(window).height() - 80),
-                    maxHeight: Math.min($(document).height() - 80, $(window).height() - 80),
+                    height: Math.min($(document).height() - 120, $(window).height() - 120),
+                    maxHeight: Math.min($(document).height() - 120, $(window).height() - 120),
                     maxWidth: $(document).width() - 80,
                     modal: true,
                     autoOpen: false

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -141,6 +141,7 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
+        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -153,8 +154,8 @@ Vue.component('file-browser', {
                 includeFiles: Number(includeFiles)
             });
 
-            this.currentPath = data.shift().currentPath;
-            this.files = data;
+            vm.currentPath = data.shift().currentPath;
+            vm.files = data;
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 

--- a/themes/dark/templates/vue-components/file-browser.mako
+++ b/themes/dark/templates/vue-components/file-browser.mako
@@ -167,7 +167,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $('.fileBrowserDialog').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -291,7 +291,7 @@ Vue.component('file-browser', {
             if (options.showBrowseButton) {
                 // Append the browse button and give it a click behaviour
                 resultField.after(
-                    $('.fileBrowserButton').on('click', function() {
+                    $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
                         $(this).nFileBrowser(callback, optionsWithInitialDir);

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -82,7 +82,7 @@ const startVue = () => {
                             Select the folder you wish to save your backup file to:
                             <br><br>
                             <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -99,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -81,7 +81,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select backup folder to save to" local-storage-key="backupPath" @update="backup.dir = $event"></file-browser>
+                            <br>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +98,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select backup file to restore" local-storage-key="backupFile" include-files @update="restore.file = $event"></file-browser>
+                            <br>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -14,41 +14,29 @@ const startVue = () => {
                 backup: {
                     disabled: false,
                     status: '',
-                    // dir: ''
+                    dir: ''
                 },
                 restore: {
                     disabled: false,
                     status: '',
-                    // file: ''
+                    file: ''
                 }
             };
         },
         mounted() {
-            /** $('#backupDir').fileBrowser({
-                title: 'Select backup folder to save to',
-                key: 'backupPath'
-            });
-            $('#backupFile').fileBrowser({
-                title: 'Select backup files to restore',
-                key: 'backupFile',
-                includeFiles: 1
-            }); 
-            */
-
             $('#config-components').tabs();
         },
         methods: {
             runBackup() {
                 const { backup } = this;
-                const dir = $('#backupDir').val();
 
-                if (!dir) return;
+                if (!backup.dir) return;
 
                 backup.disabled = true;
                 backup.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/backup', {
-                    backupDir: dir
+                    backupDir: backup.dir
                 }).done(data => {
                     backup.status = data;
                     backup.disabled = false;
@@ -56,15 +44,14 @@ const startVue = () => {
             },
             runRestore() {
                 const { restore } = this;
-                const dir = $('#backupFile').val();
 
-                if (!dir) return;
+                if (!restore.file) return;
 
                 restore.disabled = true;
                 restore.status = MEDUSA.config.loading;
 
                 $.get('config/backuprestore/restore', {
-                    backupFile: dir
+                    backupFile: restore.file
                 }).done(data => {
                     restore.status = data;
                     restore.disabled = false;
@@ -112,7 +99,7 @@ const startVue = () => {
                             Select the backup file you wish to restore:
                             <br><br>
                             <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -24,12 +24,7 @@ const startVue = () => {
             };
         },
         mounted() {
-            /*
-            @FIXME: Can't convert these to use the file-browser component
-                    because it can't handle more than one file browser per page.
-                    file-browser needs to be pure JavaScript / Vue, without any jQuery.
-            */
-            $('#backupDir').fileBrowser({
+            /** $('#backupDir').fileBrowser({
                 title: 'Select backup folder to save to',
                 key: 'backupPath'
             });
@@ -37,7 +32,9 @@ const startVue = () => {
                 title: 'Select backup files to restore',
                 key: 'backupFile',
                 includeFiles: 1
-            });
+            }); 
+            */
+
             $('#config-components').tabs();
         },
         methods: {
@@ -97,7 +94,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <input type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>
+                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
+                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"/>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -113,7 +111,8 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <input type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/>
+                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
+                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" @update:location="restore.file = $event"/>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -81,7 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -97,7 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_backuprestore.mako
+++ b/themes/light/templates/config_backuprestore.mako
@@ -81,8 +81,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the folder you wish to save your backup file to:
                             <br><br>
-                            <!-- <input v-model="backup.dir" type="text" name="backupDir" id="backupDir" class="form-control input-sm input350"/>-->
-                            <file-browser name="backupDir" ref="backupDirBrowser" id="backupDir" title="Select Show Location" :initial-dir="backup.dir" @update:location="backup.dir = $event"></file-browser>
+                            <file-browser name="backupDir" title="Select Show Location" @update:location="backup.dir = $event"></file-browser>
                             <input @click="runBackup" :disabled="backup.disabled" class="btn-medusa btn-inline" type="button" value="Backup" id="Backup" />
                             <br>
                         </div>
@@ -98,8 +97,7 @@ const startVue = () => {
                         <div class="field-pair">
                             Select the backup file you wish to restore:
                             <br><br>
-                            <!-- <input v-model="restore.file" type="text" name="backupFile" id="backupFile" class="form-control input-sm input350"/> -->
-                            <file-browser name="backupFile" ref="backupFileBrowser" id="backupFile" title="Select Show Location" :initial-dir="restore.file" :include-files="true" @update:location="restore.file = $event"></file-browser>
+                            <file-browser name="backupFile" title="Select Show Location" :initial-dir="restore.file" include-files @update:location="restore.file = $event"></file-browser>
                             <input @click="runRestore" :disabled="restore.disabled" class="btn-medusa btn-inline" type="button" value="Restore" id="Restore" />
                             <br>
                         </div>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -115,8 +115,8 @@ const startVue = () => {
                     password: '${app.TORRENT_PASSWORD}',
                     label: '${app.TORRENT_LABEL}',
                     labelAnime: '${app.TORRENT_LABEL_ANIME}',
-                    path: '${app.TORRENT_PATH}',
-                    seedLocation: '${app.TORRENT_SEED_LOCATION}',
+                    path: ${json.dumps(app.TORRENT_PATH)},
+                    seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
                     seedTime: '${app.TORRENT_SEED_TIME}',
                     testStatus: 'Click below to test',
                     authType: '${app.TORRENT_AUTH_TYPE}',
@@ -203,10 +203,6 @@ const startVue = () => {
         },
         mounted() {
             $('#config-components').tabs();
-            $('#nzb_dir').fileBrowser({ title: 'Select .nzb black hole/watch location' });
-            $('#torrent_dir').fileBrowser({ title: 'Select .torrent black hole/watch location' });
-            $('#torrent_path').fileBrowser({ title: 'Select .torrent download location' });
-            $('#torrent_seed_location').fileBrowser({ title: 'Select Post-Processed seeding torrents location' });
         },
         methods: {
             async testTorrentClient() {
@@ -582,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="nzb_dir" id="nzb_dir" v-model="nzb.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -802,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_dir" id="torrent_dir" v-model="torrent.dir" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -913,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_path" id="torrent_path" v-model="torrent.path" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -924,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <input type="text" name="torrent_seed_location" id="torrent_seed_location" v-model="torrent.seedLocation" class="form-control input-sm input350"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"/>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"/>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"/>
+                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"/>
+                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -108,18 +108,18 @@ const startVue = () => {
                 torrent: {
                     enabled: ${js_bool(app.USE_TORRENTS)},
                     dir: ${json.dumps(app.TORRENT_DIR)},
-                    method: '${app.TORRENT_METHOD}',
-                    host: '${app.TORRENT_HOST}',
-                    rpcUrl: '${app.TORRENT_RPCURL}',
-                    username: '${app.TORRENT_USERNAME}',
-                    password: '${app.TORRENT_PASSWORD}',
-                    label: '${app.TORRENT_LABEL}',
-                    labelAnime: '${app.TORRENT_LABEL_ANIME}',
+                    method: ${json.dumps(app.TORRENT_METHOD)},
+                    host: ${json.dumps(app.TORRENT_HOST)},
+                    rpcUrl: ${json.dumps(app.TORRENT_RPCURL)},
+                    username: ${json.dumps(app.TORRENT_USERNAME)},
+                    password: ${json.dumps(app.TORRENT_PASSWORD)},
+                    label: ${json.dumps(app.TORRENT_LABEL)},
+                    labelAnime: ${json.dumps(app.TORRENT_LABEL_ANIME)},
                     path: ${json.dumps(app.TORRENT_PATH)},
                     seedLocation: ${json.dumps(app.TORRENT_SEED_LOCATION)},
-                    seedTime: '${app.TORRENT_SEED_TIME}',
+                    seedTime: ${json.dumps(app.TORRENT_SEED_TIME)},
                     testStatus: 'Click below to test',
-                    authType: '${app.TORRENT_AUTH_TYPE}',
+                    authType: ${json.dumps(app.TORRENT_AUTH_TYPE)},
                     verifyCert: ${js_bool(app.TORRENT_VERIFY_CERT)},
                     paused: ${js_bool(app.TORRENT_PAUSED)},
                     highBandwidth: ${js_bool(app.TORRENT_HIGH_BANDWIDTH)},
@@ -127,17 +127,17 @@ const startVue = () => {
                 nzb: {
                     enabled: ${js_bool(app.USE_NZBS)},
                     dir: ${json.dumps(app.NZB_DIR)},
-                    method: '${app.NZB_METHOD}',
+                    method: ${json.dumps(app.NZB_METHOD)},
                     nzbget: {
                         useHttps: ${js_bool(app.NZBGET_USE_HTTPS)},
-                        host: '${app.NZBGET_HOST}',
-                        username: '${app.NZBGET_USERNAME}',
-                        password: '${app.NZBGET_PASSWORD}',
+                        host: ${json.dumps(app.NZBGET_HOST)},
+                        username: ${json.dumps(app.NZBGET_USERNAME)},
+                        password: ${json.dumps(app.NZBGET_PASSWORD)},
                         testStatus: 'Click below to test',
-                        category: '${app.NZBGET_CATEGORY}',
-                        categoryBacklog: '${app.NZBGET_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.NZBGET_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.NZBGET_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.NZBGET_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.NZBGET_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.NZBGET_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.NZBGET_CATEGORY_ANIME_BACKLOG)},
                         priority: ${app.NZBGET_PRIORITY},
                         priorityOptions: {
                             'Very low': -100,
@@ -149,15 +149,15 @@ const startVue = () => {
                         }
                     },
                     sabnzbd: {
-                        host: '${app.SAB_HOST}',
-                        username: '${app.SAB_USERNAME}',
-                        password: '${app.SAB_PASSWORD}',
-                        apiKey: '${app.SAB_APIKEY}',
+                        host: ${json.dumps(app.SAB_HOST)},
+                        username: ${json.dumps(app.SAB_USERNAME)},
+                        password: ${json.dumps(app.SAB_PASSWORD)},
+                        apiKey: ${json.dumps(app.SAB_APIKEY)},
                         testStatus: 'Click below to test',
-                        category: '${app.SAB_CATEGORY}',
-                        categoryBacklog: '${app.SAB_CATEGORY_BACKLOG}',
-                        categoryAnime: '${app.SAB_CATEGORY_ANIME}',
-                        categoryAnimeBacklog: '${app.SAB_CATEGORY_ANIME_BACKLOG}',
+                        category: ${json.dumps(app.SAB_CATEGORY)},
+                        categoryBacklog: ${json.dumps(app.SAB_CATEGORY_BACKLOG)},
+                        categoryAnime: ${json.dumps(app.SAB_CATEGORY_ANIME)},
+                        categoryAnimeBacklog: ${json.dumps(app.SAB_CATEGORY_ANIME_BACKLOG)},
                         forced: ${js_bool(app.SAB_FORCED)}
                     }
                 },
@@ -170,8 +170,8 @@ const startVue = () => {
                 // Episode Search: General Config
                 randomizeProviders: ${js_bool(app.RANDOMIZE_PROVIDERS)},
                 downloadPropers: ${js_bool(app.DOWNLOAD_PROPERS)},
-                checkPropersInterval: '${app.CHECK_PROPERS_INTERVAL}',
-                propersIntervalLabels: JSON.parse('${json.dumps(app.PROPERS_INTERVAL_LABELS)}'),
+                checkPropersInterval: ${json.dumps(app.CHECK_PROPERS_INTERVAL)},
+                propersIntervalLabels: ${json.dumps(app.PROPERS_INTERVAL_LABELS)},
                 propersSearchDays: ${app.PROPERS_SEARCH_DAYS},
                 backlogDays: ${app.BACKLOG_DAYS},
                 backlogFrequency: ${app.BACKLOG_FREQUENCY},
@@ -182,7 +182,7 @@ const startVue = () => {
                 torrentCheckerFrequency: ${app.TORRENT_CHECKER_FREQUENCY},
                 minTorrentCheckerFrequency: ${app.MIN_TORRENT_CHECKER_FREQUENCY},
                 usenetRetention: ${app.USENET_RETENTION},
-                trackersList: JSON.parse('${json.dumps(app.TRACKERS_LIST)}').join(', '),
+                trackersList: ${json.dumps(app.TRACKERS_LIST)}.join(', '),
                 allowHighPriority: ${js_bool(app.ALLOW_HIGH_PRIORITY)},
                 useFailedDownloads: ${js_bool(app.USE_FAILED_DOWNLOADS)},
                 deleteFailed: ${js_bool(app.DELETE_FAILED)},
@@ -190,11 +190,11 @@ const startVue = () => {
                 maxCacheAge: ${app.MAX_CACHE_AGE},
 
                 // Episode Search: Search Filters
-                ignoreWords: JSON.parse('${json.dumps(app.IGNORE_WORDS)}').join(', '),
-                undesiredWords: JSON.parse('${json.dumps(app.UNDESIRED_WORDS)}').join(', '),
-                preferredWords: JSON.parse('${json.dumps(app.PREFERRED_WORDS)}').join(', '),
-                requireWords: JSON.parse('${json.dumps(app.REQUIRE_WORDS)}').join(', '),
-                ignoredSubsList: JSON.parse('${json.dumps(app.IGNORED_SUBS_LIST)}').join(', '),
+                ignoreWords: ${json.dumps(app.IGNORE_WORDS)}.join(', '),
+                undesiredWords: ${json.dumps(app.UNDESIRED_WORDS)}.join(', '),
+                preferredWords: ${json.dumps(app.PREFERRED_WORDS)}.join(', '),
+                requireWords: ${json.dumps(app.REQUIRE_WORDS)}.join(', '),
+                ignoredSubsList: ${json.dumps(app.IGNORED_SUBS_LIST)}.join(', '),
                 ignoreUndSubs: ${js_bool(app.IGNORE_UND_SUBS)},
 
                 // Global
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select .nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select .torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select downloaded files location" :initial-dir="torrent.path" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed location" :initial-dir="torrent.seedLocation" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update:location="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update:location="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -578,7 +578,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="nzb_dir" id="nzb_dir" title="Select nzb black hole Location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
+                                            <file-browser name="nzb_dir" title="Select nzb black hole location" :initial-dir="nzb.dir" @update="nzb.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.nzb</b> files are stored at this location for external software to find and use</p>
                                             </div>
@@ -798,7 +798,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title">Black hole folder location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_dir" id="torrent_dir" title="Select torrent black hole Location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
+                                            <file-browser name="torrent_dir" title="Select torrent black hole location" :initial-dir="torrent.dir" @update="torrent.dir = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p><b>.torrent</b> files are stored at this location for external software to find and use</p>
                                             </div>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -909,7 +909,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Downloaded files location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_path" id="torrent_path" title="Select torrent Location" :initial-dir="torrent.path" @update:location="torrent.path = $event"></file-browser>
+                                            <file-browser name="torrent_path" title="Select torrent Location" @update:location="torrent.path = $event"></file-browser>
                                             <div class="clear-left"><p>where <span id="torrent_client">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will save downloaded files (blank for client default)
                                                 <span v-show="torrent.method === 'download_station'"> <b>note:</b> the destination has to be a shared folder for Synology DS</span></p>
                                             </div>
@@ -920,7 +920,7 @@ const startVue = () => {
                                     <label>
                                         <span class="component-title" id="directory_title">Post-Processed seeding torrents location</span>
                                         <span class="component-desc">
-                                            <file-browser name="torrent_seed_location" id="torrent_seed_location" title="Select torrent seed Location" :initial-dir="torrent.seedLocation" @update:location="torrent.seedLocation = $event"></file-browser>
+                                            <file-browser name="torrent_seed_location" title="Select torrent seed Location" @update:location="torrent.seedLocation = $event"></file-browser>
                                             <div class="clear-left">
                                                 <p>
                                                     where <span id="torrent_client_seed_path">{{clients.torrent[torrent.method].shortTitle || clients.torrent[torrent.method].title}}</span> will move Torrents after Post-Processing<br/>

--- a/themes/light/templates/config_search.mako
+++ b/themes/light/templates/config_search.mako
@@ -224,7 +224,7 @@ const startVue = () => {
             async testNzbget() {
                 const { nzb } = this;
                 const { nzbget } = nzb;
-                const { host, username, password } = nzbget;
+                const { host, username, password, useHttps } = nzbget;
 
                 this.nzb.nzbget.testStatus = MEDUSA.config.loading;
 
@@ -232,7 +232,7 @@ const startVue = () => {
                     host,
                     username,
                     password,
-                    user_https: useHttps
+                    use_https: useHttps
                 };
                 const resp = await apiRoute.get('home/testNZBget', { params });
 
@@ -241,7 +241,7 @@ const startVue = () => {
             async testSabnzbd() {
                 const { nzb } = this;
                 const { sabnzbd } = nzb;
-                const { host, username, password, apiKey } = nzbget;
+                const { host, username, password, apiKey } = sabnzbd;
 
                 this.nzb.sabnzbd.testStatus = MEDUSA.config.loading;
 
@@ -670,7 +670,7 @@ const startVue = () => {
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.sabnzbd.testStatus" v-html="nzb.sabnzbd.testStatus"></div>
-                                <input type="button" value="Test SABnzbd" id="testSABnzbd" class="btn-medusa test-button"/>
+                                <input @click="testSabnzbd" type="button" value="Test SABnzbd" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div>
                             <div v-show="nzb.method === 'nzbget'" id="nzbget_settings">
@@ -753,14 +753,14 @@ const startVue = () => {
                                         <span class="component-title">NZBget priority</span>
                                         <span class="component-desc">
                                             <select name="nzbget_priority" id="nzbget_priority" v-model="nzb.nzbget.priority" class="form-control input-sm">
-                                                <option v-for="(title, value) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
+                                                <option v-for="(value, title) in nzb.nzbget.priorityOptions" :value="value">{{title}}</option>
                                             </select>
                                             <span>priority for daily snatches (no backlog)</span>
                                         </span>
                                     </label>
                                 </div>
                                 <div class="testNotification" v-show="nzb.nzbget.testStatus" v-html="nzb.nzbget.testStatus"></div>
-                                <input @click="testNzbget" type="button" value="Test NZBget" id="testNZBget" class="btn-medusa test-button"/>
+                                <input @click="testNzbget" type="button" value="Test NZBget" class="btn-medusa test-button"/>
                                 <input type="submit" class="btn-medusa config_submitter" value="Save Changes" /><br>
                             </div><!-- /nzb.enabled //-->
                         </div>

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
+                                <file-browser name="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
+                                <file-browser name="location" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/light/templates/editShow.mako
+++ b/themes/light/templates/editShow.mako
@@ -192,7 +192,7 @@ const startVue = () => {
                             <div class="col-sm-10 content">
                                 <input type="hidden" name="indexername" id="form-indexername" :value="indexerName"/>
                                 <input type="hidden" name="seriesid" id="form-seriesid" :value="seriesId" />
-                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"/>
+                                <file-browser name="location" ref="locationBrowser" id="location" title="Select Show Location" :initial-dir="series.config.location" @update:location="series.config.location = $event"></file-browser>
                             </div>
                         </div>
 

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -316,7 +316,7 @@ Vue.component('file-browser', {
     watch: {
         currentPath(newValue, oldValue) {
             if (!this.lock) {
-                this.$emit('update:location', this.currentPath);
+                this.$emit('update', this.currentPath);
             }
         }
     }

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -92,7 +92,9 @@ Vue.component('file-browser', {
                 localStorageKey: '',
                 initialDir: ''
             },
-            browse: null
+            browse: null,
+            fileBrowserDialog: null,
+            nFileBrowser: null
         };
     },
     computed: {
@@ -116,7 +118,7 @@ Vue.component('file-browser', {
             // Otherwise browse to dir
             if (file.isFile) {
                 this.currentPath = file.path;
-                $('.browserDialog .ui-button:contains("Ok")').click();
+                $(this.$el).find('.browserDialog .ui-button:contains("Ok")').click();
             } else {
                 this.browse(file.path);
             }
@@ -138,7 +140,6 @@ Vue.component('file-browser', {
     },
     mounted() {
         const vm = this;
-
         let fileBrowserDialog;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
@@ -157,7 +158,7 @@ Vue.component('file-browser', {
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 
-        $.fn.nFileBrowser = function(callback, options) {
+        vm.nFileBrowser = function(callback, options) {
             const {browse} = vm;
             options = Object.assign({}, vm.defaults, options);
 
@@ -167,7 +168,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserDialog').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -183,7 +184,7 @@ Vue.component('file-browser', {
                     autoOpen: false
                 });
 
-                $('.fileBrowserSearchBox')
+                $(vm.$el).find('.fileBrowserSearchBox')
                     .removeAttr('style')
                     .appendTo(fileBrowserDialog)
                     .fileBrowser({ showBrowseButton: false })
@@ -215,7 +216,7 @@ Vue.component('file-browser', {
             // Set lastPath so we can reset currentPath if we cancel dialog
             vm.lastPath = vm.currentPath;
 
-            const list = $('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
+            const list = $(vm.$el).find('.fileBrowserFileList').removeAttr('style').appendTo(fileBrowserDialog);
 
             return false;
         };
@@ -250,7 +251,7 @@ Vue.component('file-browser', {
                         });
                     },
                     open() {
-                        $('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
+                        $(vm.$el).find('.ui-autocomplete li.ui-menu-item a').removeClass('ui-corner-all');
                     }
                 }).data('ui-autocomplete')._renderItem = function(ul, item) {
                     // Highlight the matched search term from the item -- note that this is global and will match anywhere
@@ -294,14 +295,16 @@ Vue.component('file-browser', {
                     $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
-                        $(this).nFileBrowser(callback, optionsWithInitialDir);
+                        vm.nFileBrowser(callback, optionsWithInitialDir);
                         return false;
                     })
                 );
             }
+            
             return resultField;
         };
 
+        // Initialize the fileBrowser.
         const { title, localStorageKey } = this;
         $(this.$refs.locationInput).fileBrowser({
             title: title,

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -81,7 +81,7 @@ Vue.component('file-browser', {
             unwatchProp: null,
 
             files: [],
-            currentPath: '',
+            currentPath: this.initialDir,
             lastPath: '',
             defaults: {
                 title: 'Choose Directory',
@@ -141,7 +141,6 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
-        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -301,7 +300,7 @@ Vue.component('file-browser', {
                     })
                 );
             }
-            
+
             return resultField;
         };
 

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -134,7 +134,7 @@ Vue.component('file-browser', {
             this.unwatchProp();
 
             this.lock = true;
-            this.currentPath = this.currentPath || newValue;
+            this.currentPath = newValue;
             this.$nextTick(() => this.lock = false);
         });
     },
@@ -173,12 +173,12 @@ Vue.component('file-browser', {
                     title: options.title,
                     position: {
                         my: 'center top',
-                        at: 'center top+60',
+                        at: 'center top+100',
                         of: window
                     },
                     minWidth: Math.min($(document).width() - 80, 650),
-                    height: Math.min($(document).height() - 80, $(window).height() - 80),
-                    maxHeight: Math.min($(document).height() - 80, $(window).height() - 80),
+                    height: Math.min($(document).height() - 120, $(window).height() - 120),
+                    maxHeight: Math.min($(document).height() - 120, $(window).height() - 120),
                     maxWidth: $(document).width() - 80,
                     modal: true,
                     autoOpen: false

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -141,6 +141,7 @@ Vue.component('file-browser', {
     mounted() {
         const vm = this;
         let fileBrowserDialog;
+        this.currentPath = this.initialDir;
 
         this.browse = async (path, url = this.url, includeFiles = this.includeFiles) => {
             console.debug('Browsing to ' + path);
@@ -153,8 +154,8 @@ Vue.component('file-browser', {
                 includeFiles: Number(includeFiles)
             });
 
-            this.currentPath = data.shift().currentPath;
-            this.files = data;
+            vm.currentPath = data.shift().currentPath;
+            vm.files = data;
             fileBrowserDialog.dialog('option', 'dialogClass', 'browserDialog');
         };
 

--- a/themes/light/templates/vue-components/file-browser.mako
+++ b/themes/light/templates/vue-components/file-browser.mako
@@ -167,7 +167,7 @@ Vue.component('file-browser', {
             } else {
                 // Make a fileBrowserDialog object if one doesn't exist already
                 // set up the jquery dialog
-                fileBrowserDialog = $('.fileBrowserDialog').dialog({
+                fileBrowserDialog = $(vm.$el).find('.fileBrowserButton').dialog({
                     dialogClass: 'browserDialog',
                     title: options.title,
                     position: {
@@ -291,7 +291,7 @@ Vue.component('file-browser', {
             if (options.showBrowseButton) {
                 // Append the browse button and give it a click behaviour
                 resultField.after(
-                    $('.fileBrowserButton').on('click', function() {
+                    $(vm.$el).find('.fileBrowserButton').on('click', function() {
                         const initialDir = vm.currentPath || (options.localStorageKey && path) || '';
                         const optionsWithInitialDir = $.extend({}, options, { initialDir });
                         $(this).nFileBrowser(callback, optionsWithInitialDir);


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

:heavy_check_mark: ~Should be rebased on develop after merge of #4055~

- Refactors file-browser to handle multiple browsers on the the same page,
  and to rely less on jQuery and more on Vue.
- Use file-browser in `config_search.mako` and `config_backuprestore.mako`.
- Fix #4347 - due to faulty Python to JS conversion. Always use `json.dumps`...
- Fix #4355 and more issues in `config_search.mako`.