### PR TITLE
Fix config being loaded twice for pages using the main app

### DIFF
--- a/themes-default/slim/src/components/login.vue
+++ b/themes-default/slim/src/components/login.vue
@@ -14,10 +14,7 @@
 
 <script>
 module.exports = {
-    name: 'login',
-    mounted() {
-        this.$root.$emit('loaded');
-    }
+    name: 'login'
 };
 </script>
 

--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -142,10 +142,13 @@
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
-                    return {
-                        globalLoading: true,
-                        pageComponent: false
-                    };
+                    // These are only needed for the root Vue
+                    if (this.$root === this) {
+                        return {
+                            globalLoading: true,
+                            pageComponent: false
+                        };
+                    }
                 },
                 mounted() {
                     if (this.$root === this && !document.location.pathname.includes('/login')) {
@@ -157,7 +160,7 @@
                     }
 
                     this.$once('loaded', () => {
-                        this.globalLoading = false;
+                        this.$root.globalLoading = false;
                     });
                 },
                 // Make auth and config accessible to all components

--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -140,34 +140,34 @@
             }
 
             // @TODO: Remove this before v1.0.0
-            Vue.mixin({
-                data() {
-                    // These are only needed for the root Vue
-                    if (this.$root === this) {
-                        return {
-                            globalLoading: true,
-                            pageComponent: false
-                        };
-                    }
-                },
-                mounted() {
-                    if (this.$root === this && !document.location.pathname.includes('/login')) {
-                        const { store, username } = window;
-                        /* This is used by the `app-header` component
-                           to only show the logout button if a username is set */
-                        store.dispatch('login', { username });
-                        store.dispatch('getConfig').then(() => this.$emit('loaded'));
-                    }
-
-                    this.$once('loaded', () => {
-                        this.$root.globalLoading = false;
-                    });
-                },
-                // Make auth and config accessible to all components
-                computed: Vuex.mapState(['auth', 'config'])
-            });
-
             if (!window.loadMainApp) {
+                Vue.mixin({
+                    data() {
+                        // These are only needed for the root Vue
+                        if (this.$root === this) {
+                            return {
+                                globalLoading: true,
+                                pageComponent: false
+                            };
+                        }
+                    },
+                    mounted() {
+                        if (this.$root === this && !document.location.pathname.includes('/login')) {
+                            const { store, username } = window;
+                            /* This is used by the `app-header` component
+                            to only show the logout button if a username is set */
+                            store.dispatch('login', { username });
+                            store.dispatch('getConfig').then(() => this.$emit('loaded'));
+                        }
+
+                        this.$once('loaded', () => {
+                            this.$root.globalLoading = false;
+                        });
+                    },
+                    // Make auth and config accessible to all components
+                    computed: Vuex.mapState(['auth', 'config'])
+                });
+
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }

--- a/themes-default/slim/views/layouts/main.mako
+++ b/themes-default/slim/views/layouts/main.mako
@@ -134,6 +134,11 @@
         <%include file="/vue-components/sub-menu.mako"/>
         <%include file="/vue-components/quality-chooser.mako"/>
         <script>
+            if ('${bool(app.DEVELOPER)}' === 'True') {
+                Vue.config.devtools = true;
+                Vue.config.performance = true;
+            }
+
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
@@ -159,23 +164,17 @@
                 computed: Vuex.mapState(['auth', 'config'])
             });
 
-            window.routes = [];
-            if ('${bool(app.DEVELOPER)}' === 'True') {
-                Vue.config.devtools = true;
-                Vue.config.performance = true;
-            }
-        </script>
-        <script>
             if (!window.loadMainApp) {
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }
+
                 Vue.use(Vuex);
                 Vue.use(VueRouter);
                 Vue.use(AsyncComputed);
                 Vue.use(VueMeta);
 
-                // Load x-template components
+                // Register components
                 window.components.forEach(component => {
                     if (window.isDevelopment) {
                         console.log('Registering ' + component.name);

--- a/themes/dark/assets/js/vendors.js
+++ b/themes/dark/assets/js/vendors.js
@@ -652,7 +652,7 @@ eval("/* WEBPACK VAR INJECTION */(function($) {\n\n//\n//\n//\n\nmodule.exports 
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\n\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n\nmodule.exports = {\n    name: 'login',\n    mounted: function mounted() {\n        this.$root.$emit('loaded');\n    }\n};\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options");
+eval("\n\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n\nmodule.exports = {\n    name: 'login'\n};\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options");
 
 /***/ }),
 
@@ -1092,7 +1092,7 @@ eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-loader/lib/css-base.js */ \"./node_modules/css-loader/lib/css-base.js\")(false);\n// imports\n\n\n// module\nexports.push([module.i, \"\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n/* placeholder */\\n\", \"\"]);\n\n// exports\n\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/css-loader!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/vue-loader/lib??vue-loader-options");
+eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-loader/lib/css-base.js */ \"./node_modules/css-loader/lib/css-base.js\")(false);\n// imports\n\n\n// module\nexports.push([module.i, \"\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n/* placeholder */\\n\", \"\"]);\n\n// exports\n\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/css-loader!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/vue-loader/lib??vue-loader-options");
 
 /***/ }),
 

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -142,10 +142,13 @@
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
-                    return {
-                        globalLoading: true,
-                        pageComponent: false
-                    };
+                    // These are only needed for the root Vue
+                    if (this.$root === this) {
+                        return {
+                            globalLoading: true,
+                            pageComponent: false
+                        };
+                    }
                 },
                 mounted() {
                     if (this.$root === this && !document.location.pathname.includes('/login')) {
@@ -157,7 +160,7 @@
                     }
 
                     this.$once('loaded', () => {
-                        this.globalLoading = false;
+                        this.$root.globalLoading = false;
                     });
                 },
                 // Make auth and config accessible to all components

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -140,34 +140,34 @@
             }
 
             // @TODO: Remove this before v1.0.0
