### PR TITLE
updated YGGtorrent provider for new URL

### DIFF
--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -36,7 +36,7 @@ class YggtorrentProvider(TorrentProvider):
         self.password = None
 
         # URLs
-        self.url = 'https://yggtorrent.is'
+        self.url = 'https://ww1.yggtorrent.is'
         self.urls = {
             'login': urljoin(self.url, 'user/login'),
             'search': urljoin(self.url, 'engine/search'),


### PR DESCRIPTION
new redirection URL has changed from www.yggtorrent.is to ww1.yggtorrent.is

testing change on my 0.2.5 medusa [c65ca26] worked (I used to get a bdecode error previously)

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
