### PR TITLE
Simplify/Improve YggTorrent pubdate parsing

### DIFF
--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -46,24 +46,6 @@ class YggtorrentProvider(TorrentProvider):
         # Proper Strings
         self.proper_strings = ['PROPER', 'REPACK', 'REAL', 'RERIP']
 
-        # Miscellaneous Options
-        self.translation = {
-            'à l\'instant': 'just now',
-            'seconde': 'second',
-            'secondes': 'seconds',
-            'minute': 'minute',
-            'minutes': 'minutes',
-            'heure': 'hour',
-            'heures': 'hours',
-            'jour': 'day',
-            'jours': 'days',
-            'mois': 'month',
-            'an': 'year',
-            'année': 'year',
-            'ans': 'years',
-            'années': 'years'
-        }
-
         # Torrent Stats
         self.minseed = None
         self.minleech = None
@@ -163,19 +145,8 @@ class YggtorrentProvider(TorrentProvider):
                     torrent_size = cells[5].get_text()
                     size = convert_size(torrent_size, sep='', units=units, default=-1)
 
-                    pubdate = None
-                    pubdate_match = re.search(r'-(\d+)\s(\w+)', cells[4].get_text('-', strip=True))
-                    if pubdate_match:
-                        translated = self.translation.get(pubdate_match.group(2))
-                        if not translated:
-                            log.exception('No translation mapping available for value: {0}',
-                                          pubdate_match.group(2))
-                        else:
-                            pubdate_raw = '{0} {1}'.format(pubdate_match.group(1), translated)
-                            pubdate = self.parse_pubdate(pubdate_raw, human_time=True)
-                    else:
-                        log.warning('Could not translate publishing date with value: {0}',
-                                    cells[4].get_text('-', strip=True))
+                    pubdate_raw = cells[4].find('div', class_='hidden').get_text(strip=True)
+                    pubdate = self.parse_pubdate(pubdate_raw, fromtimestamp=True)
 
                     item = {
                         'title': title,

--- a/tests/providers/torrent/yggtorrent/yggtorrent_test.yaml
+++ b/tests/providers/torrent/yggtorrent/yggtorrent_test.yaml
@@ -4,25 +4,25 @@ daily:
   results:
     - leechers: 3
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=271559
-      pubdate: 2018-06-28 14:28:04.533000+03:00
+      pubdate: 2018-06-28 11:09:43+00:00
       seeders: 1
       size: 2115271393
       title: Germinal (1962) VF DVDRip h264 AAC
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=271548
-      pubdate: 2018-06-28 14:10:04.533000+03:00
+      pubdate: 2018-06-28 10:52:20+00:00
       seeders: 1
       size: 1793148846
       title: "Enqu\xEAtes criminelles - Affaire Benaym, la veuve et le jardinier Affaire Roman HDTV 720p AC-3 Fr du 27 juin 2018 MKV Diablo"
     - leechers: 1
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=271542
-      pubdate: 2018-06-28 14:03:04.533000+03:00
+      pubdate: 2018-06-28 10:31:52+00:00
       seeders: 4
       size: 1342177280
       title: "La L\xE9gende Du Nil (de L'eau Dans Le D\xE9sert).2014.FRENCH.HDTV.x264.mkv"
     - leechers: 6
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=271534
-      pubdate: 2018-06-28 14:03:04.533000+03:00
+      pubdate: 2018-06-28 10:17:20+00:00
       seeders: 12
       size: 4874787880
       title: The.100.S05E08.FASTSUB.VOSTFR.1080p.AMZN.WEB-DL.DD+5.1.H.264-GOLD
@@ -33,37 +33,37 @@ backlog:
   results:
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=210187
-      pubdate: 2018-03-30 15:32:15.895000+03:00
+      pubdate: 2018-03-15 12:18:31+00:00
       seeders: 17
       size: 320507740
       title: Lethal.Weapon.S02E05.FRENCH.HDTV.x264-COLL3CTiF
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=210188
-      pubdate: 2018-03-30 15:32:15.895000+03:00
+      pubdate: 2018-03-15 12:18:33+00:00
       seeders: 30
       size: 959939870
       title: Lethal.Weapon.S02E05.FRENCH.720p.HDTV.x264-COLL3CTiF
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=210393
-      pubdate: 2018-03-30 15:32:15.895000+03:00
+      pubdate: 2018-03-15 17:27:03+00:00
       seeders: 21
       size: 2534030704
       title: Lethal.Weapon.S02E05.FRENCH.1080p.AMZN.WEB-DL.H264-FRATERNiTY
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=121656
-      pubdate: 2017-11-30 15:32:15.896000+02:00
+      pubdate: 2017-11-08 22:15:23+00:00
       seeders: 5
       size: 977734205
       title: Lethal.Weapon.S02E05.SUBFRENCH.720p.WEB-DL.x264-FDS
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=122889
-      pubdate: 2017-11-30 15:32:15.896000+02:00
+      pubdate: 2017-11-10 17:32:41+00:00
       seeders: 2
       size: 1793148846
       title: Lethal.Weapon.S02E05.SUBFRENCH.1080p.WEB-DL.H264-Yn1D.mkv
     - leechers: 0
       link: https://ww1.yggtorrent.is/engine/download_torrent?id=121510
-      pubdate: 2017-11-30 15:32:15.897000+02:00
+      pubdate: 2017-11-08 19:44:57+00:00
       seeders: 12
       size: 338868305
       title: Lethal.Weapon.S02E05.SUBFRENCH.WEB-DL.x264-ARK01


### PR DESCRIPTION
Using a hidden timestamp from the HTML:
![image](https://user-images.githubusercontent.com/10238474/42033758-99f4c27c-7ae6-11e8-8389-16e5e3a378a5.png)