### PR TITLE
Fix `gulp-util` deprecation warning

### DIFF
--- a/themes-default/slim/gulpfile.js
+++ b/themes-default/slim/gulpfile.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
-const gutil = require('gulp-util');
+const log = require('fancy-log');
+const colors = require('ansi-colors');
 const babelify = require('babelify');
 const runSequence = require('run-sequence');
 const livereload = require('gulp-livereload');
@@ -164,7 +165,7 @@ const bundleJs = done => {
                 .transform(babelify)
                 .bundle()
                 .on('error', function(err) {
-                    gutil.log(err.message);
+                    log(err.message);
                     this.emit('end');
                 })
                 .pipe(source(entry))
@@ -174,7 +175,7 @@ const bundleJs = done => {
                     loadMaps: true
                 }))
                 .pipe(gulpif(PROD, uglify()))
-                .on('error', err => gutil.log(gutil.colors.red('[Error]'), err.toString()))
+                .on('error', err => log(colors.red('[Error]'), err.toString()))
                 .pipe(sourcemaps.write('./'))
                 .pipe(gulp.dest(dest))
                 .pipe(gulpif(!PROD, livereload({ port: 35729 })));

--- a/themes-default/slim/package.json
+++ b/themes-default/slim/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "@vue/test-utils": "1.0.0-beta.20",
+    "ansi-colors": "2.0.2",
     "autoprefixer": "7.2.6",
     "ava": "1.0.0-beta.6",
     "axios": "0.18.0",
@@ -44,6 +45,7 @@
     "eslint-config-xo": "0.23.0",
     "eslint-plugin-vue": "4.5.0",
     "event-stream": "3.3.4",
+    "fancy-log": "1.3.2",
     "glob": "7.1.2",
     "gulp": "3.9.1",
     "gulp-changed": "3.2.0",
@@ -55,7 +57,6 @@
     "gulp-sass": "3.2.1",
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify-es": "0.2.0",
-    "gulp-util": "3.0.8",
     "gulp-xo": "0.16.1",
     "imagemin-pngquant": "5.1.0",
     "jquery": "3.3.1",

--- a/themes-default/slim/yarn.lock
+++ b/themes-default/slim/yarn.lock
@@ -451,6 +451,10 @@ ansi-align@^2.0.0:
   dependencies:
     string-width "^2.0.0"
 
+ansi-colors@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-2.0.2.tgz#1a95e0163c461846d44cbdea97bb2ac1aa35f1b2"
+
 ansi-colors@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-1.1.0.tgz#6374b4dd5d4718ff3ce27a671a3b1cad077132a9"
@@ -3780,7 +3784,7 @@ extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
 
-fancy-log@^1.1.0, fancy-log@^1.3.2:
+fancy-log@1.3.2, fancy-log@^1.1.0, fancy-log@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fancy-log/-/fancy-log-1.3.2.tgz#f41125e3d84f2e7d89a43d06d958c8f78be16be1"
   dependencies:
@@ -4655,7 +4659,7 @@ gulp-uglify-es@0.2.0:
     vinyl "^2.1.0"
     vinyl-sourcemaps-apply "^0.2.1"
 
-gulp-util@3.0.8, gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.2, gulp-util@^3.0.8:
+gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.2, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   dependencies:

--- a/themes/dark/package.json
+++ b/themes/dark/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "@vue/test-utils": "1.0.0-beta.20",
+    "ansi-colors": "2.0.2",
     "autoprefixer": "7.2.6",
     "ava": "1.0.0-beta.6",
     "axios": "0.18.0",
@@ -44,6 +45,7 @@
     "eslint-config-xo": "0.23.0",
     "eslint-plugin-vue": "4.5.0",
     "event-stream": "3.3.4",
+    "fancy-log": "1.3.2",
     "glob": "7.1.2",
     "gulp": "3.9.1",
     "gulp-changed": "3.2.0",
@@ -55,7 +57,6 @@
     "gulp-sass": "3.2.1",
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify-es": "0.2.0",
-    "gulp-util": "3.0.8",
     "gulp-xo": "0.16.1",
     "imagemin-pngquant": "5.1.0",
     "jquery": "3.3.1",
@@ -123,7 +124,8 @@
       "static/js/lib/**",
       "static/js/*.min.js",
       "static/js/vender.js",
-      "build/**"
+      "build/**",
+      "gulpfile.js"
     ],
     "esnext": true
   },

--- a/themes/light/package.json
+++ b/themes/light/package.json
@@ -28,6 +28,7 @@
   "dependencies": {},
   "devDependencies": {
     "@vue/test-utils": "1.0.0-beta.20",
+    "ansi-colors": "2.0.2",
     "autoprefixer": "7.2.6",
     "ava": "1.0.0-beta.6",
     "axios": "0.18.0",
@@ -44,6 +45,7 @@
     "eslint-config-xo": "0.23.0",
     "eslint-plugin-vue": "4.5.0",
     "event-stream": "3.3.4",
+    "fancy-log": "1.3.2",
     "glob": "7.1.2",
     "gulp": "3.9.1",
     "gulp-changed": "3.2.0",
@@ -55,7 +57,6 @@
     "gulp-sass": "3.2.1",
     "gulp-sourcemaps": "2.6.4",
     "gulp-uglify-es": "0.2.0",
-    "gulp-util": "3.0.8",
     "gulp-xo": "0.16.1",
     "imagemin-pngquant": "5.1.0",
     "jquery": "3.3.1",
@@ -123,7 +124,8 @@
       "static/js/lib/**",
       "static/js/*.min.js",
       "static/js/vender.js",
-      "build/**"
+      "build/**",
+      "gulpfile.js"
     ],
     "esnext": true
   },


### PR DESCRIPTION
Replace `gulp-util` with `fancy-log` and `ansi-colors`
Fixes #4572