-            Vue.mixin({
-                data() {
-                    // These are only needed for the root Vue
-                    if (this.$root === this) {
-                        return {
-                            globalLoading: true,
-                            pageComponent: false
-                        };
-                    }
-                },
-                mounted() {
-                    if (this.$root === this && !document.location.pathname.includes('/login')) {
-                        const { store, username } = window;
-                        /* This is used by the `app-header` component
-                           to only show the logout button if a username is set */
-                        store.dispatch('login', { username });
-                        store.dispatch('getConfig').then(() => this.$emit('loaded'));
-                    }
-
-                    this.$once('loaded', () => {
-                        this.$root.globalLoading = false;
-                    });
-                },
-                // Make auth and config accessible to all components
-                computed: Vuex.mapState(['auth', 'config'])
-            });
-
             if (!window.loadMainApp) {
+                Vue.mixin({
+                    data() {
+                        // These are only needed for the root Vue
+                        if (this.$root === this) {
+                            return {
+                                globalLoading: true,
+                                pageComponent: false
+                            };
+                        }
+                    },
+                    mounted() {
+                        if (this.$root === this && !document.location.pathname.includes('/login')) {
+                            const { store, username } = window;
+                            /* This is used by the `app-header` component
+                            to only show the logout button if a username is set */
+                            store.dispatch('login', { username });
+                            store.dispatch('getConfig').then(() => this.$emit('loaded'));
+                        }
+
+                        this.$once('loaded', () => {
+                            this.$root.globalLoading = false;
+                        });
+                    },
+                    // Make auth and config accessible to all components
+                    computed: Vuex.mapState(['auth', 'config'])
+                });
+
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }

--- a/themes/dark/templates/layouts/main.mako
+++ b/themes/dark/templates/layouts/main.mako
@@ -134,6 +134,11 @@
         <%include file="/vue-components/sub-menu.mako"/>
         <%include file="/vue-components/quality-chooser.mako"/>
         <script>
+            if ('${bool(app.DEVELOPER)}' === 'True') {
+                Vue.config.devtools = true;
+                Vue.config.performance = true;
+            }
+
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
@@ -159,23 +164,17 @@
                 computed: Vuex.mapState(['auth', 'config'])
             });
 
-            window.routes = [];
-            if ('${bool(app.DEVELOPER)}' === 'True') {
-                Vue.config.devtools = true;
-                Vue.config.performance = true;
-            }
-        </script>
-        <script>
             if (!window.loadMainApp) {
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }
+
                 Vue.use(Vuex);
                 Vue.use(VueRouter);
                 Vue.use(AsyncComputed);
                 Vue.use(VueMeta);
 
