### PR TITLE
Fix event handlers by restoring app-link to a mako file

### DIFF
--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -126,8 +126,9 @@
         <script src="js/notifications.js"></script>
         <script src="js/store.js"></script>
         <script>
-            Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
+            // Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
         </script>
+        <%include file="/vue-components/app-link.mako"/>
         <%include file="/vue-components/asset.mako"/>
         <%include file="/vue-components/file-browser.mako"/>
         <%include file="/vue-components/plot-info.mako"/>

--- a/themes-default/slim/views/vue-components/app-link.mako
+++ b/themes-default/slim/views/vue-components/app-link.mako
@@ -1,0 +1,154 @@
+<script type="text/x-template" id="app-link-template">
+    <component
+        :is="linkProperties.is"
+        :to="linkProperties.to"
+        :href="linkProperties.href"
+        :target="linkProperties.target"
+        :rel="linkProperties.rel"
+        :false-link="linkProperties.falseLink"
+    >
+        <slot></slot>
+    </component>
+</script>
+<script>
+Vue.component('app-link', {
+    template: '#app-link-template',
+    props: {
+        to: [String, Object],
+        href: String,
+        indexerId: {
+            type: String
+        },
+        placeholder: {
+            type: String,
+            default: 'indexer-to-name'
+        },
+        base: String
+    },
+    computed: {
+        config() {
+            return this.$store.state.config;
+        },
+        indexerName() {
+            const { config, indexerId } = this;
+            const { indexers } = config.indexers.config;
+            if (!indexerId) {
+                return undefined;
+            }
+            // Returns `undefined` if not found
+            return Object.keys(indexers).find(indexer => indexers[indexer].id === parseInt(indexerId, 10));
+        },
+        computedBase() {
+            // Return prop before HTML element to allow tests to mock
+            if (this.base) {
+                return this.base;
+            }
+
+            return document.getElementsByTagName('base')[0].getAttribute('href');
+        },
+        computedHref() {
+            const { href, indexerId, placeholder, indexerName } = this;
+            if (indexerId && placeholder) {
+                return href.replace(placeholder, indexerName);
+            }
+            return href;
+        },
+        isIRC() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('irc://');
+        },
+        isAbsolute() {
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return /^[a-z][a-z0-9+.-]*:/.test(href);
+        },
+        isExternal() {
+            const base = this.computedBase;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return !href.startsWith(base) && !href.startsWith('webcal://');
+        },
+        isHashPath() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('#');
+        },
+        anonymisedHref() {
+            const { anonRedirect } = this.config;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return anonRedirect ? anonRedirect + href : href;
+        },
+        linkProperties() {
+            const { to, isIRC, isAbsolute, isExternal, isHashPath, anonymisedHref } = this;
+            const base = this.computedBase;
+            const href = this.computedHref;
+
+            // Return normal router-link
+            if (to) {
+                return {
+                    is: 'router-link',
+                    to: (() => {
+                        if (typeof to === 'object') {
+                            return to;
+                        }
+                        return {
+                            name: to
+                        };
+                    })()
+                };
+            }
+
+            // Just return a boring link with other attrs
+            // @NOTE: This is for scroll achors as it uses the id
+            if (!href) {
+                return {
+                    is: 'a',
+                    falseLink: true
+                };
+            }
+
+            return {
+                is: 'a',
+                target: isAbsolute && isExternal ? '_blank' : '_self',
+                href: (() => {
+                    if (isHashPath) {
+                        const { location } = window;
+                        if (location.hash.length === 0) {
+                            // Current location might be `url#`
+                            const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                            return location.href + newHash;
+                        }
+                        return location.href.replace(location.hash, '') + href;
+                    }
+                    if (isIRC) {
+                        return href;
+                    }
+                    if (isAbsolute) {
+                        if (isExternal) {
+                            return anonymisedHref;
+                        }
+                        return href;
+                    }
+                    return new URL(href, base).href;
+                })(),
+                rel: isAbsolute && isExternal ? 'noreferrer' : undefined
+            };
+        }
+    }
+});
+</script>
+<style>
+/* @NOTE: This fixes the header blocking elements when using a hash link */
+/* e.g. displayShow?indexername=tvdb&seriesid=83462#season-5  */
+[false-link]:before { content: ''; display: block; position: relative; width: 0; height: 100px; margin-top: -100px }
+</style>

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -126,8 +126,9 @@
         <script src="js/notifications.js"></script>
         <script src="js/store.js"></script>
         <script>
