### PR TITLE
Fix Telegram/Growl notifiers message encodings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed reference linking ([#4463](https://github.com/pymedusa/Medusa/pull/4463))
 - Fixed the Show Selector not honoring user option to split shows & anime ([#4625](https://github.com/pymedusa/Medusa/pull/4625))
 - Fixed unhandled request error on Add Existing Show ([#4639](https://github.com/pymedusa/Medusa/pull/4639))
+- Fixed Telegram & Growl message encoding ([#4657](https://github.com/pymedusa/Medusa/pull/4657))
 - _Simple message describing the fix, and a link to the pull request._
 
 ### [**Previous versions**](https://github.com/pymedusa/medusa.github.io/blob/master/news/CHANGES.md)

--- a/medusa/notifiers/growl.py
+++ b/medusa/notifiers/growl.py
@@ -69,7 +69,7 @@ class Notifier(object):
         if message:
             notice.add_header('Notification-Text', message)
 
-        response = self._send(options['host'], options['port'], notice.encode(), options['debug'])
+        response = self._send(options['host'], options['port'], notice.encode('utf-8'), options['debug'])
         return True if isinstance(response, gntp.core.GNTPOK) else False
 
     @staticmethod
@@ -184,7 +184,7 @@ class Notifier(object):
             register.set_password(opts['password'])
 
         try:
-            return self._send(opts['host'], opts['port'], register.encode(), opts['debug'])
+            return self._send(opts['host'], opts['port'], register.encode('utf-8'), opts['debug'])
         except Exception as error:
             log.warning(
                 u'GROWL: Unable to send growl to {host}:{port} - {msg!r}',

--- a/medusa/notifiers/telegram.py
+++ b/medusa/notifiers/telegram.py
@@ -59,7 +59,7 @@ class Notifier(object):
 
         log.debug('Telegram in use with API KEY: {0}', api_key)
 
-        message = '%s : %s' % (title.encode(), msg.encode())
+        message = '{0} : {1}'.format(title, msg).encode('utf-8')
         payload = urlencode({'chat_id': user_id, 'text': message})
         telegram_api = 'https://api.telegram.org/bot%s/%s'
 


### PR DESCRIPTION
- [x] Fix #4645 - Telegram message encoding
- [x] Fix Growl message encoding
- [x] Update changelog
- [ ] ~Update Telegram notifier to use `requests`.~
