### PR TITLE
Remove keys from config object.

### DIFF
--- a/themes-default/slim/views/config_postProcessing.mako
+++ b/themes-default/slim/views/config_postProcessing.mako
@@ -124,14 +124,22 @@ window.app = new Vue({
             // Disable the save button until we're done.
             this.saving = true;
 
-            let config = {
+            const config = {
                 postProcessing: this.postProcessing,
                 metadata: {
                     metadataProviders: this.metadataProviders
                 }
             };
 
-            $store.dispatch('setConfig', {section: 'main', config: config}).then(() => {
+            // Clone the config into a new object
+            let configCopy = Object.assign({}, config);
+
+            // Use destructuring to remove the unwanted keys.
+            const { multiEpStrings, reflinkAvailable, ...rest} = configCopy.postProcessing
+            // Assign the object with the keys removed to our copied object.
+            configCopy.postProcessing = rest;
+
+            $store.dispatch('setConfig', {section: 'main', config: configCopy}).then(() => {
                 this.$snotify.success('Saved postprocessing config', 'Saved', { timeout: 5000 });
             }).catch(error => {
                 this.$snotify.error(

--- a/themes/dark/templates/config_postProcessing.mako
+++ b/themes/dark/templates/config_postProcessing.mako
@@ -124,14 +124,22 @@ window.app = new Vue({
             // Disable the save button until we're done.
             this.saving = true;
 
-            let config = {
+            const config = {
                 postProcessing: this.postProcessing,
                 metadata: {
                     metadataProviders: this.metadataProviders
                 }
             };
 
-            $store.dispatch('setConfig', {section: 'main', config: config}).then(() => {
+            // Clone the config into a new object
+            let configCopy = Object.assign({}, config);
+
+            // Use destructuring to remove the unwanted keys.
+            const { multiEpStrings, reflinkAvailable, ...rest} = configCopy.postProcessing
+            // Assign the object with the keys removed to our copied object.
+            configCopy.postProcessing = rest;
+
+            $store.dispatch('setConfig', {section: 'main', config: configCopy}).then(() => {
                 this.$snotify.success('Saved postprocessing config', 'Saved', { timeout: 5000 });
             }).catch(error => {
                 this.$snotify.error(

--- a/themes/light/templates/config_postProcessing.mako
+++ b/themes/light/templates/config_postProcessing.mako
@@ -124,14 +124,22 @@ window.app = new Vue({
             // Disable the save button until we're done.
             this.saving = true;
 
-            let config = {
+            const config = {
                 postProcessing: this.postProcessing,
                 metadata: {
                     metadataProviders: this.metadataProviders
                 }
             };
 
-            $store.dispatch('setConfig', {section: 'main', config: config}).then(() => {
+            // Clone the config into a new object
+            let configCopy = Object.assign({}, config);
+
+            // Use destructuring to remove the unwanted keys.
+            const { multiEpStrings, reflinkAvailable, ...rest} = configCopy.postProcessing
+            // Assign the object with the keys removed to our copied object.
+            configCopy.postProcessing = rest;
+
+            $store.dispatch('setConfig', {section: 'main', config: configCopy}).then(() => {
                 this.$snotify.success('Saved postprocessing config', 'Saved', { timeout: 5000 });
             }).catch(error => {
                 this.$snotify.error(


### PR DESCRIPTION
We don't want to patch all the fields that are provided by the api. Therefor these keys are removed just before the patch call is send.
Using destructuring because we don't want to remove the key from the vue data object.

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This will remove some api warnings, when saving config_postProcessing.
