### PR TITLE
Update bjshare.py - the url of the provider has been changed after server migration

### DIFF
--- a/medusa/providers/torrent/html/bjshare.py
+++ b/medusa/providers/torrent/html/bjshare.py
@@ -27,7 +27,7 @@ class BJShareProvider(TorrentProvider):
         super(BJShareProvider, self).__init__('BJ-Share')
 
         # URLs
-        self.url = 'https://bj-share.me'
+        self.url = 'https://bj-share.info'
         self.urls = {
             'search': urljoin(self.url, 'torrents.php')
         }


### PR DESCRIPTION
The url of the provider has been changed after server migration.
From: https://bj-share.me to:https://bj-share.info