### PR TITLE
Add py2 and py3 columns to get overview in the py2/py3 support for ou…

### DIFF
--- a/ext/readme.md
+++ b/ext/readme.md
@@ -1,64 +1,64 @@
 ## ext
  Status  |  Package  |  Version / Commit  | Usage | py2 | py3 | Notes
-:------: | :-------: | :----------------: | :---- | :-- | :-- | :----
-:: | `adba` | pymedusa/[70bc381](https://github.com/pymedusa/adba/tree/70bc381a75e20e1813c848c1edb7c6f16987397e) | **`medusa`** | v | v| -
-:: | <code><b>appdirs</b>.py</code> | [1.4.3](https://pypi.org/project/appdirs/1.4.3/) | `subliminal` (cli only), `simpleanidb` | v | v| -
-:: | `attrs` | [18.1.0](https://pypi.org/project/attrs/18.1.0/) | `imdbpie` | v | v| Module: `attr`
-:: | `babelfish` | [f403000](https://github.com/Diaoul/babelfish/tree/f403000dd63092cfaaae80be9f309fd85c7f20c9) | **`medusa`**, `guessit`, `knowit`, `subliminal` | v | v| -
-:: | <code><b>backports_abc</b>.py</code> | [0.5](https://pypi.org/project/backports_abc/0.5/) | `tornado` | v | v| Markers: `python_version < '3.5'`
-:: | `beautifulsoup4` | [4.6.3](https://pypi.org/project/beautifulsoup4/4.6.3/) | **`medusa`**, `subliminal` | v | v| Module: `bs4`
-:: | `bencode.py` | [2.0.0](https://pypi.org/project/bencode.py/2.0.0/) | **`medusa`** | v | v| Module: `bencode`
-:: | `boto` | [2.48.0](https://pypi.org/project/boto/2.48.0/) | `imdbpie` | v | v| -
-:: | `CacheControl` | [0.12.5](https://pypi.org/project/CacheControl/0.12.5/) | **`medusa`** | v | v| Module: `cachecontrol`
-:: | `certifi` | [2018.8.24](https://pypi.org/project/certifi/2018.8.24/) | **`medusa`**, `traktor`, `requests` | v | v| -
-:: | `chardet` | [3.0.4](https://pypi.org/project/chardet/3.0.4/) | **`medusa`**, `beautifulsoup4`, `feedparser`, `html5lib`, `pysrt`, `requests`, `subliminal` | v | v| -
-:: | `cloudflare-scrape` | pymedusa/[320456e](https://github.com/pymedusa/cloudflare-scrape/tree/320456e8b28cedb807363a7a892b1379db843f66) | **`medusa`** | v | v| Module: `cfscrape`
-:: | <code><b>configobj</b>.py</code><br>`validate.py`<br>`_version.py` | [5.0.6](https://pypi.org/project/configobj/5.0.6/) | **`medusa`** | v | v| -
-:: | <code><b>configparser</b>.py</code><br>`configparser.pth`<br>`backports.configparser` | [3.5.0](https://pypi.org/project/configparser/3.5.0/) | `adba` | v | v| `configparser.pth` was renamed from `configparser-3.5.0-py2.7-nspkg.pth`
-:: | <code><b>contextlib2</b>.py</code> | [0.5.5](https://pypi.org/project/contextlib2/0.5.5/) | **`medusa`**, `tvdbapiv2` | v | v| Markers: `python_version < '3.5'`
-:: | <code><b>decorator</b>.py</code> | [4.3.0](https://pypi.org/project/decorator/4.3.0/) | `validators` | v | v| -
-:: | `dirtyjson` | [1.0.7](https://pypi.org/project/dirtyjson/1.0.7/) | **`medusa`** | v | v| -
-:: | `diskcache` | [2.9.0](https://pypi.org/project/diskcache/2.9.0/) | `imdbpie` | v | v| -
-:: | `dogpile.cache` | [0.6.7](https://pypi.org/project/dogpile.cache/0.6.7/) | **`medusa`**, `subliminal` | v | v| -
-:: | `enzyme` | pymedusa/[665cf69](https://github.com/pymedusa/enzyme/tree/665cf6948aab1c249dcc99bd9624a81d17b3302a) | `knowit`, `subliminal` | v | v| -
-:: | `feedparser` | [2b11c80](https://github.com/kurtmckee/feedparser/tree/2b11c8028321ed43cbaf313f83b0c94820143d66) | **`medusa`** | v | v| Requires `sgmllib3k` on Python 3
-:: | **`future`**<br>`_dummy_thread`<br>`_markupbase`<br>`_thread`<br>`builtins`<br>`copyreg`<br>`html`<br>`http`<br>`libfuturize`<br>`libpasteurize`<br>`past`<br>`queue`<br>`reprlib`<br>`socketserver`<br>`tkinter`<br>`winreg`<br>`xmlrpc` | [0.16.0](https://pypi.org/project/future/0.16.0/) | **`medusa`**, `python-twitter`, ????? | v | v| -
-:: | `futures` | [3.2.0](https://pypi.org/project/futures/3.2.0/) | **`medusa`**, `subliminal`, `tornado` | v | v| Module: `concurrent.futures`<br>Markers: `python_version >= '2.6' and python_version < '3'`
-:: | `PyGithub` | [1.43.1](https://pypi.org/project/PyGithub/1.43.1/) | **`medusa`** | v | v| Module: `github`<br>**Removed tests**
-:: | `gntp` | [1.0.3](https://pypi.org/project/gntp/1.0.3/) | **`medusa`** | v | v| -
-:: | `guessit` | [3.0.0](https://pypi.org/project/guessit/3.0.0/) | **`medusa`**, `subliminal` | v | v| -
-:: | `html5lib` | [1.0.1](https://pypi.org/project/html5lib/1.0.1/) | **`medusa`** (via `beautifulsoup4`) | v | v| -
-:: | `idna` | [2.7](https://pypi.org/project/idna/2.7/) | `requests` | v | v| -
-:: | `imdbpie` | [5.6.2](https://pypi.org/project/imdbpie/5.6.2/) | **`medusa`** | v | v| -
-:: | `Js2Py` | [0.59](https://pypi.org/project/Js2Py/0.59/) | `cloudflare-scrape` | v | v| Module: `js2py`
-:: | `jsonrpclib-pelix` | [0.3.1](https://pypi.org/project/jsonrpclib-pelix/0.3.1/) | **`medusa`** | v | v| Module: `jsonrpclib`
-:: | `PyJWT` | [1.6.4](https://pypi.org/project/pyjwt/1.6.4/) | **`medusa`**, `PyGithub`, `tvdbapiv2` | v | v| Module: `jwt`
-:: | `knowit` | [0.2.4](https://pypi.org/project/knowit/0.2.4/) | **`medusa`** | v | v| -
-:: | `lockfile` | [0.12.2](https://pypi.org/project/lockfile/0.12.2/) | `CacheControl` | v | v| -
-:: | `Mako` | [1.0.7](https://pypi.org/project/mako/1.0.7/) | **`medusa`** | v | v| Module: `mako`
-:: | <code><b>markdown2</b>.py</code> | [2.3.5](https://pypi.org/project/markdown2/2.3.5/) | **`medusa`** | -
-:: | `MarkupSafe` | [1.0](https://pypi.org/project/MarkupSafe/1.0/) | `Mako` | v | v| Module: `markupsafe`
-:: | `msgpack` | [0.5.6](https://pypi.org/project/msgpack/0.5.6/) | `CacheControl` | v | v| -
-:: | `oauthlib` | [2.1.0](https://pypi.org/project/oauthlib/2.1.0/) | `requests-oauthlib` | v | v| -
-:: | `Pint` | [0.8.1](https://pypi.org/project/Pint/0.8.1/) | `knowit` | v | v| Module: `pint`
-:: | <code><b>profilehooks</b>.py</code> | [1.10.0](https://pypi.org/project/profilehooks/1.10.0/) | **`medusa`** | v | v| -
-:: | `pyjsparser` | [2.5.2](https://pypi.org/project/pyjsparser/2.5.2/) | `Js2Py` | v | v| -
-:: | `pysrt` | [1.1.0](https://pypi.org/project/pysrt/1.1.0/) | `subliminal` | v | v| -
-:: | `python-dateutil` | [2.7.3](https://pypi.org/project/python-dateutil/2.7.3/) | **`medusa`**, `tvdbapiv2`, `guessit`, `imdbpie` | v | v| Module: `dateutil`
-:: | `python-twitter` | [3.4.2](https://pypi.org/project/python-twitter/3.4.2/) | **`medusa`** | v | v| Module: `twitter`
-:: | `pytz` | [2018.4](https://pypi.org/project/pytz/2018.4/) | `subliminal`, `tzlocal` | v | v| -
-:: | <code><b>rarfile</b>.py</code> | [3.0](https://pypi.org/project/rarfile/3.0/) | **`medusa`**, `subliminal` | v | v| -
-:: | `rebulk` | [0.9.0](https://pypi.org/project/rebulk/0.9.0/) | **`medusa`**, `guessit` | v | v| -
-:: | `requests` | [2.19.1](https://pypi.org/project/requests/2.19.1/) | **`medusa`**, `adba`, `pytvmaze`, `simpleanidb`, `tmdbsimple`, `traktor`, `tvdbapiv2`, `boto`, `rtorrent`, `CacheControl`, `cloudflare-scrape`, `subliminal`, `PyGithub`, `python-twitter` | v | v| -
+:------: | :-------: | :----------------: | :---- | :--: | :--: | :----
+:: | `adba` | pymedusa/[70bc381](https://github.com/pymedusa/adba/tree/70bc381a75e20e1813c848c1edb7c6f16987397e) | **`medusa`** | v | v | -
+:: | <code><b>appdirs</b>.py</code> | [1.4.3](https://pypi.org/project/appdirs/1.4.3/) | `subliminal` (cli only), `simpleanidb` | v | v | -
+:: | `attrs` | [18.1.0](https://pypi.org/project/attrs/18.1.0/) | `imdbpie` | v | v | Module: `attr`
+:: | `babelfish` | [f403000](https://github.com/Diaoul/babelfish/tree/f403000dd63092cfaaae80be9f309fd85c7f20c9) | **`medusa`**, `guessit`, `knowit`, `subliminal` | v | v | -
+:: | <code><b>backports_abc</b>.py</code> | [0.5](https://pypi.org/project/backports_abc/0.5/) | `tornado` | v | v | Markers: `python_version < '3.5'`
+:: | `beautifulsoup4` | [4.6.3](https://pypi.org/project/beautifulsoup4/4.6.3/) | **`medusa`**, `subliminal` | v | v | Module: `bs4`
+:: | `bencode.py` | [2.0.0](https://pypi.org/project/bencode.py/2.0.0/) | **`medusa`** | v | v | Module: `bencode`
+:: | `boto` | [2.48.0](https://pypi.org/project/boto/2.48.0/) | `imdbpie` | v | v | -
+:: | `CacheControl` | [0.12.5](https://pypi.org/project/CacheControl/0.12.5/) | **`medusa`** | v | v | Module: `cachecontrol`
+:: | `certifi` | [2018.8.24](https://pypi.org/project/certifi/2018.8.24/) | **`medusa`**, `traktor`, `requests` | v | v | -
+:: | `chardet` | [3.0.4](https://pypi.org/project/chardet/3.0.4/) | **`medusa`**, `beautifulsoup4`, `feedparser`, `html5lib`, `pysrt`, `requests`, `subliminal` | v | v | -
+:: | `cloudflare-scrape` | pymedusa/[320456e](https://github.com/pymedusa/cloudflare-scrape/tree/320456e8b28cedb807363a7a892b1379db843f66) | **`medusa`** | v | v | Module: `cfscrape`
+:: | <code><b>configobj</b>.py</code><br>`validate.py`<br>`_version.py` | [5.0.6](https://pypi.org/project/configobj/5.0.6/) | **`medusa`** | v | v | -
+:: | <code><b>configparser</b>.py</code><br>`configparser.pth`<br>`backports.configparser` | [3.5.0](https://pypi.org/project/configparser/3.5.0/) | `adba` | v | v | `configparser.pth` was renamed from `configparser-3.5.0-py2.7-nspkg.pth`
+:: | <code><b>contextlib2</b>.py</code> | [0.5.5](https://pypi.org/project/contextlib2/0.5.5/) | **`medusa`**, `tvdbapiv2` | v | v | Markers: `python_version < '3.5'`
+:: | <code><b>decorator</b>.py</code> | [4.3.0](https://pypi.org/project/decorator/4.3.0/) | `validators` | v | v | -
+:: | `dirtyjson` | [1.0.7](https://pypi.org/project/dirtyjson/1.0.7/) | **`medusa`** | v | v | -
+:: | `diskcache` | [2.9.0](https://pypi.org/project/diskcache/2.9.0/) | `imdbpie` | v | v | -
+:: | `dogpile.cache` | [0.6.7](https://pypi.org/project/dogpile.cache/0.6.7/) | **`medusa`**, `subliminal` | v | v | -
+:: | `enzyme` | pymedusa/[665cf69](https://github.com/pymedusa/enzyme/tree/665cf6948aab1c249dcc99bd9624a81d17b3302a) | `knowit`, `subliminal` | v | v | -
+:: | `feedparser` | [2b11c80](https://github.com/kurtmckee/feedparser/tree/2b11c8028321ed43cbaf313f83b0c94820143d66) | **`medusa`** | v | v | Requires `sgmllib3k` on Python 3
+:: | **`future`**<br>`_dummy_thread`<br>`_markupbase`<br>`_thread`<br>`builtins`<br>`copyreg`<br>`html`<br>`http`<br>`libfuturize`<br>`libpasteurize`<br>`past`<br>`queue`<br>`reprlib`<br>`socketserver`<br>`tkinter`<br>`winreg`<br>`xmlrpc` | [0.16.0](https://pypi.org/project/future/0.16.0/) | **`medusa`**, `python-twitter`, ????? | v | v | -
+:: | `futures` | [3.2.0](https://pypi.org/project/futures/3.2.0/) | **`medusa`**, `subliminal`, `tornado` | v | v | Module: `concurrent.futures`<br>Markers: `python_version >= '2.6' and python_version < '3'`
+:: | `PyGithub` | [1.43.1](https://pypi.org/project/PyGithub/1.43.1/) | **`medusa`** | v | v | Module: `github`<br>**Removed tests**
+:: | `gntp` | [1.0.3](https://pypi.org/project/gntp/1.0.3/) | **`medusa`** | v | v | -
+:: | `guessit` | [3.0.0](https://pypi.org/project/guessit/3.0.0/) | **`medusa`**, `subliminal` | v | v | -
+:: | `html5lib` | [1.0.1](https://pypi.org/project/html5lib/1.0.1/) | **`medusa`** (via `beautifulsoup4`) | v | v | -
+:: | `idna` | [2.7](https://pypi.org/project/idna/2.7/) | `requests` | v | v | -
+:: | `imdbpie` | [5.6.2](https://pypi.org/project/imdbpie/5.6.2/) | **`medusa`** | v | v | -
+:: | `Js2Py` | [0.59](https://pypi.org/project/Js2Py/0.59/) | `cloudflare-scrape` | v | v | Module: `js2py`
+:: | `jsonrpclib-pelix` | [0.3.1](https://pypi.org/project/jsonrpclib-pelix/0.3.1/) | **`medusa`** | v | v | Module: `jsonrpclib`
+:: | `PyJWT` | [1.6.4](https://pypi.org/project/pyjwt/1.6.4/) | **`medusa`**, `PyGithub`, `tvdbapiv2` | v | v | Module: `jwt`
+:: | `knowit` | [0.2.4](https://pypi.org/project/knowit/0.2.4/) | **`medusa`** | v | v | -
+:: | `lockfile` | [0.12.2](https://pypi.org/project/lockfile/0.12.2/) | `CacheControl` | v | v | -
+:: | `Mako` | [1.0.7](https://pypi.org/project/mako/1.0.7/) | **`medusa`** | v | v | Module: `mako`
+:: | <code><b>markdown2</b>.py</code> | [2.3.5](https://pypi.org/project/markdown2/2.3.5/) | **`medusa`** | v | v | -
+:: | `MarkupSafe` | [1.0](https://pypi.org/project/MarkupSafe/1.0/) | `Mako` | v | v | Module: `markupsafe`
+:: | `msgpack` | [0.5.6](https://pypi.org/project/msgpack/0.5.6/) | `CacheControl` | v | v | -
+:: | `oauthlib` | [2.1.0](https://pypi.org/project/oauthlib/2.1.0/) | `requests-oauthlib` | v | v | -
+:: | `Pint` | [0.8.1](https://pypi.org/project/Pint/0.8.1/) | `knowit` | v | v | Module: `pint`
+:: | <code><b>profilehooks</b>.py</code> | [1.10.0](https://pypi.org/project/profilehooks/1.10.0/) | **`medusa`** | v | v | -
+:: | `pyjsparser` | [2.5.2](https://pypi.org/project/pyjsparser/2.5.2/) | `Js2Py` | v | v | -
+:: | `pysrt` | [1.1.0](https://pypi.org/project/pysrt/1.1.0/) | `subliminal` | v | v | -
+:: | `python-dateutil` | [2.7.3](https://pypi.org/project/python-dateutil/2.7.3/) | **`medusa`**, `tvdbapiv2`, `guessit`, `imdbpie` | v | v | Module: `dateutil`
+:: | `python-twitter` | [3.4.2](https://pypi.org/project/python-twitter/3.4.2/) | **`medusa`** | v | v | Module: `twitter`
+:: | `pytz` | [2018.4](https://pypi.org/project/pytz/2018.4/) | `subliminal`, `tzlocal` | v | v | -
+:: | <code><b>rarfile</b>.py</code> | [3.0](https://pypi.org/project/rarfile/3.0/) | **`medusa`**, `subliminal` | v | v | -
+:: | `rebulk` | [0.9.0](https://pypi.org/project/rebulk/0.9.0/) | **`medusa`**, `guessit` | v | v | -
+:: | `requests` | [2.19.1](https://pypi.org/project/requests/2.19.1/) | **`medusa`**, `adba`, `pytvmaze`, `simpleanidb`, `tmdbsimple`, `traktor`, `tvdbapiv2`, `boto`, `rtorrent`, `CacheControl`, `cloudflare-scrape`, `subliminal`, `PyGithub`, `python-twitter` | v | v | -
 :: | `requests-oauthlib` | [1.0.0](https://pypi.org/project/requests-oauthlib/1.0.0/) | **`medusa`**, `python-twitter` | v | v | Module: `requests_oauthlib`
-:: | <code><b>singledispatch</b>.py</code><br>`singledispatch_helpers.py` | [3.4.0.3](https://pypi.org/project/singledispatch/3.4.0.3/) | `tornado` | v | v| Markers: `python_version < '3.4'`
-:: | <code><b>six</b>.py</code> | [1.11.0](https://pypi.org/project/six/1.11.0/) | **`medusa`**, `tvdbapiv2`, `configobj`, `python-dateutil`, `guessit`, `html5lib`, `imdbpie`, `Js2Py`, `knowit`, `rebulk`, `subliminal`, `validators` | v | v| -
-:: | `stevedore` | [1.29.0](https://pypi.org/project/stevedore/1.29.0/) | `subliminal` | v | v| -
-:: | `subliminal` | pymedusa/[78687f4](https://github.com/pymedusa/subliminal/tree/78687f45d23b1bc47fae0a5493be0198dc1fd5b5) | **`medusa`** | v | v| -
-:: | `tornado` | [5.1](https://pypi.org/project/tornado/5.1/) | **`medusa`**, `tornroutes` | v | v| -
-:: | `tornroutes` | [0.5.1](https://pypi.org/project/tornroutes/0.5.1/) | **`medusa`** | v | v| -
-:: | `tzlocal` | [1.5.1](https://pypi.org/project/tzlocal/1.5.1/) | `Js2Py` | v | v| -
-:: | `urllib3` | [1.23](https://pypi.org/project/urllib3/1.23/) | `requests`, `CacheControl` | v | v| -
-:: | `validators` | [0.12.2](https://pypi.org/project/validators/0.12.2/) | **`medusa`** | v | v| -
-:: | `webencodings` | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | v | v| -
-:: | `PyYAML` | [3.13](https://pypi.org/project/PyYAML/3.13/) | `knowit` | v | v| Module: `yaml`
+:: | <code><b>singledispatch</b>.py</code><br>`singledispatch_helpers.py` | [3.4.0.3](https://pypi.org/project/singledispatch/3.4.0.3/) | `tornado` | v | v | Markers: `python_version < '3.4'`
+:: | <code><b>six</b>.py</code> | [1.11.0](https://pypi.org/project/six/1.11.0/) | **`medusa`**, `tvdbapiv2`, `configobj`, `python-dateutil`, `guessit`, `html5lib`, `imdbpie`, `Js2Py`, `knowit`, `rebulk`, `subliminal`, `validators` | v | v | -
+:: | `stevedore` | [1.29.0](https://pypi.org/project/stevedore/1.29.0/) | `subliminal` | v | v | -
+:: | `subliminal` | pymedusa/[78687f4](https://github.com/pymedusa/subliminal/tree/78687f45d23b1bc47fae0a5493be0198dc1fd5b5) | **`medusa`** | v | v | -
+:: | `tornado` | [5.1](https://pypi.org/project/tornado/5.1/) | **`medusa`**, `tornroutes` | v | v | -
+:: | `tornroutes` | [0.5.1](https://pypi.org/project/tornroutes/0.5.1/) | **`medusa`** | v | v | -
+:: | `tzlocal` | [1.5.1](https://pypi.org/project/tzlocal/1.5.1/) | `Js2Py` | v | v | -
+:: | `urllib3` | [1.23](https://pypi.org/project/urllib3/1.23/) | `requests`, `CacheControl` | v | v | -
+:: | `validators` | [0.12.2](https://pypi.org/project/validators/0.12.2/) | **`medusa`** | v | v | -
+:: | `webencodings` | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | v | v | -
+:: | `PyYAML` | [3.13](https://pypi.org/project/PyYAML/3.13/) | `knowit` | v | v | Module: `yaml`

--- a/ext/readme.md
+++ b/ext/readme.md
@@ -1,64 +1,64 @@
 ## ext
- Status  |  Package  |  Version / Commit  | Usage | Notes
-:------: | :-------: | :----------------: | :---- | :----
-:: | `adba` | pymedusa/[70bc381](https://github.com/pymedusa/adba/tree/70bc381a75e20e1813c848c1edb7c6f16987397e) | **`medusa`** | -
-:: | <code><b>appdirs</b>.py</code> | [1.4.3](https://pypi.org/project/appdirs/1.4.3/) | `subliminal` (cli only), `simpleanidb` | -
-:: | `attrs` | [18.1.0](https://pypi.org/project/attrs/18.1.0/) | `imdbpie` | Module: `attr`
-:: | `babelfish` | [f403000](https://github.com/Diaoul/babelfish/tree/f403000dd63092cfaaae80be9f309fd85c7f20c9) | **`medusa`**, `guessit`, `knowit`, `subliminal` | -
-:: | <code><b>backports_abc</b>.py</code> | [0.5](https://pypi.org/project/backports_abc/0.5/) | `tornado` | Markers: `python_version < '3.5'`
-:: | `beautifulsoup4` | [4.6.3](https://pypi.org/project/beautifulsoup4/4.6.3/) | **`medusa`**, `subliminal` | Module: `bs4`
-:: | `bencode.py` | [2.0.0](https://pypi.org/project/bencode.py/2.0.0/) | **`medusa`** | Module: `bencode`
-:: | `boto` | [2.48.0](https://pypi.org/project/boto/2.48.0/) | `imdbpie` | -
-:: | `CacheControl` | [0.12.5](https://pypi.org/project/CacheControl/0.12.5/) | **`medusa`** | Module: `cachecontrol`
-:: | `certifi` | [2018.8.24](https://pypi.org/project/certifi/2018.8.24/) | **`medusa`**, `traktor`, `requests` | -
-:: | `chardet` | [3.0.4](https://pypi.org/project/chardet/3.0.4/) | **`medusa`**, `beautifulsoup4`, `feedparser`, `html5lib`, `pysrt`, `requests`, `subliminal` | -
-:: | `cloudflare-scrape` | pymedusa/[320456e](https://github.com/pymedusa/cloudflare-scrape/tree/320456e8b28cedb807363a7a892b1379db843f66) | **`medusa`** | Module: `cfscrape`
-:: | <code><b>configobj</b>.py</code><br>`validate.py`<br>`_version.py` | [5.0.6](https://pypi.org/project/configobj/5.0.6/) | **`medusa`** | -
-:: | <code><b>configparser</b>.py</code><br>`configparser.pth`<br>`backports.configparser` | [3.5.0](https://pypi.org/project/configparser/3.5.0/) | `adba` | `configparser.pth` was renamed from `configparser-3.5.0-py2.7-nspkg.pth`
-:: | <code><b>contextlib2</b>.py</code> | [0.5.5](https://pypi.org/project/contextlib2/0.5.5/) | **`medusa`**, `tvdbapiv2` | Markers: `python_version < '3.5'`
-:: | <code><b>decorator</b>.py</code> | [4.3.0](https://pypi.org/project/decorator/4.3.0/) | `validators` | -
-:: | `dirtyjson` | [1.0.7](https://pypi.org/project/dirtyjson/1.0.7/) | **`medusa`** | -
-:: | `diskcache` | [2.9.0](https://pypi.org/project/diskcache/2.9.0/) | `imdbpie` | -
-:: | `dogpile.cache` | [0.6.7](https://pypi.org/project/dogpile.cache/0.6.7/) | **`medusa`**, `subliminal` | -
-:: | `enzyme` | pymedusa/[665cf69](https://github.com/pymedusa/enzyme/tree/665cf6948aab1c249dcc99bd9624a81d17b3302a) | `knowit`, `subliminal` | -
-:: | `feedparser` | [2b11c80](https://github.com/kurtmckee/feedparser/tree/2b11c8028321ed43cbaf313f83b0c94820143d66) | **`medusa`** | Requires `sgmllib3k` on Python 3
-:: | **`future`**<br>`_dummy_thread`<br>`_markupbase`<br>`_thread`<br>`builtins`<br>`copyreg`<br>`html`<br>`http`<br>`libfuturize`<br>`libpasteurize`<br>`past`<br>`queue`<br>`reprlib`<br>`socketserver`<br>`tkinter`<br>`winreg`<br>`xmlrpc` | [0.16.0](https://pypi.org/project/future/0.16.0/) | **`medusa`**, `python-twitter`, ????? | -
-:: | `futures` | [3.2.0](https://pypi.org/project/futures/3.2.0/) | **`medusa`**, `subliminal`, `tornado` | Module: `concurrent.futures`<br>Markers: `python_version >= '2.6' and python_version < '3'`
-:: | `PyGithub` | [1.43.1](https://pypi.org/project/PyGithub/1.43.1/) | **`medusa`** | Module: `github`<br>**Removed tests**
-:: | `gntp` | [1.0.3](https://pypi.org/project/gntp/1.0.3/) | **`medusa`** | -
-:: | `guessit` | [3.0.0](https://pypi.org/project/guessit/3.0.0/) | **`medusa`**, `subliminal` | -
-:: | `html5lib` | [1.0.1](https://pypi.org/project/html5lib/1.0.1/) | **`medusa`** (via `beautifulsoup4`) | -
-:: | `idna` | [2.7](https://pypi.org/project/idna/2.7/) | `requests` | -
-:: | `imdbpie` | [5.6.2](https://pypi.org/project/imdbpie/5.6.2/) | **`medusa`** | -
-:: | `Js2Py` | [0.59](https://pypi.org/project/Js2Py/0.59/) | `cloudflare-scrape` | Module: `js2py`
-:: | `jsonrpclib-pelix` | [0.3.1](https://pypi.org/project/jsonrpclib-pelix/0.3.1/) | **`medusa`** | Module: `jsonrpclib`
-:: | `PyJWT` | [1.6.4](https://pypi.org/project/pyjwt/1.6.4/) | **`medusa`**, `PyGithub`, `tvdbapiv2` | Module: `jwt`
-:: | `knowit` | [0.2.4](https://pypi.org/project/knowit/0.2.4/) | **`medusa`** | -
-:: | `lockfile` | [0.12.2](https://pypi.org/project/lockfile/0.12.2/) | `CacheControl` | -
-:: | `Mako` | [1.0.7](https://pypi.org/project/mako/1.0.7/) | **`medusa`** | Module: `mako`
+ Status  |  Package  |  Version / Commit  | Usage | py2 | py3 | Notes
+:------: | :-------: | :----------------: | :---- | :-- | :-- | :----
+:: | `adba` | pymedusa/[70bc381](https://github.com/pymedusa/adba/tree/70bc381a75e20e1813c848c1edb7c6f16987397e) | **`medusa`** | v | v| -
+:: | <code><b>appdirs</b>.py</code> | [1.4.3](https://pypi.org/project/appdirs/1.4.3/) | `subliminal` (cli only), `simpleanidb` | v | v| -
+:: | `attrs` | [18.1.0](https://pypi.org/project/attrs/18.1.0/) | `imdbpie` | v | v| Module: `attr`
+:: | `babelfish` | [f403000](https://github.com/Diaoul/babelfish/tree/f403000dd63092cfaaae80be9f309fd85c7f20c9) | **`medusa`**, `guessit`, `knowit`, `subliminal` | v | v| -
+:: | <code><b>backports_abc</b>.py</code> | [0.5](https://pypi.org/project/backports_abc/0.5/) | `tornado` | v | v| Markers: `python_version < '3.5'`
+:: | `beautifulsoup4` | [4.6.3](https://pypi.org/project/beautifulsoup4/4.6.3/) | **`medusa`**, `subliminal` | v | v| Module: `bs4`
+:: | `bencode.py` | [2.0.0](https://pypi.org/project/bencode.py/2.0.0/) | **`medusa`** | v | v| Module: `bencode`
+:: | `boto` | [2.48.0](https://pypi.org/project/boto/2.48.0/) | `imdbpie` | v | v| -
+:: | `CacheControl` | [0.12.5](https://pypi.org/project/CacheControl/0.12.5/) | **`medusa`** | v | v| Module: `cachecontrol`
+:: | `certifi` | [2018.8.24](https://pypi.org/project/certifi/2018.8.24/) | **`medusa`**, `traktor`, `requests` | v | v| -
+:: | `chardet` | [3.0.4](https://pypi.org/project/chardet/3.0.4/) | **`medusa`**, `beautifulsoup4`, `feedparser`, `html5lib`, `pysrt`, `requests`, `subliminal` | v | v| -
+:: | `cloudflare-scrape` | pymedusa/[320456e](https://github.com/pymedusa/cloudflare-scrape/tree/320456e8b28cedb807363a7a892b1379db843f66) | **`medusa`** | v | v| Module: `cfscrape`
+:: | <code><b>configobj</b>.py</code><br>`validate.py`<br>`_version.py` | [5.0.6](https://pypi.org/project/configobj/5.0.6/) | **`medusa`** | v | v| -
+:: | <code><b>configparser</b>.py</code><br>`configparser.pth`<br>`backports.configparser` | [3.5.0](https://pypi.org/project/configparser/3.5.0/) | `adba` | v | v| `configparser.pth` was renamed from `configparser-3.5.0-py2.7-nspkg.pth`
+:: | <code><b>contextlib2</b>.py</code> | [0.5.5](https://pypi.org/project/contextlib2/0.5.5/) | **`medusa`**, `tvdbapiv2` | v | v| Markers: `python_version < '3.5'`
+:: | <code><b>decorator</b>.py</code> | [4.3.0](https://pypi.org/project/decorator/4.3.0/) | `validators` | v | v| -
+:: | `dirtyjson` | [1.0.7](https://pypi.org/project/dirtyjson/1.0.7/) | **`medusa`** | v | v| -
+:: | `diskcache` | [2.9.0](https://pypi.org/project/diskcache/2.9.0/) | `imdbpie` | v | v| -
+:: | `dogpile.cache` | [0.6.7](https://pypi.org/project/dogpile.cache/0.6.7/) | **`medusa`**, `subliminal` | v | v| -
+:: | `enzyme` | pymedusa/[665cf69](https://github.com/pymedusa/enzyme/tree/665cf6948aab1c249dcc99bd9624a81d17b3302a) | `knowit`, `subliminal` | v | v| -
+:: | `feedparser` | [2b11c80](https://github.com/kurtmckee/feedparser/tree/2b11c8028321ed43cbaf313f83b0c94820143d66) | **`medusa`** | v | v| Requires `sgmllib3k` on Python 3
+:: | **`future`**<br>`_dummy_thread`<br>`_markupbase`<br>`_thread`<br>`builtins`<br>`copyreg`<br>`html`<br>`http`<br>`libfuturize`<br>`libpasteurize`<br>`past`<br>`queue`<br>`reprlib`<br>`socketserver`<br>`tkinter`<br>`winreg`<br>`xmlrpc` | [0.16.0](https://pypi.org/project/future/0.16.0/) | **`medusa`**, `python-twitter`, ????? | v | v| -
+:: | `futures` | [3.2.0](https://pypi.org/project/futures/3.2.0/) | **`medusa`**, `subliminal`, `tornado` | v | v| Module: `concurrent.futures`<br>Markers: `python_version >= '2.6' and python_version < '3'`
+:: | `PyGithub` | [1.43.1](https://pypi.org/project/PyGithub/1.43.1/) | **`medusa`** | v | v| Module: `github`<br>**Removed tests**
+:: | `gntp` | [1.0.3](https://pypi.org/project/gntp/1.0.3/) | **`medusa`** | v | v| -
+:: | `guessit` | [3.0.0](https://pypi.org/project/guessit/3.0.0/) | **`medusa`**, `subliminal` | v | v| -
+:: | `html5lib` | [1.0.1](https://pypi.org/project/html5lib/1.0.1/) | **`medusa`** (via `beautifulsoup4`) | v | v| -
+:: | `idna` | [2.7](https://pypi.org/project/idna/2.7/) | `requests` | v | v| -
+:: | `imdbpie` | [5.6.2](https://pypi.org/project/imdbpie/5.6.2/) | **`medusa`** | v | v| -
+:: | `Js2Py` | [0.59](https://pypi.org/project/Js2Py/0.59/) | `cloudflare-scrape` | v | v| Module: `js2py`
+:: | `jsonrpclib-pelix` | [0.3.1](https://pypi.org/project/jsonrpclib-pelix/0.3.1/) | **`medusa`** | v | v| Module: `jsonrpclib`
+:: | `PyJWT` | [1.6.4](https://pypi.org/project/pyjwt/1.6.4/) | **`medusa`**, `PyGithub`, `tvdbapiv2` | v | v| Module: `jwt`
+:: | `knowit` | [0.2.4](https://pypi.org/project/knowit/0.2.4/) | **`medusa`** | v | v| -
+:: | `lockfile` | [0.12.2](https://pypi.org/project/lockfile/0.12.2/) | `CacheControl` | v | v| -
+:: | `Mako` | [1.0.7](https://pypi.org/project/mako/1.0.7/) | **`medusa`** | v | v| Module: `mako`
 :: | <code><b>markdown2</b>.py</code> | [2.3.5](https://pypi.org/project/markdown2/2.3.5/) | **`medusa`** | -
-:: | `MarkupSafe` | [1.0](https://pypi.org/project/MarkupSafe/1.0/) | `Mako` | Module: `markupsafe`
-:: | `msgpack` | [0.5.6](https://pypi.org/project/msgpack/0.5.6/) | `CacheControl` | -
-:: | `oauthlib` | [2.1.0](https://pypi.org/project/oauthlib/2.1.0/) | `requests-oauthlib` | -
-:: | `Pint` | [0.8.1](https://pypi.org/project/Pint/0.8.1/) | `knowit` | Module: `pint`
-:: | <code><b>profilehooks</b>.py</code> | [1.10.0](https://pypi.org/project/profilehooks/1.10.0/) | **`medusa`** | -
-:: | `pyjsparser` | [2.5.2](https://pypi.org/project/pyjsparser/2.5.2/) | `Js2Py` | -
-:: | `pysrt` | [1.1.0](https://pypi.org/project/pysrt/1.1.0/) | `subliminal` | -
-:: | `python-dateutil` | [2.7.3](https://pypi.org/project/python-dateutil/2.7.3/) | **`medusa`**, `tvdbapiv2`, `guessit`, `imdbpie` | Module: `dateutil`
-:: | `python-twitter` | [3.4.2](https://pypi.org/project/python-twitter/3.4.2/) | **`medusa`** | Module: `twitter`
-:: | `pytz` | [2018.4](https://pypi.org/project/pytz/2018.4/) | `subliminal`, `tzlocal` | -
-:: | <code><b>rarfile</b>.py</code> | [3.0](https://pypi.org/project/rarfile/3.0/) | **`medusa`**, `subliminal` | -
-:: | `rebulk` | [0.9.0](https://pypi.org/project/rebulk/0.9.0/) | **`medusa`**, `guessit` | -
-:: | `requests` | [2.19.1](https://pypi.org/project/requests/2.19.1/) | **`medusa`**, `adba`, `pytvmaze`, `simpleanidb`, `tmdbsimple`, `traktor`, `tvdbapiv2`, `boto`, `rtorrent`, `CacheControl`, `cloudflare-scrape`, `subliminal`, `PyGithub`, `python-twitter` | -
-:: | `requests-oauthlib` | [1.0.0](https://pypi.org/project/requests-oauthlib/1.0.0/) | **`medusa`**, `python-twitter` | Module: `requests_oauthlib`
-:: | <code><b>singledispatch</b>.py</code><br>`singledispatch_helpers.py` | [3.4.0.3](https://pypi.org/project/singledispatch/3.4.0.3/) | `tornado` | Markers: `python_version < '3.4'`
-:: | <code><b>six</b>.py</code> | [1.11.0](https://pypi.org/project/six/1.11.0/) | **`medusa`**, `tvdbapiv2`, `configobj`, `python-dateutil`, `guessit`, `html5lib`, `imdbpie`, `Js2Py`, `knowit`, `rebulk`, `subliminal`, `validators` | -
-:: | `stevedore` | [1.29.0](https://pypi.org/project/stevedore/1.29.0/) | `subliminal` | -
-:: | `subliminal` | pymedusa/[78687f4](https://github.com/pymedusa/subliminal/tree/78687f45d23b1bc47fae0a5493be0198dc1fd5b5) | **`medusa`** | -
-:: | `tornado` | [5.1](https://pypi.org/project/tornado/5.1/) | **`medusa`**, `tornroutes` | -
-:: | `tornroutes` | [0.5.1](https://pypi.org/project/tornroutes/0.5.1/) | **`medusa`** | -
-:: | `tzlocal` | [1.5.1](https://pypi.org/project/tzlocal/1.5.1/) | `Js2Py` | -
-:: | `urllib3` | [1.23](https://pypi.org/project/urllib3/1.23/) | `requests`, `CacheControl` | -
-:: | `validators` | [0.12.2](https://pypi.org/project/validators/0.12.2/) | **`medusa`** | -
-:: | `webencodings` | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | -
-:: | `PyYAML` | [3.13](https://pypi.org/project/PyYAML/3.13/) | `knowit` | Module: `yaml`
+:: | `MarkupSafe` | [1.0](https://pypi.org/project/MarkupSafe/1.0/) | `Mako` | v | v| Module: `markupsafe`
+:: | `msgpack` | [0.5.6](https://pypi.org/project/msgpack/0.5.6/) | `CacheControl` | v | v| -
+:: | `oauthlib` | [2.1.0](https://pypi.org/project/oauthlib/2.1.0/) | `requests-oauthlib` | v | v| -
+:: | `Pint` | [0.8.1](https://pypi.org/project/Pint/0.8.1/) | `knowit` | v | v| Module: `pint`
+:: | <code><b>profilehooks</b>.py</code> | [1.10.0](https://pypi.org/project/profilehooks/1.10.0/) | **`medusa`** | v | v| -
+:: | `pyjsparser` | [2.5.2](https://pypi.org/project/pyjsparser/2.5.2/) | `Js2Py` | v | v| -
+:: | `pysrt` | [1.1.0](https://pypi.org/project/pysrt/1.1.0/) | `subliminal` | v | v| -
+:: | `python-dateutil` | [2.7.3](https://pypi.org/project/python-dateutil/2.7.3/) | **`medusa`**, `tvdbapiv2`, `guessit`, `imdbpie` | v | v| Module: `dateutil`
+:: | `python-twitter` | [3.4.2](https://pypi.org/project/python-twitter/3.4.2/) | **`medusa`** | v | v| Module: `twitter`
+:: | `pytz` | [2018.4](https://pypi.org/project/pytz/2018.4/) | `subliminal`, `tzlocal` | v | v| -
+:: | <code><b>rarfile</b>.py</code> | [3.0](https://pypi.org/project/rarfile/3.0/) | **`medusa`**, `subliminal` | v | v| -
+:: | `rebulk` | [0.9.0](https://pypi.org/project/rebulk/0.9.0/) | **`medusa`**, `guessit` | v | v| -
+:: | `requests` | [2.19.1](https://pypi.org/project/requests/2.19.1/) | **`medusa`**, `adba`, `pytvmaze`, `simpleanidb`, `tmdbsimple`, `traktor`, `tvdbapiv2`, `boto`, `rtorrent`, `CacheControl`, `cloudflare-scrape`, `subliminal`, `PyGithub`, `python-twitter` | v | v| -
+:: | `requests-oauthlib` | [1.0.0](https://pypi.org/project/requests-oauthlib/1.0.0/) | **`medusa`**, `python-twitter` | v | v | Module: `requests_oauthlib`
+:: | <code><b>singledispatch</b>.py</code><br>`singledispatch_helpers.py` | [3.4.0.3](https://pypi.org/project/singledispatch/3.4.0.3/) | `tornado` | v | v| Markers: `python_version < '3.4'`
+:: | <code><b>six</b>.py</code> | [1.11.0](https://pypi.org/project/six/1.11.0/) | **`medusa`**, `tvdbapiv2`, `configobj`, `python-dateutil`, `guessit`, `html5lib`, `imdbpie`, `Js2Py`, `knowit`, `rebulk`, `subliminal`, `validators` | v | v| -
+:: | `stevedore` | [1.29.0](https://pypi.org/project/stevedore/1.29.0/) | `subliminal` | v | v| -
+:: | `subliminal` | pymedusa/[78687f4](https://github.com/pymedusa/subliminal/tree/78687f45d23b1bc47fae0a5493be0198dc1fd5b5) | **`medusa`** | v | v| -
+:: | `tornado` | [5.1](https://pypi.org/project/tornado/5.1/) | **`medusa`**, `tornroutes` | v | v| -
+:: | `tornroutes` | [0.5.1](https://pypi.org/project/tornroutes/0.5.1/) | **`medusa`** | v | v| -
+:: | `tzlocal` | [1.5.1](https://pypi.org/project/tzlocal/1.5.1/) | `Js2Py` | v | v| -
+:: | `urllib3` | [1.23](https://pypi.org/project/urllib3/1.23/) | `requests`, `CacheControl` | v | v| -
+:: | `validators` | [0.12.2](https://pypi.org/project/validators/0.12.2/) | **`medusa`** | v | v| -
+:: | `webencodings` | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | v | v| -
+:: | `PyYAML` | [3.13](https://pypi.org/project/PyYAML/3.13/) | `knowit` | v | v| Module: `yaml`

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -1,8 +1,8 @@
 ## lib
  Status  |  Package  |  Version / Commit  | Usage | py2 | py3 | Notes
-:------: | :-------: | :----------------: | :---- | :-- | :-- | :----
+:------: | :-------: | :----------------: | :---- | :--: | :--: | :----
 :: | `certgen.py` | [d52975c](https://github.com/pyca/pyopenssl/blob/d52975cef3a36e18552aeb23de7c06aa73d76454/examples/certgen.py) | **`medusa`** | v | x | **Not a package**
-:: | `native` | - | `pymediainfo` | **Not a package**
+:: | `native` | - | `pymediainfo` | - | - | **Not a package**
 :: | `pkg_resources` | ????? | `babelfish`, `enzyme`, `guessit`, `stevedore`, `pint`, ... | v | x | **Not a package**<br>Part of `setuptools`
 :: | `pymediainfo` | [2.2.1](https://pypi.org/project/pymediainfo/2.2.1/) | `knowit` | v | x | **Modified**: Version number fixed
 :: | `pytimeparse` | [1.1.5](https://pypi.org/project/pytimeparse/1.1.5/) | **`medusa`** | v | x | **Modified**: [#1792](https://github.com/pymedusa/Medusa/pull/1792)

--- a/lib/readme.md
+++ b/lib/readme.md
@@ -1,18 +1,18 @@
 ## lib
- Status  |  Package  |  Version / Commit  | Usage | Notes
-:------: | :-------: | :----------------: | :---- | :----
-:: | `certgen.py` | [d52975c](https://github.com/pyca/pyopenssl/blob/d52975cef3a36e18552aeb23de7c06aa73d76454/examples/certgen.py) | **`medusa`** | **Not a package**
+ Status  |  Package  |  Version / Commit  | Usage | py2 | py3 | Notes
+:------: | :-------: | :----------------: | :---- | :-- | :-- | :----
+:: | `certgen.py` | [d52975c](https://github.com/pyca/pyopenssl/blob/d52975cef3a36e18552aeb23de7c06aa73d76454/examples/certgen.py) | **`medusa`** | v | x | **Not a package**
 :: | `native` | - | `pymediainfo` | **Not a package**
-:: | `pkg_resources` | ????? | `babelfish`, `enzyme`, `guessit`, `stevedore`, `pint`, ... | **Not a package**<br>Part of `setuptools`
-:: | `pymediainfo` | [2.2.1](https://pypi.org/project/pymediainfo/2.2.1/) | `knowit` | **Modified**: Version number fixed
-:: | `pytimeparse` | [1.1.5](https://pypi.org/project/pytimeparse/1.1.5/) | **`medusa`** | **Modified**: [#1792](https://github.com/pymedusa/Medusa/pull/1792)
-:: | `pytvmaze` | [2.0.7](https://pypi.org/project/pytvmaze/2.0.7/) | **`medusa`** | **Modified**: [#1706](https://github.com/pymedusa/Medusa/pull/1706)
-:: | `rtorrent-python` | [0.2.9](https://pypi.org/project/rtorrent-python/0.2.9/) | **`medusa`** | Module: `rtorrent`<br>**Modified**: [commit log](https://github.com/pymedusa/Medusa/commits/master/lib/rtorrent)
-:: | `send2trash` | [1.3.0](https://pypi.org/project/send2trash/1.3.0/) | **`medusa`** | **Modified**
-:: | `shutil_custom` | - | **`medusa`** | **Custom**
-:: | `simpleanidb` | pymedusa/[5d26c8c](https://github.com/pymedusa/simpleanidb/tree/5d26c8c146891225c05651821ef34ced0c118221) | **`medusa`** | -
-:: | `synchronousdeluge` | ????? | **`medusa`** | From CouchPotato?
-:: | `tmdbsimple` | [2.2.0](https://pypi.org/project/tmdbsimple/2.2.0/) | **`medusa`** | **Modified**: [#4026](https://github.com/pymedusa/Medusa/pull/4026) -- [Upstream PR](https://github.com/celiao/tmdbsimple/pull/52)
-:: | `traktor` | - | **`medusa`** | **Custom**
-:: | `tvdbapiv2` | pymedusa/[3a51858](https://github.com/pymedusa/tvdbv2/tree/3a51858640cfcb960be635e91394cbce1d73e036) | **`medusa`** | **Modified**: [Upstream PR](https://github.com/pymedusa/tvdbv2/pull/2)
-:: | `pyUnRAR2` | [commit](https://github.com/kyegupov/py-unrar2/tree/186a4c1feb9ef3d96a2331f8fb3ebf88036e15e5) | **`medusa`** | Module: `unrar2`<br>**Modified**: [#5096](https://github.com/pymedusa/Medusa/pull/5096)<br>`test.rar` is not part of the package<br>The `UnRARDLL` folder isn't installed through `pip`
+:: | `pkg_resources` | ????? | `babelfish`, `enzyme`, `guessit`, `stevedore`, `pint`, ... | v | x | **Not a package**<br>Part of `setuptools`
+:: | `pymediainfo` | [2.2.1](https://pypi.org/project/pymediainfo/2.2.1/) | `knowit` | v | x | **Modified**: Version number fixed
+:: | `pytimeparse` | [1.1.5](https://pypi.org/project/pytimeparse/1.1.5/) | **`medusa`** | v | x | **Modified**: [#1792](https://github.com/pymedusa/Medusa/pull/1792)
+:: | `pytvmaze` | [2.0.7](https://pypi.org/project/pytvmaze/2.0.7/) | **`medusa`** | v | x | **Modified**: [#1706](https://github.com/pymedusa/Medusa/pull/1706)
+:: | `rtorrent-python` | [0.2.9](https://pypi.org/project/rtorrent-python/0.2.9/) | **`medusa`** | v | x | Module: `rtorrent`<br>**Modified**: [commit log](https://github.com/pymedusa/Medusa/commits/master/lib/rtorrent)
+:: | `send2trash` | [1.3.0](https://pypi.org/project/send2trash/1.3.0/) | **`medusa`** | v | x | **Modified**
+:: | `shutil_custom` | - | **`medusa`** | v | x | **Custom**
+:: | `simpleanidb` | pymedusa/[5d26c8c](https://github.com/pymedusa/simpleanidb/tree/5d26c8c146891225c05651821ef34ced0c118221) | **`medusa`** | v | x | -
+:: | `synchronousdeluge` | ????? | **`medusa`** | v | x | From CouchPotato?
+:: | `tmdbsimple` | [2.2.0](https://pypi.org/project/tmdbsimple/2.2.0/) | **`medusa`** | v | x | **Modified**: [#4026](https://github.com/pymedusa/Medusa/pull/4026) -- [Upstream PR](https://github.com/celiao/tmdbsimple/pull/52)
+:: | `traktor` | - | **`medusa`** | v | x | **Custom**
+:: | `tvdbapiv2` | pymedusa/[3a51858](https://github.com/pymedusa/tvdbv2/tree/3a51858640cfcb960be635e91394cbce1d73e036) | **`medusa`** | v | x | **Modified**: [Upstream PR](https://github.com/pymedusa/tvdbv2/pull/2)
+:: | `pyUnRAR2` | [commit](https://github.com/kyegupov/py-unrar2/tree/186a4c1feb9ef3d96a2331f8fb3ebf88036e15e5) | **`medusa`** | v | x | Module: `unrar2`<br>**Modified**: [#5096](https://github.com/pymedusa/Medusa/pull/5096)<br>`test.rar` is not part of the package<br>The `UnRARDLL` folder isn't installed through `pip`


### PR DESCRIPTION
…r libraries in /lib and /ext

/lib is opt-in, there all py2 and *not* py3 supported.
/ext is opt-out, by default the're all py2 and py3 supported.

@ngosang could you go through these? And update where needed?

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
