### PR TITLE
CI: Test on Python 3.6

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -48,7 +48,8 @@ coverage:
         if_ci_failed: failure
       backend:
         flags:
-          - backend
+          - backend_py27
+          - backend_py36
         target: 0%
         threshold: 5.0%
         if_no_uploads: error

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ before_install:
 install: false
 script: false
 jobs:
+  fast_finish: true
+  allow_failures:
+    - python: '3.6'
   include:
     # test stage + frontend tests start here
     - stage: test
@@ -30,19 +33,44 @@ jobs:
         - yarn lint-css
         - yarn test
         - yarn coverage
-    # backend tests start here
-    - name: 'Backend tests'
-      python:
-        - 2.7.10
+    # backend tests (py2.7) start here
+    - name: 'Backend tests (py2.7)'
+      python: '2.7.10'
+      env:
+        - TOXENV=py27,lint
       install:
         - pip install --upgrade pip
         - pip install --upgrade tox
       script:
         - tox -v --recreate
-    # dredd tests start here
-    - name: 'Dredd tests'
-      python:
-        - 2.7.10
+    # backend tests (py3.6) start here
+    - name: 'Backend tests (py3.6)'
+      python: '3.6'
+      env:
+        - TOXENV=py36
+      install:
+        - pip install --upgrade pip
+        - pip install --upgrade tox
+      script:
+        - tox -v --recreate
+    # dredd tests (py2.7) start here
+    - name: 'Dredd tests (py2.7)'
+      python: '2.7.10'
+      install:
+        - pip install --upgrade pip
+        - pip install dredd_hooks
+        - pip install 'PyYAML<4'
+        - pip install six
+        - nvm install v10.7.0
+        - 'curl -o- -L https://yarnpkg.com/install.sh | bash'
+        - 'export PATH="$HOME/.yarn/bin:$PATH" && yarn install --ignore-scripts'
+      script:
+        - yarn test-api
+      after_failure:
+        - cat ./dredd/data/Logs/application.log
+    # dredd tests (py3.6) start here
+    - name: 'Dredd tests (py3.6)'
+      python: '3.6'
       install:
         - pip install --upgrade pip
         - pip install dredd_hooks

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,20 +69,21 @@ jobs:
       after_failure:
         - cat ./dredd/data/Logs/application.log
     # dredd tests (py3.6) start here
-    - name: 'Dredd tests (py3.6)'
-      python: '3.6'
-      install:
-        - pip install --upgrade pip
-        - pip install dredd_hooks
-        - pip install 'PyYAML<4'
-        - pip install six
-        - nvm install v10.7.0
-        - 'curl -o- -L https://yarnpkg.com/install.sh | bash'
-        - 'export PATH="$HOME/.yarn/bin:$PATH" && yarn install --ignore-scripts'
-      script:
-        - yarn test-api
-      after_failure:
-        - cat ./dredd/data/Logs/application.log
+    # @FIXME: Disabled because they take too long. Enable when Medusa can *actually* start on Python 3.
+    # - name: 'Dredd tests (py3.6)'
+    #   python: '3.6'
+    #   install:
+    #     - pip install --upgrade pip
+    #     - pip install dredd_hooks
+    #     - pip install 'PyYAML<4'
+    #     - pip install six
+    #     - nvm install v10.7.0
+    #     - 'curl -o- -L https://yarnpkg.com/install.sh | bash'
+    #     - 'export PATH="$HOME/.yarn/bin:$PATH" && yarn install --ignore-scripts'
+    #   script:
+    #     - yarn test-api
+    #   after_failure:
+    #     - cat ./dredd/data/Logs/application.log
 notifications:
   slack:
     secure: >-

--- a/dredd/dredd_hook.py
+++ b/dredd/dredd_hook.py
@@ -1,16 +1,20 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
+# coding=utf-8
 """Dredd hook."""
 from __future__ import absolute_import
+from __future__ import print_function
+from __future__ import unicode_literals
 
-import ConfigParser
+import io
 import json
-import urlparse
 from collections import Mapping
-from urllib import urlencode
 
 import dredd_hooks as hooks
 
+import six
 from six import string_types
+from six.moves.configparser import RawConfigParser
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 import yaml
 
@@ -28,7 +32,7 @@ stash = {
 def load_api_description(transactions):
     """Load api description."""
     global api_description
-    with open(transactions[0]['origin']['filename'], 'r') as stream:
+    with io.open(transactions[0]['origin']['filename'], 'rb') as stream:
         api_description = yaml.safe_load(stream)
 
 
@@ -65,8 +69,8 @@ def configure_transaction(transaction):
 
     # Change request based on x-request configuration
     url = transaction['fullPath']
-    parsed_url = urlparse.urlparse(url)
-    parsed_params = urlparse.parse_qs(parsed_url.query)
+    parsed_url = urlparse(url)
+    parsed_params = parse_qs(parsed_url.query)
     parsed_path = parsed_url.path
 
     request = response.get('x-request', {})
@@ -159,13 +163,13 @@ def start():
 
     os.makedirs(data_dir)
     os.chdir(data_dir)
-    config = ConfigParser.RawConfigParser()
+    config = RawConfigParser()
     config.read('config.ini')
     config.add_section('General')
     config.set('General', 'web_username', stash['web-username'])
     config.set('General', 'web_password', stash['web-password'])
     config.set('General', 'api_key', stash['api-key'])
-    with open('config.ini', 'wb') as configfile:
+    with io.open('config.ini', 'w' if six.PY3 else 'wb') as configfile:
         config.write(configfile)
 
     sys.path.insert(1, app_dir)

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
 skipsdist = true
-envlist = py27,lint
+envlist =
+    py{27,36}
+    lint
 
-[testenv:py27]
+[testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_*
 
 deps = codecov
 
 commands =
     python setup.py test -a "tests --cov=medusa"
-    codecov -e TOXENV -F backend
+    codecov -e TOXENV -F backend_{envname}
 
 [testenv:lint]
 commands =


### PR DESCRIPTION
Runs pytest tests on Python 3.6.
Dredd tests disabled for now, because they take too long (13 minutes ... to fail).
Re enable them when Medusa can *actually* start on Python 3.