### PR TITLE
Remove babel group from renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,14 +25,6 @@
           "@vue/test-utils"
         ],
         "groupName": "vue-base"
-      },
-      {
-        "packagePatterns": [
-          "^@babel/",
-          "^babel-",
-          "-babel$"
-        ],
-        "groupName": "babel"
       }
     ]
   },


### PR DESCRIPTION
It's being handled by the official babel monorepo preset
https://git.io/fA3Fm
