### PR TITLE
Enable CSS linting for Vue SFC

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
     "build": "node ./themes-default/helper.js lint",
     "coverage": "nyc ava && yarn report-coverage",
     "report-coverage": "nyc report --reporter=lcov > coverage.lcov && codecov",
-    "test-css": "node node_modules/stylelint/bin/stylelint.js ./themes-default/**/static/css/*.css",
+    "test-css": "stylelint ./themes-default/**/static/css/*.css ./themes-default/**/static/js/templates/**/*.vue",
     "test-api": "node_modules/.bin/dredd --config dredd/dredd.yml",
     "security": "snyk test",
     "install": "yarn run build"
   },
   "devDependencies": {
+    "@mapbox/stylelint-processor-arbitrary-tags": "0.2.0",
     "ava": "0.25.0",
     "codecov": "3.0.4",
     "dredd": "5.1.11",
@@ -32,6 +33,12 @@
   },
   "stylelint": {
     "extends": "stylelint-config-standard",
+    "processors": [
+      [
+        "@mapbox/stylelint-processor-arbitrary-tags",
+        { "fileFilterRegex": [".vue$"] }
+      ]
+    ],
     "rules": {
       "indentation": [
         4,

--- a/themes-default/slim/static/js/templates/add-recommended.vue
+++ b/themes-default/slim/static/js/templates/add-recommended.vue
@@ -35,3 +35,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes-default/slim/static/js/templates/add-shows.vue
+++ b/themes-default/slim/static/js/templates/add-shows.vue
@@ -27,3 +27,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes-default/slim/static/js/templates/anidb-release-group-ui.vue
+++ b/themes-default/slim/static/js/templates/anidb-release-group-ui.vue
@@ -166,6 +166,7 @@ module.exports = {
 <style scoped>
 div.anidb-release-group-ui-wrapper {
     clear: both;
+    margin-bottom: 20px;
 }
 
 div.anidb-release-group-ui-wrapper ul {
@@ -185,11 +186,8 @@ div.anidb-release-group-ui-wrapper div.arrow img {
     width: 32px;
 }
 
-div.anidb-release-group-ui-wrapper {
-    margin-bottom: 20px;
-}
-
-div.anidb-release-group-ui-wrapper img.deleteFromWhitelist, img.deleteFromBlacklist {
+div.anidb-release-group-ui-wrapper img.deleteFromWhitelist,
+div.anidb-release-group-ui-wrapper img.deleteFromBlacklist {
     float: right;
 }
 

--- a/themes-default/slim/static/js/templates/asset.vue
+++ b/themes-default/slim/static/js/templates/asset.vue
@@ -59,3 +59,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes-default/slim/static/js/templates/backstretch.vue
+++ b/themes-default/slim/static/js/templates/backstretch.vue
@@ -42,4 +42,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes-default/slim/static/js/templates/config.vue
+++ b/themes-default/slim/static/js/templates/config.vue
@@ -61,6 +61,6 @@ module.exports = {
 
 <style>
 .infoTable tr td:first-child {
-  vertical-align: top;
+    vertical-align: top;
 }
 </style>

--- a/themes-default/slim/static/js/templates/file-browser.vue
+++ b/themes-default/slim/static/js/templates/file-browser.vue
@@ -306,6 +306,7 @@ module.exports = {
 div.file-browser.max-width {
     max-width: 450px;
 }
+
 div.file-browser .input-group-no-btn {
     display: flex;
 }

--- a/themes-default/slim/static/js/templates/http/404.vue
+++ b/themes-default/slim/static/js/templates/http/404.vue
@@ -6,3 +6,6 @@ module.exports = {
     name: 'not-found'
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes-default/slim/static/js/templates/language-select.vue
+++ b/themes-default/slim/static/js/templates/language-select.vue
@@ -41,4 +41,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes-default/slim/static/js/templates/login.vue
+++ b/themes-default/slim/static/js/templates/login.vue
@@ -22,4 +22,5 @@ module.exports = {
 </script>
 
 <style>
+/* placeholder */
 </style>

--- a/themes-default/slim/static/js/templates/name-pattern.vue
+++ b/themes-default/slim/static/js/templates/name-pattern.vue
@@ -481,3 +481,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes-default/slim/static/js/templates/select-list.vue
+++ b/themes-default/slim/static/js/templates/select-list.vue
@@ -180,7 +180,8 @@ div.select-list .new-item-help {
     padding-top: 5px;
 }
 
-div.select-list input, div.select-list img {
+div.select-list input,
+div.select-list img {
     display: inline-block;
     box-sizing: border-box;
 }

--- a/themes-default/slim/views/errorlogs.mako
+++ b/themes-default/slim/views/errorlogs.mako
@@ -25,9 +25,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/themes-default/slim/views/viewlogs.mako
+++ b/themes-default/slim/views/viewlogs.mako
@@ -61,9 +61,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/themes/dark/assets/js/templates/add-recommended.vue
+++ b/themes/dark/assets/js/templates/add-recommended.vue
@@ -35,3 +35,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/dark/assets/js/templates/add-shows.vue
+++ b/themes/dark/assets/js/templates/add-shows.vue
@@ -27,3 +27,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/dark/assets/js/templates/anidb-release-group-ui.vue
+++ b/themes/dark/assets/js/templates/anidb-release-group-ui.vue
@@ -166,6 +166,7 @@ module.exports = {
 <style scoped>
 div.anidb-release-group-ui-wrapper {
     clear: both;
+    margin-bottom: 20px;
 }
 
 div.anidb-release-group-ui-wrapper ul {
@@ -185,11 +186,8 @@ div.anidb-release-group-ui-wrapper div.arrow img {
     width: 32px;
 }
 
-div.anidb-release-group-ui-wrapper {
-    margin-bottom: 20px;
-}
-
-div.anidb-release-group-ui-wrapper img.deleteFromWhitelist, img.deleteFromBlacklist {
+div.anidb-release-group-ui-wrapper img.deleteFromWhitelist,
+div.anidb-release-group-ui-wrapper img.deleteFromBlacklist {
     float: right;
 }
 

--- a/themes/dark/assets/js/templates/asset.vue
+++ b/themes/dark/assets/js/templates/asset.vue
@@ -59,3 +59,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/dark/assets/js/templates/backstretch.vue
+++ b/themes/dark/assets/js/templates/backstretch.vue
@@ -42,4 +42,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes/dark/assets/js/templates/config.vue
+++ b/themes/dark/assets/js/templates/config.vue
@@ -61,6 +61,6 @@ module.exports = {
 
 <style>
 .infoTable tr td:first-child {
-  vertical-align: top;
+    vertical-align: top;
 }
 </style>

--- a/themes/dark/assets/js/templates/file-browser.vue
+++ b/themes/dark/assets/js/templates/file-browser.vue
@@ -306,6 +306,7 @@ module.exports = {
 div.file-browser.max-width {
     max-width: 450px;
 }
+
 div.file-browser .input-group-no-btn {
     display: flex;
 }

--- a/themes/dark/assets/js/templates/http/404.vue
+++ b/themes/dark/assets/js/templates/http/404.vue
@@ -6,3 +6,6 @@ module.exports = {
     name: 'not-found'
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/dark/assets/js/templates/language-select.vue
+++ b/themes/dark/assets/js/templates/language-select.vue
@@ -41,4 +41,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes/dark/assets/js/templates/login.vue
+++ b/themes/dark/assets/js/templates/login.vue
@@ -22,4 +22,5 @@ module.exports = {
 </script>
 
 <style>
+/* placeholder */
 </style>

--- a/themes/dark/assets/js/templates/name-pattern.vue
+++ b/themes/dark/assets/js/templates/name-pattern.vue
@@ -481,3 +481,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/dark/assets/js/templates/select-list.vue
+++ b/themes/dark/assets/js/templates/select-list.vue
@@ -180,7 +180,8 @@ div.select-list .new-item-help {
     padding-top: 5px;
 }
 
-div.select-list input, div.select-list img {
+div.select-list input,
+div.select-list img {
     display: inline-block;
     box-sizing: border-box;
 }

--- a/themes/dark/templates/errorlogs.mako
+++ b/themes/dark/templates/errorlogs.mako
@@ -25,9 +25,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/themes/dark/templates/viewlogs.mako
+++ b/themes/dark/templates/viewlogs.mako
@@ -61,9 +61,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/themes/light/assets/js/templates/add-recommended.vue
+++ b/themes/light/assets/js/templates/add-recommended.vue
@@ -35,3 +35,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/light/assets/js/templates/add-shows.vue
+++ b/themes/light/assets/js/templates/add-shows.vue
@@ -27,3 +27,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/light/assets/js/templates/anidb-release-group-ui.vue
+++ b/themes/light/assets/js/templates/anidb-release-group-ui.vue
@@ -166,6 +166,7 @@ module.exports = {
 <style scoped>
 div.anidb-release-group-ui-wrapper {
     clear: both;
+    margin-bottom: 20px;
 }
 
 div.anidb-release-group-ui-wrapper ul {
@@ -185,11 +186,8 @@ div.anidb-release-group-ui-wrapper div.arrow img {
     width: 32px;
 }
 
-div.anidb-release-group-ui-wrapper {
-    margin-bottom: 20px;
-}
-
-div.anidb-release-group-ui-wrapper img.deleteFromWhitelist, img.deleteFromBlacklist {
+div.anidb-release-group-ui-wrapper img.deleteFromWhitelist,
+div.anidb-release-group-ui-wrapper img.deleteFromBlacklist {
     float: right;
 }
 

--- a/themes/light/assets/js/templates/asset.vue
+++ b/themes/light/assets/js/templates/asset.vue
@@ -59,3 +59,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/light/assets/js/templates/backstretch.vue
+++ b/themes/light/assets/js/templates/backstretch.vue
@@ -42,4 +42,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes/light/assets/js/templates/config.vue
+++ b/themes/light/assets/js/templates/config.vue
@@ -61,6 +61,6 @@ module.exports = {
 
 <style>
 .infoTable tr td:first-child {
-  vertical-align: top;
+    vertical-align: top;
 }
 </style>

--- a/themes/light/assets/js/templates/file-browser.vue
+++ b/themes/light/assets/js/templates/file-browser.vue
@@ -306,6 +306,7 @@ module.exports = {
 div.file-browser.max-width {
     max-width: 450px;
 }
+
 div.file-browser .input-group-no-btn {
     display: flex;
 }

--- a/themes/light/assets/js/templates/http/404.vue
+++ b/themes/light/assets/js/templates/http/404.vue
@@ -6,3 +6,6 @@ module.exports = {
     name: 'not-found'
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/light/assets/js/templates/language-select.vue
+++ b/themes/light/assets/js/templates/language-select.vue
@@ -41,4 +41,5 @@ module.exports = {
 };
 </script>
 <style>
+/* placeholder */
 </style>

--- a/themes/light/assets/js/templates/login.vue
+++ b/themes/light/assets/js/templates/login.vue
@@ -22,4 +22,5 @@ module.exports = {
 </script>
 
 <style>
+/* placeholder */
 </style>

--- a/themes/light/assets/js/templates/name-pattern.vue
+++ b/themes/light/assets/js/templates/name-pattern.vue
@@ -481,3 +481,6 @@ module.exports = {
     }
 };
 </script>
+<style>
+/* placeholder */
+</style>

--- a/themes/light/assets/js/templates/select-list.vue
+++ b/themes/light/assets/js/templates/select-list.vue
@@ -180,7 +180,8 @@ div.select-list .new-item-help {
     padding-top: 5px;
 }
 
-div.select-list input, div.select-list img {
+div.select-list input,
+div.select-list img {
     display: inline-block;
     box-sizing: border-box;
 }

--- a/themes/light/templates/errorlogs.mako
+++ b/themes/light/templates/errorlogs.mako
@@ -25,9 +25,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/themes/light/templates/viewlogs.mako
+++ b/themes/light/templates/viewlogs.mako
@@ -61,9 +61,9 @@ const startVue = () => {
 <%block name="css">
 <style>
 pre {
-  overflow: auto;
-  word-wrap: normal;
-  white-space: pre;
+    overflow: auto;
+    word-wrap: normal;
+    white-space: pre;
 }
 </style>
 </%block>

--- a/yarn.lock
+++ b/yarn.lock
@@ -133,6 +133,13 @@
     pretty-ms "^0.2.1"
     text-table "^0.2.0"
 
+"@mapbox/stylelint-processor-arbitrary-tags@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@mapbox/stylelint-processor-arbitrary-tags/-/stylelint-processor-arbitrary-tags-0.2.0.tgz#4c2b50711bd9033a6c4f7f19e418b5f43f1a1e51"
+  dependencies:
+    execall "^1.0.0"
+    split-lines "^1.1.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
@@ -2238,7 +2245,7 @@ gavel@2.1.2:
     http-string-parser "0.0.5"
     is-type "0.0.1"
     json-pointer "^0.6.0"
-    jsonlint "github:josdejong/jsonlint"
+    jsonlint josdejong/jsonlint
     media-typer "^0.3.0"
     tv4 "^1.3.0"
 
@@ -3237,7 +3244,6 @@ jsonfile@^4.0.0:
 
 "jsonlint@github:josdejong/jsonlint":
   version "1.6.2"
-  uid "85a19d77126771f3177582e3d09c6ffae185d391"
   resolved "https://codeload.github.com/josdejong/jsonlint/tar.gz/85a19d77126771f3177582e3d09c6ffae185d391"
   dependencies:
     JSV ">= 4.0.x"
@@ -5340,6 +5346,10 @@ spdx-license-ids@^3.0.0:
 specificity@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.3.2.tgz#99e6511eceef0f8d9b57924937aac2cb13d13c42"
+
+split-lines@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-lines/-/split-lines-1.1.0.tgz#3abba8f598614142f9db8d27ab6ab875662a1e09"
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
The only caveat is, the file must have a `<style>` tag with at least one non-empty line in it, to not trigger [`no-empty-source`](https://stylelint.io/user-guide/rules/no-empty-source/).

I opted for:
```html
<style>
/* placeholder */
</style>
```

Note: The `.mako` components are not tested, but I did find and fix a few CSS issues in some of them.