-            Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
+            // Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
         </script>
+        <%include file="/vue-components/app-link.mako"/>
         <%include file="/vue-components/asset.mako"/>
         <%include file="/vue-components/file-browser.mako"/>
         <%include file="/vue-components/plot-info.mako"/>

--- a/themes/dark/templates/vue-components/app-link.mako
+++ b/themes/dark/templates/vue-components/app-link.mako
@@ -1,0 +1,154 @@
+<script type="text/x-template" id="app-link-template">
+    <component
+        :is="linkProperties.is"
+        :to="linkProperties.to"
+        :href="linkProperties.href"
+        :target="linkProperties.target"
+        :rel="linkProperties.rel"
+        :false-link="linkProperties.falseLink"
+    >
+        <slot></slot>
+    </component>
+</script>
+<script>
+Vue.component('app-link', {
+    template: '#app-link-template',
+    props: {
+        to: [String, Object],
+        href: String,
+        indexerId: {
+            type: String
+        },
+        placeholder: {
+            type: String,
+            default: 'indexer-to-name'
+        },
+        base: String
+    },
+    computed: {
+        config() {
+            return this.$store.state.config;
+        },
+        indexerName() {
+            const { config, indexerId } = this;
+            const { indexers } = config.indexers.config;
+            if (!indexerId) {
+                return undefined;
+            }
+            // Returns `undefined` if not found
+            return Object.keys(indexers).find(indexer => indexers[indexer].id === parseInt(indexerId, 10));
+        },
+        computedBase() {
+            // Return prop before HTML element to allow tests to mock
+            if (this.base) {
+                return this.base;
+            }
+
+            return document.getElementsByTagName('base')[0].getAttribute('href');
+        },
+        computedHref() {
+            const { href, indexerId, placeholder, indexerName } = this;
+            if (indexerId && placeholder) {
+                return href.replace(placeholder, indexerName);
+            }
+            return href;
+        },
+        isIRC() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('irc://');
+        },
+        isAbsolute() {
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return /^[a-z][a-z0-9+.-]*:/.test(href);
+        },
+        isExternal() {
+            const base = this.computedBase;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return !href.startsWith(base) && !href.startsWith('webcal://');
+        },
+        isHashPath() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('#');
+        },
+        anonymisedHref() {
+            const { anonRedirect } = this.config;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return anonRedirect ? anonRedirect + href : href;
+        },
+        linkProperties() {
+            const { to, isIRC, isAbsolute, isExternal, isHashPath, anonymisedHref } = this;
+            const base = this.computedBase;
+            const href = this.computedHref;
+
+            // Return normal router-link
+            if (to) {
+                return {
+                    is: 'router-link',
+                    to: (() => {
+                        if (typeof to === 'object') {
+                            return to;
+                        }
+                        return {
+                            name: to
+                        };
+                    })()
+                };
+            }
+
+            // Just return a boring link with other attrs
+            // @NOTE: This is for scroll achors as it uses the id
+            if (!href) {
+                return {
+                    is: 'a',
+                    falseLink: true
+                };
+            }
+
+            return {
+                is: 'a',
+                target: isAbsolute && isExternal ? '_blank' : '_self',
+                href: (() => {
+                    if (isHashPath) {
+                        const { location } = window;
+                        if (location.hash.length === 0) {
+                            // Current location might be `url#`
+                            const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                            return location.href + newHash;
+                        }
+                        return location.href.replace(location.hash, '') + href;
+                    }
+                    if (isIRC) {
+                        return href;
+                    }
+                    if (isAbsolute) {
+                        if (isExternal) {
+                            return anonymisedHref;
+                        }
+                        return href;
+                    }
+                    return new URL(href, base).href;
+                })(),
+                rel: isAbsolute && isExternal ? 'noreferrer' : undefined
+            };
+        }
+    }
+});
+</script>
+<style>
+/* @NOTE: This fixes the header blocking elements when using a hash link */
+/* e.g. displayShow?indexername=tvdb&seriesid=83462#season-5  */
+[false-link]:before { content: ''; display: block; position: relative; width: 0; height: 100px; margin-top: -100px }
+</style>

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -126,8 +126,9 @@
         <script src="js/notifications.js"></script>
         <script src="js/store.js"></script>
         <script>
-            Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
+            // Vue.component('app-link', httpVueLoader('js/templates/app-link.vue'));
         </script>
