### PR TITLE
Fix API error when an episode airdate is `datetime.date.min`

### DIFF
--- a/dredd/api-description.yml
+++ b/dredd/api-description.yml
@@ -1463,10 +1463,12 @@ definitions:
         type: string
       season:
         type: integer
-        minimum: 0
+        minimum: 1
+        x-nullable: true
       type:
         type: string
-        enum: [local]
+        enum: [null, local]
+        x-nullable: true
     example:
       series: tvdb301824
       name: TheBig

--- a/dredd/api-description.yml
+++ b/dredd/api-description.yml
@@ -942,6 +942,7 @@ definitions:
         type: string
         format: date-time
         description: Next episode air date
+        x-nullable: true
       runtime:
         type: integer
         minimum: 1
@@ -972,7 +973,7 @@ definitions:
             votes: 558507
       classification:
         type: string
-        enum: ['TV-Y', 'TV-Y7', 'TV-G', 'TV-PG', 'TV-14', 'TV-MA']
+        enum: ['', 'TV-Y', 'TV-Y7', 'TV-G', 'TV-PG', 'TV-14', 'TV-MA']
         description: TV Parental Guidelines
       cache:
         type: object

--- a/dredd/api-description.yml
+++ b/dredd/api-description.yml
@@ -1116,6 +1116,7 @@ definitions:
       airDate:
         type: string
         format: date-time
+        x-nullable: true
       title:
         type: string
         description: Episode title

--- a/medusa/server/api/v2/alias.py
+++ b/medusa/server/api/v2/alias.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 from medusa import db
-from medusa.helper.mappings import NonEmptyDict
 from medusa.server.api.v2.base import BaseRequestHandler
 from medusa.tv.series import SeriesIdentifier
 
@@ -71,7 +70,7 @@ class AliasHandler(BaseRequestHandler):
 
         data = []
         for item in sql_results:
-            d = NonEmptyDict()
+            d = {}
             d['id'] = item[0]
             d['series'] = SeriesIdentifier.from_id(item[1], item[2]).slug
             d['name'] = item[3]

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -58,7 +58,6 @@ from medusa.helper.exceptions import (
     NoNFOException,
     ex,
 )
