### PR TITLE
Improve detection of quality from filename

### DIFF
--- a/medusa/common.py
+++ b/medusa/common.py
@@ -265,15 +265,13 @@ class Quality(object):
         """
         Return the quality from an episode filename.
 
-        If no quality is achieved it will try scene_quality regex.
-
         :param name: to parse
-        :param anime: Boolean to indicate if the show we're resolving is Anime
+        :param anime: Boolean to indicate if the show we're resolving is anime
         :param extend: boolean to extend methods to try
         :return: Quality
         """
-        # Try Scene names first
-        quality = Quality.scene_quality(name, anime)
+        # Try getting the quality from the filename
+        quality = Quality.quality_from_name(name, anime)
         if quality != Quality.UNKNOWN:
             return quality
 
@@ -284,12 +282,12 @@ class Quality(object):
         return Quality.UNKNOWN
 
     @staticmethod
-    def scene_quality(name, anime=False):
+    def quality_from_name(name, anime=False):
         """
         Return the quality from the episode filename with the regex.
 
         :param name: Episode filename to analyse
-        :param anime: Boolean to indicate if the show we're resolving is Anime
+        :param anime: Boolean to indicate if the show we're resolving is anime
         :return: Quality
         """
         from medusa.tagger.episode import EpisodeTags
@@ -310,67 +308,62 @@ class Quality(object):
             # BluRay
             if ep.bluray and (full_hd or hd_options):
                 result = Quality.FULLHDBLURAY if full_hd else Quality.HDBLURAY
-            # HD TV
-            elif not ep.bluray and (full_hd or hd_options):
+            # HDTV
+            elif full_hd or hd_options:
                 result = Quality.FULLHDTV if full_hd else Quality.HDTV
-            # SD DVD
+            # SDDVD
             elif ep.dvd:
                 result = Quality.SDDVD
-            # SD TV
+            # SDTV
             elif sd_options:
                 result = Quality.SDTV
 
             return Quality.UNKNOWN if result is None else result
 
         # Is it UHD?
-        if ep.vres in [2160, 4320] and ep.scan == 'p':
-            # BluRay
-            full_res = (ep.vres == 4320)
-            if ep.avc and ep.bluray:
-                result = Quality.UHD_4K_BLURAY if not full_res else Quality.UHD_8K_BLURAY
-            # WEB-DL
-            elif (ep.avc and ep.itunes) or ep.web:
-                result = Quality.UHD_4K_WEBDL if not full_res else Quality.UHD_8K_WEBDL
-            # HDTV
-            elif ep.avc and ep.tv == 'hd':
-                result = Quality.UHD_4K_TV if not full_res else Quality.UHD_8K_TV
+        if ep.vres in [2160, 4320]:
+            is_4320p = ep.vres == 4320
+            if ep.scan == 'p':
+                # BluRay
+                if ep.bluray:
+                    result = Quality.UHD_8K_BLURAY if is_4320p else Quality.UHD_4K_BLURAY
+                # WEB-DL
+                elif ep.web or any([ep.amazon, ep.itunes, ep.netflix]):
+                    result = Quality.UHD_8K_WEBDL if is_4320p else Quality.UHD_4K_WEBDL
+                # HDTV
+                else:
+                    result = Quality.UHD_8K_TV if is_4320p else Quality.UHD_4K_TV
 
         # Is it HD?
         elif ep.vres in [1080, 720]:
+            is_1080p = ep.vres == 1080
             if ep.scan == 'p':
                 # BluRay
-                full_res = (ep.vres == 1080)
-                if ep.avc and (ep.bluray or ep.hddvd):
-                    result = Quality.FULLHDBLURAY if full_res else Quality.HDBLURAY
+                if ep.bluray or ep.hddvd:
+                    result = Quality.FULLHDBLURAY if is_1080p else Quality.HDBLURAY
                 # WEB-DL
