### PR TITLE
Revert "Add .eggs to Travis cache (#4714)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
   directories:
     - $HOME/.cache/pip
     - node_modules
-    - .eggs
 before_install:
   - python .github/check_version.py
 install: false


### PR DESCRIPTION
This reverts commit 42cd141ce70515d6c3573aaf93a556976bd3de41 (#4714).

Sorry, this was a bad idea. :man_facepalming: 
If we cache `.eggs`, then the tests might keep using old dependencies instead of downloading the latest version.
