### PR TITLE
Only check for scene_exception when series_name is known.

### DIFF
--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -199,7 +199,8 @@ class NameParser(object):
                 #
                 # Don't assume that scene_exceptions season is the same as indexer season.
                 # E.g.: [HorribleSubs] Cardcaptor Sakura Clear Card - 08 [720p].mkv thetvdb s04, thexem s02
-                if result.series.is_scene or (result.season_number is None and scene_season > 0):
+                if result.series.is_scene or (result.season_number is None and
+                                              scene_season is not None and scene_season > 0):
                     a = scene_numbering.get_indexer_absolute_numbering(
                         result.series, absolute_episode, True, scene_season
                     )
@@ -207,7 +208,7 @@ class NameParser(object):
                 # Translate the absolute episode number, back to the indexers season and episode.
                 (season, episode) = helpers.get_all_episodes_from_absolute_number(result.series, [a])
 
-                if result.season_number is None and scene_season > 0:
+                if result.season_number is None and scene_season is not None and scene_season > 0:
                     log.debug(
                         'Detected a season scene exception [{series_name} -> {scene_season}] without a '
                         'season number in the title, '

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -186,7 +186,8 @@ class NameParser(object):
         # "diamond is unbreakable" exception back to season 4 of it's "master" table. This will be used later
         # to translate it to an absolute number, which in turn can be translated to an indexer SxEx.
         # For example Diamond is unbreakable - 26 -> Season 4 -> Absolute number 100 -> tvdb S03E26
-        scene_season = scene_exceptions.get_scene_exceptions_by_name(result.series_name)[0][1]
+        scene_season = scene_exceptions.get_scene_exceptions_by_name(
+            result.series_name or result.series.name)[0][1]
 
         if result.ab_episode_numbers:
             for absolute_episode in result.ab_episode_numbers:

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -141,9 +141,7 @@ def get_scene_exceptions_by_name(show_name):
     # TODO: Make the query more linient. For example. `Jojo's Bizarre Adventure Stardust Crusaders` will not match
     # while `Jojo's Bizarre Adventure - Stardust Crusaders` is available.
     if show_name is None:
-        logger.debug(
-            'Scene exception lookup failed because no show name was provided'
-        )
+        logger.debug('Scene exception lookup failed because no show name was provided')
         return [(None, None, None)]
 
     # Try the obvious case first

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -170,7 +170,7 @@ def get_scene_exceptions_by_name(show_name):
             sanitized_name.lower().replace('.', ' '),
         )
 
-        if show_name.lower() in show_names:
+        if show_name and show_name.lower() in show_names:
             logger.debug(
                 'Scene exception lookup got indexer ID {cur_indexer},'
                 ' using that', cur_indexer=indexer_id

--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -140,6 +140,12 @@ def get_scene_exceptions_by_name(show_name):
     # TODO: Rewrite to use exceptions_cache since there is no need to hit db.
     # TODO: Make the query more linient. For example. `Jojo's Bizarre Adventure Stardust Crusaders` will not match
     # while `Jojo's Bizarre Adventure - Stardust Crusaders` is available.
+    if show_name is None:
+        logger.debug(
+            'Scene exception lookup failed because no show name was provided'
+        )
+        return [(None, None, None)]
+
     # Try the obvious case first
     cache_db_con = db.DBConnection('cache.db')
     scene_exceptions = cache_db_con.select(
@@ -170,7 +176,7 @@ def get_scene_exceptions_by_name(show_name):
             sanitized_name.lower().replace('.', ' '),
         )
 
-        if show_name and show_name.lower() in show_names:
+        if show_name.lower() in show_names:
             logger.debug(
                 'Scene exception lookup got indexer ID {cur_indexer},'
                 ' using that', cur_indexer=indexer_id


### PR DESCRIPTION
When parsing an episode like Lupin III/Season 02/S2E22.mkv, it will parse it in two goes.
First attempt parsing `Lupin III/Season 02/S2E22.mkv` and then `S2E22.mkv`. The second parse, cannot resolve it to a series name.
And therefor the scene_exceptions call resulted in an exception.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Should fix #4941
@medariox can you double check the solution?

Alternative could be changing to
`scene_season = scene_exceptions.get_scene_exceptions_by_name(result.series_name or result.series.name)[0][1]`
in parser.py:L189