-                elif (ep.avc and ep.itunes) or ep.web:
-                    result = Quality.FULLHDWEBDL if full_res else Quality.HDWEBDL
+                elif ep.web or any([ep.amazon, ep.itunes, ep.netflix]):
+                    result = Quality.FULLHDWEBDL if is_1080p else Quality.HDWEBDL
+                # HDTV and MPEG2 encoded
+                elif ep.tv == 'hd' and ep.mpeg:
+                    result = Quality.RAWHDTV
                 # HDTV
-                elif ep.avc and ep.tv == 'hd':
-                    result = Quality.FULLHDTV if full_res else Quality.HDTV  # 1080 HDTV h264
-                # MPEG2 encoded
-                elif all([ep.vres == 1080, ep.tv == 'hd', ep.mpeg]):
-                    result = Quality.RAWHDTV
-                elif all([ep.vres == 720, ep.tv == 'hd', ep.mpeg]):
-                    result = Quality.RAWHDTV
-            elif (ep.res == '1080i') and ep.tv == 'hd' and (ep.mpeg or (ep.raw and ep.avc_non_free)):
+                else:
+                    result = Quality.FULLHDTV if is_1080p else Quality.HDTV
+            elif ep.scan == 'i' and ep.tv == 'hd' and (ep.mpeg or (ep.raw and ep.avc_non_free)):
                 result = Quality.RAWHDTV
         elif ep.hrws:
             result = Quality.HDTV
 
         # Is it SD?
-        elif ep.xvid or ep.avc:
-            # SD DVD
-            if ep.dvd or ep.bluray:
-                result = Quality.SDDVD
-            # SDTV
-            elif ep.res == '480p' or any([ep.tv, ep.sat, ep.web]):
-                result = Quality.SDTV
-        elif ep.dvd:
+        elif ep.dvd or ep.bluray:
             # SD DVD
             result = Quality.SDDVD
-        elif ep.tv:
-            # SD TV/HD TV
+        elif ep.web or any([ep.amazon, ep.itunes, ep.netflix]):
+            # This should be Quality.WEB in the future
+            result = Quality.SDTV
+        elif ep.tv or any([ep.res == '480p', ep.sat]):
+            # SDTV/HDTV
             result = Quality.SDTV
 
         return Quality.UNKNOWN if result is None else result

--- a/medusa/common.py
+++ b/medusa/common.py
@@ -322,34 +322,34 @@ class Quality(object):
 
         # Is it UHD?
         if ep.vres in [2160, 4320]:
-            is_4320p = ep.vres == 4320
+            is_4320 = ep.vres == 4320
             if ep.scan == 'p':
                 # BluRay
                 if ep.bluray:
-                    result = Quality.UHD_8K_BLURAY if is_4320p else Quality.UHD_4K_BLURAY
+                    result = Quality.UHD_8K_BLURAY if is_4320 else Quality.UHD_4K_BLURAY
                 # WEB-DL
                 elif ep.web or any([ep.amazon, ep.itunes, ep.netflix]):
-                    result = Quality.UHD_8K_WEBDL if is_4320p else Quality.UHD_4K_WEBDL
+                    result = Quality.UHD_8K_WEBDL if is_4320 else Quality.UHD_4K_WEBDL
                 # HDTV
                 else:
-                    result = Quality.UHD_8K_TV if is_4320p else Quality.UHD_4K_TV
+                    result = Quality.UHD_8K_TV if is_4320 else Quality.UHD_4K_TV
 
         # Is it HD?
         elif ep.vres in [1080, 720]:
-            is_1080p = ep.vres == 1080
+            is_1080 = ep.vres == 1080
             if ep.scan == 'p':
                 # BluRay
                 if ep.bluray or ep.hddvd:
-                    result = Quality.FULLHDBLURAY if is_1080p else Quality.HDBLURAY
+                    result = Quality.FULLHDBLURAY if is_1080 else Quality.HDBLURAY
                 # WEB-DL
                 elif ep.web or any([ep.amazon, ep.itunes, ep.netflix]):
-                    result = Quality.FULLHDWEBDL if is_1080p else Quality.HDWEBDL
+                    result = Quality.FULLHDWEBDL if is_1080 else Quality.HDWEBDL
                 # HDTV and MPEG2 encoded
                 elif ep.tv == 'hd' and ep.mpeg:
                     result = Quality.RAWHDTV
                 # HDTV
                 else:
