### PR TITLE
Revert "Travis: Allow Dredd tests to fail"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,6 @@ before_install:
 install: false
 script: false
 jobs:
-  fast_finish: true
-  allow_failures:
-    - name: 'Dredd tests'
   include:
     # test stage + frontend tests start here
     - stage: test


### PR DESCRIPTION
This *partially* reverts commit e2e5ab62f2e5d71f364c7ca16320dd9d179df580.
Related to #4768

Don't think it's needed anymore.