### PR TITLE
Fix test email notification with TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fixed UI not loading using edge browser, when using a reverse proxy (without an alternative port) ([#4928](https://github.com/pymedusa/Medusa/pull/4928))
 - Fixed episode lookup with conflicting show IDs ([#4933](https://github.com/pymedusa/Medusa/pull/4933))
 - Fixed error getting season scene exceptions on show page [#4964](https://github.com/pymedusa/Medusa/pull/4964)
+- Fixed testing email notification with TLS ([#4972](https://github.com/pymedusa/Medusa/pull/4972))
 
 -----
 

--- a/themes-default/slim/static/js/config/notifications.js
+++ b/themes-default/slim/static/js/config/notifications.js
@@ -472,7 +472,7 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
         host = host.length > 0 ? host : null;
         let port = $('#email_port').val();
         port = port.length > 0 ? port : null;
-        const tls = $('#email_tls').attr('checked') === undefined ? 0 : 1;
+        const tls = $('#email_tls').is(':checked') ? 1 : 0;
         let from = $('#email_from').val();
         from = from.length > 0 ? from : 'root@localhost';
         const user = $('#email_user').val().trim();

--- a/themes/dark/assets/js/config/notifications.js
+++ b/themes/dark/assets/js/config/notifications.js
@@ -472,7 +472,7 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
         host = host.length > 0 ? host : null;
         let port = $('#email_port').val();
         port = port.length > 0 ? port : null;
-        const tls = $('#email_tls').attr('checked') === undefined ? 0 : 1;
+        const tls = $('#email_tls').is(':checked') ? 1 : 0;
         let from = $('#email_from').val();
         from = from.length > 0 ? from : 'root@localhost';
         const user = $('#email_user').val().trim();

--- a/themes/light/assets/js/config/notifications.js
+++ b/themes/light/assets/js/config/notifications.js
@@ -472,7 +472,7 @@ MEDUSA.config.notifications = function() { // eslint-disable-line max-lines
         host = host.length > 0 ? host : null;
         let port = $('#email_port').val();
         port = port.length > 0 ? port : null;
-        const tls = $('#email_tls').attr('checked') === undefined ? 0 : 1;
+        const tls = $('#email_tls').is(':checked') ? 1 : 0;
         let from = $('#email_from').val();
         from = from.length > 0 ? from : 'root@localhost';
         const user = $('#email_user').val().trim();


### PR DESCRIPTION
Test email notification is not working. I tested with 2 email providers `inbox.ru` and `gmail.com`
Both email provides requires SSL for SMTP connections. I'm always getting this message:
```
ERROR: SMTP AUTH extension not supported by server.
```
I found that the problem is in the UI, the TLS checkbox is always sent as 0.
