### PR TITLE
Avoid Yggtorrent warning on first auth check

### DIFF
--- a/medusa/providers/torrent/html/yggtorrent.py
+++ b/medusa/providers/torrent/html/yggtorrent.py
@@ -177,8 +177,12 @@ class YggtorrentProvider(TorrentProvider):
         if not self._is_authenticated():
             login_url = self.get_redirect_url(self.urls['login'])
             login_resp = self.session.post(login_url, data=login_params)
-            if not login_resp or not self._is_authenticated():
+            if not login_resp:
                 log.warning('Invalid username or password. Check your settings')
+                return False
+
+            if not self._is_authenticated():
+                log.warning('Unable to connect or login to provider')
                 return False
 
         return True
@@ -186,7 +190,6 @@ class YggtorrentProvider(TorrentProvider):
     def _is_authenticated(self):
         response = self.session.get(self.urls['auth'])
         if not response:
-            log.warning('Unable to connect or login to provider')
             return False
 
         return True


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

It would otherwise show `Unable to connect or login to provider` on the very first login check as well.