### PR TITLE
Ensure show IMDB info is never None

### DIFF
--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -464,7 +464,7 @@ class Series(TV):
     def imdb_akas(self):
         """Return genres akas dict."""
         akas = {}
-        for x in [v for v in self.imdb_info.get('akas', '').split('|') if v]:
+        for x in [v for v in (self.imdb_info.get('akas') or '').split('|') if v]:
             if '::' in x:
                 val, key = x.split('::')
                 akas[key] = val
@@ -473,17 +473,17 @@ class Series(TV):
     @property
     def imdb_countries(self):
         """Return country codes."""
-        return [v for v in self.imdb_info.get('country_codes', '').split('|') if v]
+        return [v for v in (self.imdb_info.get('country_codes') or '').split('|') if v]
 
     @property
     def imdb_plot(self):
         """Return series plot."""
-        return self.imdb_info.get('plot', '')
+        return self.imdb_info.get('plot') or ''
 
     @property
     def imdb_genres(self):
         """Return series genres."""
-        return self.imdb_info.get('genres', '')
+        return self.imdb_info.get('genres') or ''
 
     @property
     def imdb_votes(self):
@@ -511,7 +511,7 @@ class Series(TV):
     @property
     def countries(self):
         """Return countries."""
-        return [v for v in self.imdb_info.get('countries', '').split('|') if v]
+        return [v for v in (self.imdb_info.get('countries') or '').split('|') if v]
 
     @property
     def genres(self):
@@ -1545,8 +1545,8 @@ class Series(TV):
                 self.imdb_info['country_codes'] = '|'.join(country_codes).lower()
 
         # Make sure these always have a value
-        self.imdb_info['countries'] = self.imdb_info.get('countries', '')
-        self.imdb_info['country_codes'] = self.imdb_info.get('country_codes', '')
+        self.imdb_info['countries'] = self.imdb_info.get('countries') or ''
+        self.imdb_info['country_codes'] = self.imdb_info.get('country_codes') or ''
 
         try:
             imdb_info = imdb_api.get_title(self.imdb_id)


### PR DESCRIPTION
Reported on Slack

```
Traceback (most recent call last):
  File "/home/pi/Medusa/ext/tornado/web.py", line 1590, in _execute
    result = method(*self.path_args, **self.path_kwargs)
  File "/home/pi/Medusa/medusa/server/api/v2/series.py", line 52, in get
    data = [s.to_json(detailed=detailed) for s in Series.find_series(predicate=filter_series)]
  File "/home/pi/Medusa/medusa/tv/series.py", line 2000, in to_json
    data['countries'] = self.countries  # e.g. ['ITALY', 'FRANCE']
  File "/home/pi/Medusa/medusa/tv/series.py", line 514, in countries
    return [v for v in self.imdb_info.get('countries', '').split('|') if v]
AttributeError: 'NoneType' object has no attribute 'split'
```