-                    result = Quality.FULLHDTV if is_1080p else Quality.HDTV
+                    result = Quality.FULLHDTV if is_1080 else Quality.HDTV
             elif ep.scan == 'i' and ep.tv == 'hd' and (ep.mpeg or (ep.raw and ep.avc_non_free)):
                 result = Quality.RAWHDTV
         elif ep.hrws:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -491,9 +491,9 @@ class GenericProvider(object):
         return GenericProvider.make_id(self.name)
 
     def get_quality(self, item, anime=False):
-        """Get scene quality of the result."""
+        """Get quality of the result from its name."""
         (title, _) = self._get_title_and_url(item)
-        quality = Quality.scene_quality(title, anime)
+        quality = Quality.quality_from_name(title, anime)
 
         return quality
 

--- a/medusa/recompiled/tags.py
+++ b/medusa/recompiled/tags.py
@@ -13,14 +13,15 @@ dvd = re.compile(r'(?P<hd>hd)?dvd(?P<rip>rip|mux)?', re.IGNORECASE)
 web = re.compile(r'(web(?P<type>rip|mux|hd|.?dl|\b))', re.IGNORECASE)
 bluray = re.compile(r'(blue?-?ray|b[rd](?:rip|mux))', re.IGNORECASE)
 sat = re.compile(r'(dsr|satrip)', re.IGNORECASE)
-itunes = re.compile(r'(itunes)', re.IGNORECASE)
+amazon = re.compile(r'(amzn|amazon)(hd|uhd)?', re.IGNORECASE)
+itunes = re.compile(r'itunes(hd|uhd)?', re.IGNORECASE)
+netflix = re.compile(r'(nf|netflix)(hd|uhd)?', re.IGNORECASE)
 aussie = re.compile(r'\b(bf1)\b', re.IGNORECASE)  # aussie p2p release group
-netflix = re.compile(r'netflix(hd|uhd)', re.IGNORECASE)
 
 # Codecs
 avc = re.compile(r'([xh].?26[45]|(?:he|a)vc)', re.IGNORECASE)
 xvid = re.compile(r'(xvid|divx)', re.IGNORECASE)
-mpeg = re.compile(r'(mpeg-?2)', re.IGNORECASE)
+mpeg = re.compile(r'mpeg(-?2)?', re.IGNORECASE)
 
 # anime
 anime_sd = re.compile(r'(848x480|480p|360p|xvid)', re.IGNORECASE)

--- a/medusa/tagger/episode.py
+++ b/medusa/tagger/episode.py
@@ -30,6 +30,7 @@ class EpisodeTags(object):
             'wide': tags.widescreen,
             'aussie': tags.aussie,
             'netflix': tags.netflix,
+            'amazon': tags.amazon,
         }
 
     def _get_match_obj(self, attr, regex=None, flags=0):
