### PR TITLE
Fix issue submitter speed

### DIFF
--- a/medusa/github_client.py
+++ b/medusa/github_client.py
@@ -8,6 +8,11 @@ import github
 
 logger = logging.getLogger(__name__)
 
+OPTIONS = {
+    'user_agent': 'Medusa',
+    'per_page': 100,
+}
+
 
 def authenticate(username, password):
     """Github authentication.
@@ -21,7 +26,7 @@ def authenticate(username, password):
     """
     try:
         if username or password:
-            gh = github.MainClass.Github(login_or_token=username, password=password, user_agent='Medusa')
+            gh = github.MainClass.Github(login_or_token=username, password=password, **OPTIONS)
 
             # Make a simple request to validate username and password
             gh.get_rate_limit()
@@ -44,7 +49,7 @@ def token_authenticate(token):
     """
     try:
         if token:
-            gh = github.MainClass.Github(login_or_token=token, user_agent='Medusa')
+            gh = github.MainClass.Github(login_or_token=token, **OPTIONS)
 
             # Make a simple request to validate username and password
             gh.get_rate_limit()
@@ -72,7 +77,7 @@ def get_user(gh=None):
     :rtype github.Repository.Repository
     """
     try:
-        gh = gh or github.MainClass.Github(user_agent='Medusa')
+        gh = gh or github.MainClass.Github(**OPTIONS)
         return gh.get_user().login
     except github.GithubException as e:
         logger.debug('Unable to contact Github: {ex!r}', ex=e)
@@ -92,7 +97,7 @@ def get_github_repo(organization, repo, gh=None):
     :rtype github.Repository.Repository
     """
     try:
-        gh = gh or github.MainClass.Github(user_agent='Medusa', per_page=100)
+        gh = gh or github.MainClass.Github(**OPTIONS)
         return gh.get_organization(organization).get_repo(repo)
     except github.GithubException as e:
         logger.debug('Unable to contact Github: {ex!r}', ex=e)

--- a/medusa/issue_submitter.py
+++ b/medusa/issue_submitter.py
@@ -11,7 +11,7 @@ from builtins import object
 from builtins import str
 from datetime import datetime, timedelta
 
-from github import InputFileContent
+from github import GithubObject, InputFileContent
 from github.GithubException import GithubException, RateLimitExceededException, UnknownObjectException
 
 from medusa import app, db
@@ -112,13 +112,12 @@ class IssueSubmitter(object):
         """Find similar issues in the GitHub repository."""
         results = dict()
         issues = github_repo.get_issues(state='all', since=datetime.now() - max_age)
-        issue_count = 0  # issues is a PaginatedList, can't do len() on it
         log.debug('Searching for issues similar to:\n{titles}', {
             'titles': '\n'.join([line.issue_title for line in loglines])
         })
         for issue in issues:
-            issue_count += 1
-            if hasattr(issue, 'pull_request') and issue.pull_request:
+            # Skip pull requests without calling GitHub for more information
+            if issue._pull_request is not GithubObject.NotSet:
                 continue
             issue_title = issue.title
             if issue_title.startswith(cls.TITLE_PREFIX):
@@ -143,8 +142,8 @@ class IssueSubmitter(object):
             if len(results) >= len(loglines):
                 break
 
-        log.debug('Found {similar} similar issues out of {logs} log lines and {issues}.',
-                  {'similar': len(results), 'logs': len(loglines), 'issues': issue_count})
+        log.debug('Found {similar} similar issues for {logs} log lines.',
+                  {'similar': len(results), 'logs': len(loglines)})
 
         return results
 

--- a/tests/test_issue_submitter.py
+++ b/tests/test_issue_submitter.py
@@ -183,27 +183,31 @@ def test_find_similar_issues(monkeypatch, logger, github_repo, read_loglines, cr
         4: 'Missing time zone for network: USA Network',
         5: "AttributeError: 'NoneType' object has no attribute 'findall'",
     }
-    for line_number in lines:
-        logger.warning(lines[line_number])
+    for line in lines.values():
+        logger.warning(line)
     loglines = list(read_loglines)
 
-    issues = {
-        1: '[APP SUBMITTED]: Really strange that one',
-        2: 'Some Issue like This',
-        3: '[APP SUBMITTED]: Missing time zone for network: Hub Network',
-        4: '[APP SUBMITTED]: Missing time zone for network: USA Network',
-        5: "AttributeError: 'NoneType' object has no attribute 'findall'",
-        6: "AttributeError: 'NoneType' object has no attribute 'lower'",
-    }
-    for issue_number in issues:
-        issues[issue_number] = create_github_issue(issues[issue_number], number=issue_number)
+    raw_issues = [
+        (1, '[APP SUBMITTED]: Really strange that one', False),
+        (2, 'Some Issue like This', False),
+        (3, 'Fix Some Issue like This', True),  # Pull request
+        (4, '[APP SUBMITTED]: Missing time zone for network: Hub Network', False),
+        (5, '[APP SUBMITTED]: Missing time zone for network: USA Network', False),
+        (6, "AttributeError: 'NoneType' object has no attribute 'findall'", False),
+        (7, "AttributeError: 'NoneType' object has no attribute 'lower'", False),
+    ]
+    issues = dict()
+    for (number, title, pull_request) in raw_issues:
+        kwargs = {} if not pull_request else {'pull_request': 'mock'}
+        issues[number] = create_github_issue(title=title, number=number, **kwargs)
+
     monkeypatch.setattr(github_repo, 'get_issues', lambda *args, **kwargs: issues.values())
 
     expected = {
         lines[1]: issues[2],
         lines[3]: issues[1],
-        lines[4]: issues[4],
-        lines[5]: issues[5],
+        lines[4]: issues[5],
+        lines[5]: issues[6],
     }
 
     # When


### PR DESCRIPTION
Found and fixed the cause for the slow speeds in the issue submitter.
The `.pull_request` property is lazy - when you call it, it fetches the information from GitHub.
This solves the issue, plus correctly upping the `per_page` parameter to 100 for all GitHub requests.

Keep in mind it fetches issues and pull requests between now and 6 months ago, maybe it's a bit too much.
But it should be **much** faster now.