+        <%include file="/vue-components/app-link.mako"/>
         <%include file="/vue-components/asset.mako"/>
         <%include file="/vue-components/file-browser.mako"/>
         <%include file="/vue-components/plot-info.mako"/>

--- a/themes/light/templates/vue-components/app-link.mako
+++ b/themes/light/templates/vue-components/app-link.mako
@@ -1,0 +1,154 @@
+<script type="text/x-template" id="app-link-template">
+    <component
+        :is="linkProperties.is"
+        :to="linkProperties.to"
+        :href="linkProperties.href"
+        :target="linkProperties.target"
+        :rel="linkProperties.rel"
+        :false-link="linkProperties.falseLink"
+    >
+        <slot></slot>
+    </component>
+</script>
+<script>
+Vue.component('app-link', {
+    template: '#app-link-template',
+    props: {
+        to: [String, Object],
+        href: String,
+        indexerId: {
+            type: String
+        },
+        placeholder: {
+            type: String,
+            default: 'indexer-to-name'
+        },
+        base: String
+    },
+    computed: {
+        config() {
+            return this.$store.state.config;
+        },
+        indexerName() {
+            const { config, indexerId } = this;
+            const { indexers } = config.indexers.config;
+            if (!indexerId) {
+                return undefined;
+            }
+            // Returns `undefined` if not found
+            return Object.keys(indexers).find(indexer => indexers[indexer].id === parseInt(indexerId, 10));
+        },
+        computedBase() {
+            // Return prop before HTML element to allow tests to mock
+            if (this.base) {
+                return this.base;
+            }
+
+            return document.getElementsByTagName('base')[0].getAttribute('href');
+        },
+        computedHref() {
+            const { href, indexerId, placeholder, indexerName } = this;
+            if (indexerId && placeholder) {
+                return href.replace(placeholder, indexerName);
+            }
+            return href;
+        },
+        isIRC() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('irc://');
+        },
+        isAbsolute() {
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return /^[a-z][a-z0-9+.-]*:/.test(href);
+        },
+        isExternal() {
+            const base = this.computedBase;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return !href.startsWith(base) && !href.startsWith('webcal://');
+        },
+        isHashPath() {
+            if (!this.computedHref) {
+                return;
+            }
+            return this.computedHref.startsWith('#');
+        },
+        anonymisedHref() {
+            const { anonRedirect } = this.config;
+            const href = this.computedHref;
+            if (!href) {
+                return;
+            }
+            return anonRedirect ? anonRedirect + href : href;
+        },
+        linkProperties() {
+            const { to, isIRC, isAbsolute, isExternal, isHashPath, anonymisedHref } = this;
+            const base = this.computedBase;
+            const href = this.computedHref;
+
+            // Return normal router-link
+            if (to) {
+                return {
+                    is: 'router-link',
+                    to: (() => {
+                        if (typeof to === 'object') {
+                            return to;
+                        }
+                        return {
+                            name: to
+                        };
+                    })()
+                };
+            }
+
+            // Just return a boring link with other attrs
+            // @NOTE: This is for scroll achors as it uses the id
+            if (!href) {
+                return {
+                    is: 'a',
+                    falseLink: true
+                };
+            }
+
+            return {
+                is: 'a',
+                target: isAbsolute && isExternal ? '_blank' : '_self',
+                href: (() => {
+                    if (isHashPath) {
+                        const { location } = window;
+                        if (location.hash.length === 0) {
+                            // Current location might be `url#`
+                            const newHash = location.href.endsWith('#') ? href.substr(1) : href;
+                            return location.href + newHash;
+                        }
+                        return location.href.replace(location.hash, '') + href;
+                    }
+                    if (isIRC) {
+                        return href;
+                    }
+                    if (isAbsolute) {
+                        if (isExternal) {
+                            return anonymisedHref;
+                        }
+                        return href;
+                    }
+                    return new URL(href, base).href;
+                })(),
+                rel: isAbsolute && isExternal ? 'noreferrer' : undefined
+            };
+        }
+    }
+});
+</script>
+<style>
+/* @NOTE: This fixes the header blocking elements when using a hash link */
+/* e.g. displayShow?indexername=tvdb&seriesid=83462#season-5  */
+[false-link]:before { content: ''; display: block; position: relative; width: 0; height: 100px; margin-top: -100px }
+</style>


### PR DESCRIPTION
This is a temporary fix, just to get develop working again.

This fixes:
- Everything related to links with event handlers from jQuery and other libraries other than Vue.
  So confirmation popups, everything still using the separate javascript files.
- Images on displayShow