@@ -297,5 +298,16 @@ class EpisodeTags(object):
         :return: an empty string if not found
         """
         attr = 'netflix'
+        match = self._get_match_obj(attr)
+        return '' if not match else match.group()
+
+    @property
+    def amazon(self):
+        """
+        Amazon tag found in name.
+
+        :return: an empty string if not found
+        """
+        attr = 'amazon'
         match = self._get_match_obj(attr)
         return '' if not match else match.group()

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,211 +1,349 @@
 # coding=utf-8
 """Tests for medusa.common.py."""
 
-from medusa.common import DOWNLOADED, Quality
+from medusa.common import Quality
+
 import pytest
 
 
-class TestQuality(object):
-    @pytest.mark.parametrize('p', [
-        {  # p0: No screen_size, no format
-            'expected': Quality.UNKNOWN
-        },
-        {  # p1: screen_size but no format
+@pytest.mark.parametrize('p', [
+    {  # p0: No screen_size, no format
+        'expected': Quality.UNKNOWN
+    },
+    {  # p1: screen_size but no format
+        'screen_size': '720p',
+        'expected': Quality.UNKNOWN
+    },
+    {  # p2: format but no screen_size
+        'format': 'HDTV',
+        'expected': Quality.UNKNOWN
+    },
+    {  # p3
+        'screen_size': '720p',
+        'format': 'HDTV',
+        'expected': Quality.HDTV
+    },
+    {  # p4
+        'screen_size': '720p',
+        'format': 'WEB-DL',
+        'expected': Quality.HDWEBDL
+    },
+    {  # p5
+        'screen_size': '720p',
+        'format': 'WEBRip',
+        'expected': Quality.HDWEBDL
+    },
+    {  # p6
+        'screen_size': '720p',
+        'format': 'BluRay',
+        'expected': Quality.HDBLURAY
+    },
+    {  # p7
+        'screen_size': '1080i',
+        'expected': Quality.RAWHDTV
+    },
+    {  # p8
+        'screen_size': '1080p',
+        'format': 'HDTV',
+        'expected': Quality.FULLHDTV
+    },
+    {  # p9
+        'screen_size': '1080p',
+        'format': 'WEB-DL',
+        'expected': Quality.FULLHDWEBDL
+    },
+    {  # p10
+        'screen_size': '1080p',
+        'format': 'WEBRip',
+        'expected': Quality.FULLHDWEBDL
+    },
+    {  # p11
+        'screen_size': '1080p',
+        'format': 'BluRay',
+        'expected': Quality.FULLHDBLURAY
+    },
+    {  # p12
+        'screen_size': '4K',
+        'format': 'HDTV',
+        'expected': Quality.UHD_4K_TV
+    },
+    {  # p13
+        'screen_size': '4K',
+        'format': 'WEB-DL',
+        'expected': Quality.UHD_4K_WEBDL
+    },
+    {  # p14
+        'screen_size': '4K',
+        'format': 'WEBRip',
+        'expected': Quality.UHD_4K_WEBDL
+    },
+    {  # p15
+        'screen_size': '4K',
+        'format': 'BluRay',
+        'expected': Quality.UHD_4K_BLURAY
+    },
+    {  # p16: multiple screen sizes
+        'screen_size': ['4K', '720p'],
+        'format': 'BluRay',
+        'expected': Quality.UNKNOWN
+    },
+    {  # p17: multiple formats
+        'screen_size': '720p',
+        'format': ['HDTV', 'BluRay'],
+        'expected': Quality.UNKNOWN
+    },
+    {  # p18: format not mapped (at least not yet)
+        'screen_size': '480p',
+        'format': 'HDTV',
+        'expected': Quality.UNKNOWN
+    },
+])
+def test_from_guessit(p):
+    # Given
+    guess = {
+        'screen_size': p.get('screen_size'),
+        'format': p.get('format'),
+    }
+    expected = p['expected']
+
+    # When
+    actual = Quality.from_guessit(guess)
+
+    # Then
+    assert expected == actual
+
+
+@pytest.mark.parametrize('p', [
+    {  # p0
+        'quality': Quality.UNKNOWN,
+        'expected': dict(),
+    },
+    {  # p1: invalid quality
+        'quality': 0,
+        'expected': dict()
+    },
+    {  # p2: another invalid quality
+        'quality': 9999999,
+        'expected': dict()
+    },
+    {  # p3
+        'quality': Quality.HDTV,
+        'expected': {
             'screen_size': '720p',
-            'expected': Quality.UNKNOWN
-        },
-        {  # p2: format but no screen_size
-            'format': 'HDTV',
-            'expected': Quality.UNKNOWN
-        },
-        {  # p3
-            'screen_size': '720p',
-            'format': 'HDTV',
-            'expected': Quality.HDTV
-        },
-        {  # p4
-            'screen_size': '720p',
-            'format': 'WEB-DL',
-            'expected': Quality.HDWEBDL
-        },
-        {  # p5
-            'screen_size': '720p',
-            'format': 'WEBRip',
-            'expected': Quality.HDWEBDL
-        },
-        {  # p6
-            'screen_size': '720p',
-            'format': 'BluRay',
-            'expected': Quality.HDBLURAY
-        },
-        {  # p7
-            'screen_size': '1080i',
-            'expected': Quality.RAWHDTV
-        },
-        {  # p8
-            'screen_size': '1080p',
-            'format': 'HDTV',
-            'expected': Quality.FULLHDTV
-        },
-        {  # p9
-            'screen_size': '1080p',
-            'format': 'WEB-DL',
-            'expected': Quality.FULLHDWEBDL
-        },
-        {  # p10
-            'screen_size': '1080p',
-            'format': 'WEBRip',
-            'expected': Quality.FULLHDWEBDL
-        },
-        {  # p11
-            'screen_size': '1080p',
-            'format': 'BluRay',
-            'expected': Quality.FULLHDBLURAY
-        },
-        {  # p12
-            'screen_size': '4K',
-            'format': 'HDTV',
-            'expected': Quality.UHD_4K_TV
-        },
-        {  # p13
-            'screen_size': '4K',
-            'format': 'WEB-DL',
-            'expected': Quality.UHD_4K_WEBDL
-        },
-        {  # p14
-            'screen_size': '4K',
-            'format': 'WEBRip',
-            'expected': Quality.UHD_4K_WEBDL
-        },
-        {  # p15
-            'screen_size': '4K',
-            'format': 'BluRay',
-            'expected': Quality.UHD_4K_BLURAY
-        },
-        {  # p16: multiple screen sizes
-            'screen_size': ['4K', '720p'],
-            'format': 'BluRay',
-            'expected': Quality.UNKNOWN
-        },
-        {  # p17: multiple formats
-            'screen_size': '720p',
-            'format': ['HDTV', 'BluRay'],
-            'expected': Quality.UNKNOWN
-        },
-        {  # p18: format not mapped (at least not yet)
-            'screen_size': '480p',
-            'format': 'HDTV',
-            'expected': Quality.UNKNOWN
-        },
-    ])
-    def test_from_guessit(self, p):
-        # Given
-        guess = {
-            'screen_size': p.get('screen_size'),
-            'format': p.get('format'),
+            'format': 'HDTV'
         }
-        expected = p['expected']
-
-        # When
-        actual = Quality.from_guessit(guess)
-
-        # Then
-        assert expected == actual
-
-    @pytest.mark.parametrize('p', [
-        {  # p0
-            'quality': Quality.UNKNOWN,
-            'expected': dict(),
-        },
-        {  # p1: invalid quality
-            'quality': 0,
-            'expected': dict()
-        },
-        {  # p2: another invalid quality
-            'quality': 9999999,
-            'expected': dict()
-        },
-        {  # p3
-            'quality': Quality.HDTV,
-            'expected': {
-                'screen_size': '720p',
-                'format': 'HDTV'
-            }
-        },
-        {  # p4
-            'quality': Quality.HDWEBDL,
-            'expected': {
-                'screen_size': '720p',
-                'format': 'WEB-DL',
-            }
-        },
-        {  # p5
-            'quality': Quality.HDBLURAY,
-            'expected': {
-                'screen_size': '720p',
-                'format': 'BluRay',
-            }
-        },
-        {  # p6
-            'quality': Quality.RAWHDTV,
-            'expected': {
-                'screen_size': '1080i'
-            }
-        },
-        {  # p7
-            'quality': Quality.FULLHDTV,
-            'expected': {
-                'screen_size': '1080p',
-                'format': 'HDTV',
-            }
-        },
-        {  # p8
-            'quality': Quality.FULLHDWEBDL,
-            'expected': {
-                'screen_size': '1080p',
-                'format': 'WEB-DL',
-            }
-        },
-        {  # p9
-            'quality': Quality.FULLHDBLURAY,
-            'expected': {
-                'screen_size': '1080p',
-                'format': 'BluRay',
-            }
-        },
-        {  # p10
-            'quality': Quality.UHD_4K_TV,
-            'expected': {
-                'screen_size': '4K',
-                'format': 'HDTV',
-            }
-        },
-        {  # p11
-            'quality': Quality.UHD_4K_WEBDL,
-            'expected': {
-                'screen_size': '4K',
-                'format': 'WEB-DL',
-            }
-        },
-        {  # p12
-            'quality': Quality.UHD_4K_BLURAY,
-            'expected': {
-                'screen_size': '4K',
-                'format': 'BluRay',
-            }
-        },
-        {  # p13: guessit unsupported quality
-            'quality': Quality.UHD_8K_BLURAY,
-            'expected': dict()
+    },
+    {  # p4
+        'quality': Quality.HDWEBDL,
+        'expected': {
+            'screen_size': '720p',
+            'format': 'WEB-DL',
         }
-    ])
-    def test_to_guessit(self, p):
-        # Given
-        quality = p['quality']
-        expected = p['expected']
+    },
+    {  # p5
+        'quality': Quality.HDBLURAY,
+        'expected': {
+            'screen_size': '720p',
+            'format': 'BluRay',
+        }
+    },
+    {  # p6
+        'quality': Quality.RAWHDTV,
+        'expected': {
+            'screen_size': '1080i'
+        }
+    },
+    {  # p7
+        'quality': Quality.FULLHDTV,
+        'expected': {
+            'screen_size': '1080p',
+            'format': 'HDTV',
+        }
+    },
+    {  # p8
+        'quality': Quality.FULLHDWEBDL,
+        'expected': {
+            'screen_size': '1080p',
+            'format': 'WEB-DL',
+        }
+    },
+    {  # p9
+        'quality': Quality.FULLHDBLURAY,
+        'expected': {
+            'screen_size': '1080p',
+            'format': 'BluRay',
+        }
+    },
+    {  # p10
+        'quality': Quality.UHD_4K_TV,
+        'expected': {
+            'screen_size': '4K',
+            'format': 'HDTV',
+        }
+    },
+    {  # p11
+        'quality': Quality.UHD_4K_WEBDL,
+        'expected': {
+            'screen_size': '4K',
+            'format': 'WEB-DL',
+        }
+    },
+    {  # p12
+        'quality': Quality.UHD_4K_BLURAY,
+        'expected': {
+            'screen_size': '4K',
+            'format': 'BluRay',
+        }
+    },
+    {  # p13: guessit unsupported quality
+        'quality': Quality.UHD_8K_BLURAY,
+        'expected': dict()
+    }
+])
+def test_to_guessit(p):
+    # Given
+    quality = p['quality']
+    expected = p['expected']
 
-        # When
-        actual = Quality.to_guessit(quality)
+    # When
+    actual = Quality.to_guessit(quality)
 
-        # Then
-        assert expected == actual
+    # Then
+    assert expected == actual
+
+
+@pytest.mark.parametrize('p', [
+    {  # p0: no resolution, source or codec
+        'name': 'Show Name - 2x03 - Ep Name.mkv',
+        'expected': Quality.UNKNOWN
+    },
+    {  # p1: SDDVD, only source
+        'name': 'Show Name - 2x03 - DVD - Ep Name.mkv',
+        'expected': Quality.SDDVD
+    },
+    {  # p2: SDDVD, only source
+        'name': 'Show Name - 2x03 - BluRay - Ep Name.mkv',
+        'expected': Quality.SDDVD
+    },
+    {  # p3: SDTV, only source
+        'name': 'Show Name - 2x03 - WEB - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p4: SDTV, only source
+        'name': 'Show Name - 2x03 - AMZN - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p5: SDTV, only source
+        'name': 'Show Name - 2x03 - DSR - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p6: SDTV, only 480p resolution
+        'name': 'Show Name - 2x03 - 480p - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p7: SDTV, source and codec
+        'name': 'Show Name - 2x03 - HDTV x264 - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p8: SDTV, only source
+        'name': 'Show Name - 2x03 - HDTV - Ep Name.mkv',
+        'expected': Quality.SDTV
+    },
+    {  # p9: 720p, only with resolution
+        'name': 'Show Name - 2x03 - 720p - Ep Name.mkv',
+        'expected': Quality.HDTV
+    },
+    {  # p10: 720p, resolution and source
+        'name': 'Show Name - 2x03 - 720p HDTV - Ep Name.mkv',
+        'expected': Quality.HDTV
+    },
+    {  # p11: 720p, resolution, source and codec
+        'name': 'Show Name - 2x03 - 720p HDTV x264 - Ep Name.mkv',
+        'expected': Quality.HDTV
+    },
+    {  # p12: 720p, source and codec
+        'name': 'Show Name - 2x03 - HR WS PDTV x264 - Ep Name.mkv',
+        'expected': Quality.HDTV
+    },
+    {  # p13: 1080p, only with resolution
+        'name': 'Show Name - 2x03 - 1080p - Ep Name.mkv',
+        'expected': Quality.FULLHDTV
+    },
+    {  # p14: 1080p, resolution and source
+        'name': 'Show Name - 2x03 - 1080p BluRay - Ep Name.mkv',
+        'expected': Quality.FULLHDBLURAY
+    },
+    {  # p15: 1080p, resolution and source
+        'name': 'Show Name - 2x03 - 1080p WEB - Ep Name.mkv',
+        'expected': Quality.FULLHDWEBDL
+    },
+    {  # p16: 1080p, resolution and source
+        'name': 'Show Name - 2x03 - 1080p AMZN - Ep Name.mkv',
+        'expected': Quality.FULLHDWEBDL
+    },
+    {  # p17: 1080p, resolution, source and codec
+        'name': 'Show Name - 2x03 - 1080p HDTV MPEG - Ep Name.mkv',
+        'expected': Quality.RAWHDTV
+    },
+    {  # p18: 1080i, resolution, source and codec
+        'name': 'Show Name - 2x03 - 1080i HDTV MPEG - Ep Name.mkv',
+        'expected': Quality.RAWHDTV
+    },
+    {  # p19: 1080i, resolution, source and codec
+        'name': 'Show Name - 2x03 - 1080i HDTV h264 - Ep Name.mkv',
+        'expected': Quality.RAWHDTV
+    },
+    {  # p20: 2160p, resolution and source
+        'name': 'Show Name - 2x03 - 2160p BluRay - Ep Name.mkv',
+        'expected': Quality.UHD_4K_BLURAY
+    },
+    {  # p21: 2160p, resolution and source
+        'name': 'Show Name - 2x03 - 2160p WEB - Ep Name.mkv',
+        'expected': Quality.UHD_4K_WEBDL
+    },
+    {  # p22: 4320p, resolution and source
+        'name': 'Show Name - 2x03 - 4320p HDTV - Ep Name.mkv',
+        'expected': Quality.UHD_8K_TV
+    },
+    {  # p23: SDTV, anime, only resolution
+        'name': 'Show Name - 2x03 - 480p - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.SDTV
+    },
+    {  # p24: SDDVD, anime, only source
+        'name': 'Show Name - 2x03 - DVD - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.SDDVD
+    },
+    {  # p25: 720p, anime, resolution and source
+        'name': 'Show Name - 2x03 - 720p BluRay - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.HDBLURAY
+    },
+    {  # p26: 720p, anime, only resolution
+        'name': 'Show Name - 2x03 - 720p - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.HDTV
+    },
+    {  # p27: 1080p, anime, resolution and source
+        'name': 'Show Name - 2x03 - 1080p BluRay - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.FULLHDBLURAY
+    },
+    {  # p28: 1080p, anime, only resolution
+        'name': 'Show Name - 2x03 - 1080p - Ep Name.mkv',
+        'anime': True,
+        'expected': Quality.FULLHDTV
+    },
+])
+def test_quality_from_name(p):
+    # Given
+    name = p['name']
+    anime = p.get('anime', False)
+    expected = p['expected']
+
+    # When
+    actual = Quality.quality_from_name(name, anime)
+
+    # Then
+    assert expected == actual


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

1) Renamed `scene_quality` to `quality_from_name` as it is more accurate.
2) The resolution is now enough to determine a quality (without source it defaults to HDTV)
3) Fixed detection of `mpeg` releases
   Added detection of Amazon releases
   Improved detection of Netflix releases
4) Added tests for `quality_from_name`