### PR TITLE
Fix gulp sync for now

### DIFF
--- a/themes-default/slim/gulpfile.js
+++ b/themes-default/slim/gulpfile.js
@@ -303,11 +303,11 @@ const syncTheme = (theme, sequence) => {
  *
  * Do not run the xo build, as this takes a lot of time.
  */
-gulp.task('sync', () => {
+gulp.task('sync', async () => {
     // Whe're building the light and dark theme. For this we need to run two sequences.
     // If we need a yargs parameter name csstheme.
     for (const theme of Object.entries(config.cssThemes)) {
-        syncTheme(theme, ['css', 'cssTheme', 'img', 'js', 'static', 'templates', 'root']);
+        await syncTheme(theme, ['css', 'cssTheme', 'img', 'js', 'static', 'templates', 'root']);
     }
 });
 

--- a/themes-default/slim/package.json
+++ b/themes-default/slim/package.json
@@ -123,7 +123,8 @@
       "static/js/lib/**",
       "static/js/*.min.js",
       "static/js/vender.js",
-      "build/**"
+      "build/**",
+      "gulpfile.js"
     ],
     "esnext": true
   },


### PR DESCRIPTION
@OmgImAlexis 
If we remove the `async`/`await` for the `sync` task, it doesn't work correctly anymore - only syncs the first theme.

I spent 2 hours trying to get it to work with Promises, and couldn't.
I think this has something to do with how `runSequence` works..