### PR TITLE
TVDB: Fix exception when no updates are returned. Fixes #4419

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -633,7 +633,7 @@ class TVDBv2(BaseIndexer):
         try:
             while updates and count < weeks:
                 updates = self.config['session'].updates_api.updated_query_get(from_time).data
-                if updates is not None:
+                if updates:
                     last_update_ts = max(x.last_updated for x in updates)
                     from_time = last_update_ts
                     total_updates += [int(_.id) for _ in updates]


### PR DESCRIPTION
Fixes #4419

The endpoint returns an empty list if no shows were updated in the requested time frame.