-                // Load x-template components
+                // Register components
                 window.components.forEach(component => {
                     if (window.isDevelopment) {
                         console.log('Registering ' + component.name);

--- a/themes/light/assets/js/vendors.js
+++ b/themes/light/assets/js/vendors.js
@@ -652,7 +652,7 @@ eval("/* WEBPACK VAR INJECTION */(function($) {\n\n//\n//\n//\n\nmodule.exports 
 /***/ (function(module, exports, __webpack_require__) {
 
 "use strict";
-eval("\n\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n\nmodule.exports = {\n    name: 'login',\n    mounted: function mounted() {\n        this.$root.$emit('loaded');\n    }\n};\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options");
+eval("\n\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n//\n\nmodule.exports = {\n    name: 'login'\n};\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/babel-loader/lib!./node_modules/vue-loader/lib??vue-loader-options");
 
 /***/ }),
 
@@ -1092,7 +1092,7 @@ eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-
 /*! no static exports found */
 /***/ (function(module, exports, __webpack_require__) {
 
-eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-loader/lib/css-base.js */ \"./node_modules/css-loader/lib/css-base.js\")(false);\n// imports\n\n\n// module\nexports.push([module.i, \"\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n/* placeholder */\\n\", \"\"]);\n\n// exports\n\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/css-loader!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/vue-loader/lib??vue-loader-options");
+eval("exports = module.exports = __webpack_require__(/*! ../../node_modules/css-loader/lib/css-base.js */ \"./node_modules/css-loader/lib/css-base.js\")(false);\n// imports\n\n\n// module\nexports.push([module.i, \"\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n\\n/* placeholder */\\n\", \"\"]);\n\n// exports\n\n\n//# sourceURL=webpack:///./src/components/login.vue?./node_modules/css-loader!./node_modules/vue-loader/lib/loaders/stylePostLoader.js!./node_modules/vue-loader/lib??vue-loader-options");
 
 /***/ }),
 

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -142,10 +142,13 @@
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
-                    return {
-                        globalLoading: true,
-                        pageComponent: false
-                    };
+                    // These are only needed for the root Vue
+                    if (this.$root === this) {
+                        return {
+                            globalLoading: true,
+                            pageComponent: false
+                        };
+                    }
                 },
                 mounted() {
                     if (this.$root === this && !document.location.pathname.includes('/login')) {
@@ -157,7 +160,7 @@
                     }
 
                     this.$once('loaded', () => {
-                        this.globalLoading = false;
+                        this.$root.globalLoading = false;
                     });
                 },
                 // Make auth and config accessible to all components

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -140,34 +140,34 @@
             }
 
             // @TODO: Remove this before v1.0.0
-            Vue.mixin({
-                data() {
-                    // These are only needed for the root Vue
-                    if (this.$root === this) {
-                        return {
-                            globalLoading: true,
-                            pageComponent: false
-                        };
-                    }
-                },
-                mounted() {
-                    if (this.$root === this && !document.location.pathname.includes('/login')) {
-                        const { store, username } = window;
-                        /* This is used by the `app-header` component
-                           to only show the logout button if a username is set */
-                        store.dispatch('login', { username });
-                        store.dispatch('getConfig').then(() => this.$emit('loaded'));
-                    }
-
-                    this.$once('loaded', () => {
-                        this.$root.globalLoading = false;
-                    });
-                },
-                // Make auth and config accessible to all components
-                computed: Vuex.mapState(['auth', 'config'])
-            });
-
             if (!window.loadMainApp) {
+                Vue.mixin({
+                    data() {
+                        // These are only needed for the root Vue
+                        if (this.$root === this) {
+                            return {
+                                globalLoading: true,
+                                pageComponent: false
+                            };
+                        }
+                    },
+                    mounted() {
+                        if (this.$root === this && !document.location.pathname.includes('/login')) {
+                            const { store, username } = window;
+                            /* This is used by the `app-header` component
+                            to only show the logout button if a username is set */
+                            store.dispatch('login', { username });
+                            store.dispatch('getConfig').then(() => this.$emit('loaded'));
+                        }
+
+                        this.$once('loaded', () => {
+                            this.$root.globalLoading = false;
+                        });
+                    },
+                    // Make auth and config accessible to all components
+                    computed: Vuex.mapState(['auth', 'config'])
+                });
+
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }

--- a/themes/light/templates/layouts/main.mako
+++ b/themes/light/templates/layouts/main.mako
@@ -134,6 +134,11 @@
         <%include file="/vue-components/sub-menu.mako"/>
         <%include file="/vue-components/quality-chooser.mako"/>
         <script>
+            if ('${bool(app.DEVELOPER)}' === 'True') {
+                Vue.config.devtools = true;
+                Vue.config.performance = true;
+            }
+
             // @TODO: Remove this before v1.0.0
             Vue.mixin({
                 data() {
@@ -159,23 +164,17 @@
                 computed: Vuex.mapState(['auth', 'config'])
             });
 
-            window.routes = [];
-            if ('${bool(app.DEVELOPER)}' === 'True') {
-                Vue.config.devtools = true;
-                Vue.config.performance = true;
-            }
-        </script>
-        <script>
             if (!window.loadMainApp) {
                 if (window.isDevelopment) {
                     console.debug('Loading local Vue');
                 }
+
                 Vue.use(Vuex);
                 Vue.use(VueRouter);
                 Vue.use(AsyncComputed);
                 Vue.use(VueMeta);
 
-                // Load x-template components
+                // Register components
                 window.components.forEach(component => {
                     if (window.isDevelopment) {
                         console.log('Registering ' + component.name);


### PR DESCRIPTION
- Fix config being loaded twice for pages using the main app
- Remove unnecessary code from `login.vue` (Confirmed it's working without it)
- Reorganize `main.mako`
- Fix mixin scope to only the root Vue
  This fixes the `pageComponent` and `globalLoading` data being added to **every** component.
  It will now only add them to the root instance.
  ### Before:
  ![chrome_2018-08-20_13-07-57](https://user-images.githubusercontent.com/10238474/44335627-bb987c00-a47d-11e8-9ff8-534f288d783d.png)
  ### After:
  ![chrome_2018-08-20_13-08-40](https://user-images.githubusercontent.com/10238474/44335631-bf2c0300-a47d-11e8-98b6-c8fd16c814d2.png)  ![image](https://user-images.githubusercontent.com/10238474/44336188-580f4e00-a47f-11e8-94a9-503abe4aa7d5.png)
