### PR TITLE
Render restart page before updating to prevent errors

### DIFF
--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -737,13 +737,16 @@ class Home(WebRoot):
             if branch:
                 checkversion.updater.branch = branch
 
+            # @FIXME: Pre-render the restart page. This is a workaround to stop errors on updates.
+            t = PageTemplate(rh=self, filename='restart.mako')
+            restart_rendered = t.render(title='Home', header='Restarting Medusa', topmenu='home',
+                                        controller='home', action='restart')
+
             if checkversion.updater.need_update() and checkversion.updater.update():
                 # do a hard restart
                 app.events.put(app.events.SystemEvent.RESTART)
 
-                t = PageTemplate(rh=self, filename='restart.mako')
-                return t.render(title='Home', header='Restarting Medusa', topmenu='home',
-                                controller='home', action='restart')
+                return restart_rendered
             else:
                 return self._genericMessage('Update Failed',
                                             'Update wasn\'t successful, not restarting. Check your log for more information.')


### PR DESCRIPTION
This should prevent the white page error that is caused when we change values in Python then try to render mako templates with the new values (before Python was restarted)
For example:
Last update we changed `Quality.NONE` to `Quality.NA`.
After the update it tried to render `restart.mako` with `Quality.NA`, but it wasn't available yet,
causing `500.mako` to render, which couldn't render because `quality-chooser.mako` imported in `main.mako` was trying to use `Quality.NA`.

This is a temporary solution, but it should be this way anyway.