-from medusa.helper.mappings import NonEmptyDict
 from medusa.indexers.indexer_api import indexerApi
 from medusa.indexers.indexer_config import indexerConfig
 from medusa.indexers.indexer_exceptions import (
@@ -1047,7 +1046,7 @@ class Episode(TV):
 
     def to_json(self, detailed=True):
         """Return the json representation."""
-        data = NonEmptyDict()
+        data = {}
         data['identifier'] = self.identifier
         data['id'] = {self.indexer_name: self.indexerid}
         data['season'] = self.season
@@ -1064,19 +1063,19 @@ class Episode(TV):
         data['subtitles'] = self.subtitles
         data['status'] = self.status_name
         data['quality'] = self.quality
-        data['release'] = NonEmptyDict()
+        data['release'] = {}
         data['release']['name'] = self.release_name
         data['release']['group'] = self.release_group
         data['release']['proper'] = self.is_proper
         data['release']['version'] = self.version
-        data['scene'] = NonEmptyDict()
+        data['scene'] = {}
         data['scene']['season'] = self.scene_season
         data['scene']['episode'] = self.scene_episode
 
         if self.scene_absolute_number:
             data['scene']['absoluteNumber'] = self.scene_absolute_number
 
-        data['file'] = NonEmptyDict()
+        data['file'] = {}
         data['file']['location'] = self.location
         if self.file_size:
             data['file']['size'] = self.file_size
@@ -1087,8 +1086,8 @@ class Episode(TV):
             data['content'].append('thumbnail')
 
         if detailed:
-            data['statistics'] = NonEmptyDict()
-            data['statistics']['subtitleSearch'] = NonEmptyDict()
+            data['statistics'] = {}
+            data['statistics']['subtitleSearch'] = {}
             data['statistics']['subtitleSearch']['last'] = self.subtitles_lastsearch
             data['statistics']['subtitleSearch']['count'] = self.subtitles_searchcount
             data['wantedQualities'] = self.wanted_quality

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -401,6 +401,9 @@ class Episode(TV):
     @property
     def air_date(self):
         """Return air date from the episode."""
+        if self.airdate == date.min:
+            return None
+
         return sbdatetime.convert_to_setting(
             network_timezones.parse_date_time(
                 date.toordinal(self.airdate),

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -61,7 +61,6 @@ from medusa.helper.exceptions import (
     ShowNotFoundException,
     ex,
 )
-from medusa.helper.mappings import NonEmptyDict
 from medusa.helpers.anidb import get_release_groups_for_anime, short_group_names
 from medusa.helpers.externals import get_externals, load_externals_from_db
 from medusa.helpers.utils import safe_get
@@ -1958,8 +1957,8 @@ class Series(TV):
         """Return JSON representation."""
         bw_list = self.release_groups or BlackAndWhiteList(self)
 
-        data = NonEmptyDict()
-        data['id'] = NonEmptyDict()
+        data = {}
+        data['id'] = {}
         data['id'][self.indexer_name] = self.series_id
         data['id']['imdb'] = text_type(self.imdb_id)
         data['id']['slug'] = self.identifier.slug
@@ -1972,27 +1971,27 @@ class Series(TV):
         data['language'] = self.lang
         data['showType'] = self.show_type  # e.g. anime, sport, series
         data['akas'] = self.imdb_akas
-        data['year'] = NonEmptyDict()
+        data['year'] = {}
         data['year']['start'] = self.imdb_year or self.start_year
         data['nextAirDate'] = self.next_airdate.isoformat() if self.next_airdate else None
         data['runtime'] = self.imdb_runtime or self.runtime
         data['genres'] = self.genres
-        data['rating'] = NonEmptyDict()
+        data['rating'] = {}
         if self.imdb_rating and self.imdb_votes:
-            data['rating']['imdb'] = NonEmptyDict()
+            data['rating']['imdb'] = {}
             data['rating']['imdb']['rating'] = self.imdb_rating
             data['rating']['imdb']['votes'] = self.imdb_votes
 
         data['classification'] = self.imdb_certificates
-        data['cache'] = NonEmptyDict()
+        data['cache'] = {}
         data['cache']['poster'] = self.poster
         data['cache']['banner'] = self.banner
         data['countries'] = self.countries  # e.g. ['ITALY', 'FRANCE']
         data['country_codes'] = self.imdb_countries  # e.g. ['it', 'fr']
         data['plot'] = self.plot or self.imdb_plot
-        data['config'] = NonEmptyDict()
+        data['config'] = {}
         data['config']['location'] = self.raw_location
-        data['config']['qualities'] = NonEmptyDict()
+        data['config']['qualities'] = {}
         data['config']['qualities']['allowed'] = self.qualities_allowed
         data['config']['qualities']['preferred'] = self.qualities_preferred
         data['config']['paused'] = bool(self.paused)
@@ -2006,7 +2005,7 @@ class Series(TV):
         data['config']['paused'] = bool(self.paused)
         data['config']['defaultEpisodeStatus'] = self.default_ep_status_name
         data['config']['aliases'] = list(self.aliases)
-        data['config']['release'] = NonEmptyDict()
+        data['config']['release'] = {}
         # These are for now considered anime-only options, as they query anidb for available release groups.
         if self.is_anime:
             data['config']['release']['blacklist'] = bw_list.blacklist


### PR DESCRIPTION
Fixes #4633

See: https://github.com/pymedusa/Medusa/issues/4633#issuecomment-408007736 for the explanation.
In short, it affected users with timezones smaller than UTC.

Changelog updated in #4756 