### PR TITLE
Decode log lines from UTF-8 on Windows

### DIFF
--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -224,7 +224,7 @@ def reverse_readlines(filename, buf_size=2097152, encoding=default_encoding):
             fh.seek(file_size - offset)
             buf = fh.read(min(remaining_size, buf_size))
             if os.name == 'nt':
-                buf = buf.decode(sys.getfilesystemencoding())
+                buf = buf.decode(encoding, errors='replace')
             if not isinstance(buf, text_type):
                 buf = text_type(buf, errors='replace')
             remaining_size -= buf_size


### PR DESCRIPTION
Fixes non-ASCII characters being decoded using an incorrect encoding on Windows.
Also fixes [one of the logger tests](https://github.com/pymedusa/Medusa/blob/06deabf/tests/test_logger.py#L115) not passing on Windows.

~To be merged **after** 0.2.6.~
I really want to give this as much time as possible.
I've been using this fix for a while now (since June 9th according to the commit date) on Windows, so it should be fine.