### PR TITLE
Fix #4402 - Only Absolute Number broken for SxxExx format

### DIFF
--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1688,7 +1688,7 @@ class Episode(TV):
                             ep_string += '-' + '%(#)03d' % {'#': rel_ep.episode}
 
             regex_replacement = None
-            if anime_type == 2 and not ep_only_match:
+            if anime_type == 2 and regex_used != ep_only_regex:
                 regex_replacement = r'\g<pre_sep>' + ep_string + r'\g<post_sep>'
             elif season_ep_match:
                 regex_replacement = r'\g<pre_sep>\g<2>\g<3>' + ep_string + r'\g<post_sep>'


### PR DESCRIPTION
Looks like it's working.
I just needs to be tested a little better to make sure it works with different naming schemes.

Fixes #4402 