### PR TITLE
Fix proper search downloading multiple propers. Fixes #4495

### DIFF
--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -341,12 +341,10 @@ class ProperFinder(object):  # pylint: disable=too-few-public-methods
                 b'AND episode IN ({episodes}) '
                 b'AND quality = ? '
                 b'AND date >= ? '
-                b'AND action IN (?, ?, ?, ?) '
-                b'LIMIT {amount}'.format(
+                b'AND action IN (?, ?, ?, ?)'.format(
                     episodes=','.join(
                         text_type(ep) for ep in candidate.actual_episodes
                     ),
-                    amount=len(candidate.actual_episodes) * 2,
                 ),
                 [candidate.indexerid, candidate.actual_season, candidate.quality,
                  history_limit.strftime(History.date_format),

--- a/medusa/search/proper.py
+++ b/medusa/search/proper.py
@@ -9,13 +9,12 @@ import logging
 import operator
 import re
 import threading
-import time
 from builtins import map
 from builtins import object
 from builtins import str
 
 from medusa import app, db, helpers
-from medusa.common import DOWNLOADED, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER, SUBTITLED, cpu_presets
+from medusa.common import DOWNLOADED, SNATCHED, SNATCHED_BEST, SNATCHED_PROPER, SUBTITLED
 from medusa.helper.common import enabled_providers
 from medusa.helper.exceptions import AuthException, ex
 from medusa.logger.adapters.style import BraceAdapter


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

2 issues here:
- Multi episodes would get propers downloaded over and over
- There was no check to make sure that the existing release wasn't already proper, that means that it kept downloading proper releases over and over (not the same, but e.g. by different groups/name)