### PR TITLE
Fix Scene release group E7 match confused with episode.

### DIFF
--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -25,6 +25,9 @@ expected_groups = [
 
     # The.Good.Wife.Season.6.480p.HDTV.H264-20-40.WEB-DL
     '20-40',
+
+    # Scene release group confused with episode.
+    'E7',
 ]
 
 allowed_languages = [


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Before:
```
# guessit: 3.0.0  rebulk: 0.9.0
? Law.and.Order.S18E18.HDTV.XviD-E7
: title: Law and Order
  season: 18
  episode: [18, 7]
  source: HDTV
  video_codec: Xvid
  type: episode
  parsing_time: 0.281111001968
```
After:
```
guessit "Law.and.Order.S18E18.HDTV.XviD-E7" -G "E7"
For: Law.and.Order.S18E18.HDTV.XviD-E7
GuessIt found: {
    "title": "Law and Order",
    "season": 18,
    "episode": 18,
    "source": "HDTV",
    "video_codec": "Xvid",
    "release_group": "E7",
    "type": "episode"
}
```

Other examples:
```
guessit "Bones.S03E12.REPACK.HDTV.XviD-E7" -G "E7"
For: Bones.S03E12.REPACK.HDTV.XviD-E7
GuessIt found: {
    "title": "Bones",
    "season": 3,
    "episode": 12,
    "other": "Proper",
    "proper_count": 1,
    "source": "HDTV",
    "video_codec": "Xvid",
    "release_group": "E7",
    "type": "episode"
}
```
And with filename
```
For: e7-bones.s03e12.720p-x264.mkv
GuessIt found: {
    "release_group": "E7",
    "title": "bones",
    "season": 3,
    "episode": 12,
    "screen_size": "720p",
    "video_codec": "H.264",
    "container": "mkv",
    "mimetype": "video/x-matroska",
    "type": "episode"
```

