### PR TITLE
Add .eggs to Travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
   directories:
     - $HOME/.cache/pip
     - node_modules
+    - .eggs
 before_install:
   - python .github/check_version.py
 install: false


### PR DESCRIPTION
`.eggs` is a cache folder for dependencies used by `setup.py`.
It might make Python tests run a bit faster as we don't have to keep downloading and building the same packages with each build job.
