### PR TITLE
Fix "already added" link using incorrect indexer and show id

### DIFF
--- a/medusa/server/api/v2/internal.py
+++ b/medusa/server/api/v2/internal.py
@@ -208,10 +208,11 @@ class InternalHandler(BaseRequestHandler):
         # Get all possible show ids
         all_show_ids = {}
         for show in app.showList:
-            for external in show.externals:
-                indexer_id = reverse_mappings.get(external)
-                show_id = show.externals[external]
-                all_show_ids.setdefault(indexer_id, []).append(show_id)
+            for ex_indexer_name, ex_show_id in iteritems(show.externals):
+                ex_indexer_id = reverse_mappings.get(ex_indexer_name)
+                if not ex_indexer_id:
+                    continue
+                all_show_ids[(ex_indexer_id, ex_show_id)] = (show.indexer_name, show.series_id)
 
         for indexer, shows in iteritems(results):
             indexer_api = indexerApi(indexer)
@@ -228,7 +229,7 @@ class InternalHandler(BaseRequestHandler):
                         show['firstaired'] or 'N/A',
                         show.get('network', '').encode('utf-8') or 'N/A',
                         sanitize_filename(show['seriesname']).encode('utf-8'),
-                        show_id in all_show_ids.get(indexer, []) and (indexer, show_id)
+                        all_show_ids.get((indexer, show_id), False)
                     )
                 )
 

--- a/themes-default/slim/views/addShows_newShow.mako
+++ b/themes-default/slim/views/addShows_newShow.mako
@@ -370,8 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerName, mShowId ] = alreadyAdded;
-                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
+                            const [ matchIndexerName, matchShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + matchIndexerName + '&seriesid=' + matchShowId;
                         })();
 
                         return {

--- a/themes-default/slim/views/addShows_newShow.mako
+++ b/themes-default/slim/views/addShows_newShow.mako
@@ -370,9 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerId, mShowId ] = alreadyAdded;
-                            const indexerIdentifier = indexers[mIndexerId] ? indexers[mIndexerId].identifier : mIndexerId;
-                            return 'home/displayShow?indexername=' + indexerIdentifier + '&seriesid=' + mShowId;
+                            const [ mIndexerName, mShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
                         })();
 
                         return {

--- a/themes/dark/templates/addShows_newShow.mako
+++ b/themes/dark/templates/addShows_newShow.mako
@@ -370,8 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerName, mShowId ] = alreadyAdded;
-                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
+                            const [ matchIndexerName, matchShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + matchIndexerName + '&seriesid=' + matchShowId;
                         })();
 
                         return {

--- a/themes/dark/templates/addShows_newShow.mako
+++ b/themes/dark/templates/addShows_newShow.mako
@@ -370,9 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerId, mShowId ] = alreadyAdded;
-                            const indexerIdentifier = indexers[mIndexerId] ? indexers[mIndexerId].identifier : mIndexerId;
-                            return 'home/displayShow?indexername=' + indexerIdentifier + '&seriesid=' + mShowId;
+                            const [ mIndexerName, mShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
                         })();
 
                         return {

--- a/themes/light/templates/addShows_newShow.mako
+++ b/themes/light/templates/addShows_newShow.mako
@@ -370,8 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerName, mShowId ] = alreadyAdded;
-                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
+                            const [ matchIndexerName, matchShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + matchIndexerName + '&seriesid=' + matchShowId;
                         })();
 
                         return {

--- a/themes/light/templates/addShows_newShow.mako
+++ b/themes/light/templates/addShows_newShow.mako
@@ -370,9 +370,8 @@ const startVue = () => {
                         alreadyAdded = (() => {
                             if (!alreadyAdded) return false;
                             // Extract existing show info
-                            const [ mIndexerId, mShowId ] = alreadyAdded;
-                            const indexerIdentifier = indexers[mIndexerId] ? indexers[mIndexerId].identifier : mIndexerId;
-                            return 'home/displayShow?indexername=' + indexerIdentifier + '&seriesid=' + mShowId;
+                            const [ mIndexerName, mShowId ] = alreadyAdded;
+                            return 'home/displayShow?indexername=' + mIndexerName + '&seriesid=' + mShowId;
                         })();
 
                         return {


### PR DESCRIPTION
It was using the indexer's name and show id instead of the values of the show added to the library.
Made the `displayShow` link invalid as it pointed to a show that didn't exist in the library.