### PR TITLE
Re-add removed Scene column header

### DIFF
--- a/themes-default/slim/views/displayShow.mako
+++ b/themes-default/slim/views/displayShow.mako
@@ -69,6 +69,7 @@
                         <th data-sorter="false" class="col-metadata">TBN</th>
                         <th data-sorter="false" class="col-ep">Episode</th>
                         <th data-sorter="false" :class="['col-ep', { 'columnSelector-false': !show.config.anime }]">Absolute</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
                         <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
                         <th data-sorter="false" class="col-name">Name</th>
                         <th data-sorter="false" class="col-name columnSelector-false">File Name</th>

--- a/themes/dark/templates/displayShow.mako
+++ b/themes/dark/templates/displayShow.mako
@@ -69,6 +69,7 @@
                         <th data-sorter="false" class="col-metadata">TBN</th>
                         <th data-sorter="false" class="col-ep">Episode</th>
                         <th data-sorter="false" :class="['col-ep', { 'columnSelector-false': !show.config.anime }]">Absolute</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
                         <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
                         <th data-sorter="false" class="col-name">Name</th>
                         <th data-sorter="false" class="col-name columnSelector-false">File Name</th>

--- a/themes/light/templates/displayShow.mako
+++ b/themes/light/templates/displayShow.mako
@@ -69,6 +69,7 @@
                         <th data-sorter="false" class="col-metadata">TBN</th>
                         <th data-sorter="false" class="col-ep">Episode</th>
                         <th data-sorter="false" :class="['col-ep', { 'columnSelector-false': !show.config.anime }]">Absolute</th>
+                        <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene)]}>Scene</th>
                         <th data-sorter="false" ${("class=\"col-ep columnSelector-false\"", "class=\"col-ep\"")[bool(scene_anime)]}>Scene Absolute</th>
                         <th data-sorter="false" class="col-name">Name</th>
                         <th data-sorter="false" class="col-name columnSelector-false">File Name</th>


### PR DESCRIPTION
Fixes:
> #4888 introduced a bug on displayShow, the `Column Selector` dropdown doesn't have the `Scene` column in it and it's causing incorrect columns to be hidden