### PR TITLE
Yarn: default to adding with a pinned version

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+--add.exact true

--- a/themes-default/slim/.yarnrc
+++ b/themes-default/slim/.yarnrc
@@ -1,0 +1,1 @@
+--add.exact true


### PR DESCRIPTION
Small QoL thing.
https://yarnpkg.com/en/docs/yarnrc#toc-cli-arguments

Override using: `--no-default-rc`

It's not needed in `themes-default/slim` if it's added to the root folder,
but if the themes are split from Medusa at a later date it would need the file.