### PR TITLE
Fix #4408 - Search delay UI bug with fractions

### DIFF
--- a/themes-default/slim/views/config_providers.mako
+++ b/themes-default/slim/views/config_providers.mako
@@ -1057,7 +1057,7 @@ const startVue = () => {
                             <label for="${cur_newznab_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_newznab_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1176,7 +1176,7 @@ const startVue = () => {
                             <label for="${cur_nzb_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_nzb_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1511,7 +1511,7 @@ const startVue = () => {
                             <label for="${cur_torrent_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_torrent_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>

--- a/themes/dark/templates/config_providers.mako
+++ b/themes/dark/templates/config_providers.mako
@@ -1057,7 +1057,7 @@ const startVue = () => {
                             <label for="${cur_newznab_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_newznab_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1176,7 +1176,7 @@ const startVue = () => {
                             <label for="${cur_nzb_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_nzb_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1511,7 +1511,7 @@ const startVue = () => {
                             <label for="${cur_torrent_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_torrent_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>

--- a/themes/light/templates/config_providers.mako
+++ b/themes/light/templates/config_providers.mako
@@ -1057,7 +1057,7 @@ const startVue = () => {
                             <label for="${cur_newznab_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_newznab_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_newznab_provider.get_id()}_search_delay" id="${cur_newznab_provider.get_id()}_search_delay" value="${8 if cur_newznab_provider.search_delay is None else round(cur_newznab_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1176,7 +1176,7 @@ const startVue = () => {
                             <label for="${cur_nzb_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_nzb_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_nzb_provider.get_id()}_search_delay" id="${cur_nzb_provider.get_id()}_search_delay" value="${8 if cur_nzb_provider.search_delay is None else round(cur_nzb_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>
@@ -1511,7 +1511,7 @@ const startVue = () => {
                             <label for="${cur_torrent_provider.get_id()}_ratio">
                                 <span class="component-title" id="${cur_torrent_provider.get_id()}_search_delay">Search delay (hours):</span>
                                 <span class="component-desc">
-                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60, 1)}" class="form-control input-sm input75" />
+                                    <input type="number" min="0.5" step="0.5" name="${cur_torrent_provider.get_id()}_search_delay" id="${cur_torrent_provider.get_id()}_search_delay" value="${8 if cur_torrent_provider.search_delay is None else round(cur_torrent_provider.search_delay / 60.0, 1)}" class="form-control input-sm input75" />
                                 </span>
                             </label>
                             <label>


### PR DESCRIPTION
Wanted to use `from __future__ import division`, but we can't do that in mako templates.
Fixes #4408

@p0psicles 