### PR TITLE
Send episode object to download and subtitle notifications

### DIFF
--- a/medusa/notifiers/__init__.py
+++ b/medusa/notifiers/__init__.py
@@ -86,18 +86,18 @@ notifiers = [
 ]
 
 
-def notify_download(ep_name):
+def notify_download(ep_obj):
     for n in notifiers:
         try:
-            n.notify_download(ep_name)
+            n.notify_download(ep_obj)
         except (RequestException, socket.gaierror, socket.timeout) as error:
             log.debug(u'Unable to send download notification. Error: {0}', error.message)
 
 
-def notify_subtitle_download(ep_name, lang):
+def notify_subtitle_download(ep_obj, lang):
     for n in notifiers:
         try:
-            n.notify_subtitle_download(ep_name, lang)
+            n.notify_subtitle_download(ep_obj, lang)
         except (RequestException, socket.gaierror, socket.timeout) as error:
             log.debug(u'Unable to send download notification. Error: {0}', error.message)
 

--- a/medusa/notifiers/boxcar2.py
+++ b/medusa/notifiers/boxcar2.py
@@ -62,15 +62,15 @@ class Notifier(object):
         if app.BOXCAR2_NOTIFY_ONSNATCH:
             self._notify_boxcar2(title, ep_name)
 
-    def notify_download(self, ep_name, title=common.notifyStrings[common.NOTIFY_DOWNLOAD]):
+    def notify_download(self, ep_obj, title=common.notifyStrings[common.NOTIFY_DOWNLOAD]):
         """Send the download message."""
         if app.BOXCAR2_NOTIFY_ONDOWNLOAD:
-            self._notify_boxcar2(title, ep_name)
+            self._notify_boxcar2(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang, title=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD]):
+    def notify_subtitle_download(self, ep_obj, lang, title=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD]):
         """Send the subtitle download message."""
         if app.BOXCAR2_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify_boxcar2(title, ep_name + ': ' + lang)
+            self._notify_boxcar2(title, ep_obj.pretty_name() + ': ' + lang)
 
     def notify_git_update(self, new_version='??'):
         """Send update available message."""

--- a/medusa/notifiers/boxcar2.py
+++ b/medusa/notifiers/boxcar2.py
@@ -65,7 +65,7 @@ class Notifier(object):
     def notify_download(self, ep_obj, title=common.notifyStrings[common.NOTIFY_DOWNLOAD]):
         """Send the download message."""
         if app.BOXCAR2_NOTIFY_ONDOWNLOAD:
-            self._notify_boxcar2(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._notify_boxcar2(title, ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang, title=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD]):
         """Send the subtitle download message."""

--- a/medusa/notifiers/emailnotify.py
+++ b/medusa/notifiers/emailnotify.py
@@ -110,14 +110,14 @@ class Notifier(object):
                 else:
                     log.warning('Snatch notification error: {0}', self.last_err)
 
-    def notify_download(self, ep_name, title='Completed:'):
+    def notify_download(self, ep_obj, title='Completed:'):
         """
         Send a notification that an episode was downloaded.
 
         ep_name: The name of the episode that was downloaded
         title: The title of the notification (optional)
         """
-        ep_name = ss(ep_name)
+        ep_name = ss(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
         if app.USE_EMAIL and app.EMAIL_NOTIFY_ONDOWNLOAD:
             parsed = self._parse_name(ep_name)
@@ -161,14 +161,14 @@ class Notifier(object):
                 else:
                     log.warning('Download notification error: {0}', self.last_err)
 
-    def notify_subtitle_download(self, ep_name, lang, title='Downloaded subtitle:'):
+    def notify_subtitle_download(self, ep_obj, lang, title='Downloaded subtitle:'):
         """
         Send a notification that a subtitle was downloaded.
 
         ep_name: The name of the episode that was downloaded
         lang: Subtitle language wanted
         """
-        ep_name = ss(ep_name)
+        ep_name = ss(ep_obj.pretty_name())
 
         if app.USE_EMAIL and app.EMAIL_NOTIFY_ONSUBTITLEDOWNLOAD:
             parsed = self._parse_name(ep_name)

--- a/medusa/notifiers/emailnotify.py
+++ b/medusa/notifiers/emailnotify.py
@@ -117,7 +117,7 @@ class Notifier(object):
         ep_name: The name of the episode that was downloaded
         title: The title of the notification (optional)
         """
-        ep_name = ss(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+        ep_name = ss(ep_obj.pretty_name_with_quality())
 
         if app.USE_EMAIL and app.EMAIL_NOTIFY_ONDOWNLOAD:
             parsed = self._parse_name(ep_name)

--- a/medusa/notifiers/freemobile.py
+++ b/medusa/notifiers/freemobile.py
@@ -85,7 +85,7 @@ class Notifier(object):
 
     def notify_download(self, ep_obj, title=notifyStrings[NOTIFY_DOWNLOAD]):
         if app.FREEMOBILE_NOTIFY_ONDOWNLOAD:
-            self._notifyFreeMobile(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._notifyFreeMobile(title, ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         if app.FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD:

--- a/medusa/notifiers/freemobile.py
+++ b/medusa/notifiers/freemobile.py
@@ -83,13 +83,13 @@ class Notifier(object):
         if app.FREEMOBILE_NOTIFY_ONSNATCH:
             self._notifyFreeMobile(title, ep_name)
 
-    def notify_download(self, ep_name, title=notifyStrings[NOTIFY_DOWNLOAD]):
+    def notify_download(self, ep_obj, title=notifyStrings[NOTIFY_DOWNLOAD]):
         if app.FREEMOBILE_NOTIFY_ONDOWNLOAD:
-            self._notifyFreeMobile(title, ep_name)
+            self._notifyFreeMobile(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
+    def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         if app.FREEMOBILE_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notifyFreeMobile(title, ep_name + ': ' + lang)
+            self._notifyFreeMobile(title, ep_obj.pretty_name() + ': ' + lang)
 
     def notify_git_update(self, new_version='??'):
         if app.USE_FREEMOBILE:

--- a/medusa/notifiers/growl.py
+++ b/medusa/notifiers/growl.py
@@ -30,13 +30,13 @@ class Notifier(object):
                     (common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]
                 ], ep_name)
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         if app.GROWL_NOTIFY_ONDOWNLOAD:
-            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_name)
+            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.GROWL_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._sendGrowl(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD], ep_name + ': ' + lang)
+            self._sendGrowl(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD], ep_obj.pretty_name() + ': ' + lang)
 
     def notify_git_update(self, new_version='??'):
         update_text = common.notifyStrings[common.NOTIFY_GIT_UPDATE_TEXT]

--- a/medusa/notifiers/growl.py
+++ b/medusa/notifiers/growl.py
@@ -32,7 +32,7 @@ class Notifier(object):
 
     def notify_download(self, ep_obj):
         if app.GROWL_NOTIFY_ONDOWNLOAD:
-            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._sendGrowl(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang):
         if app.GROWL_NOTIFY_ONSUBTITLEDOWNLOAD:

--- a/medusa/notifiers/kodi.py
+++ b/medusa/notifiers/kodi.py
@@ -430,7 +430,7 @@ class Notifier(object):
     def notify_download(self, ep_obj):
         """Send the download message."""
         if app.KODI_NOTIFY_ONDOWNLOAD:
-            self._notify_kodi(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'), common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            self._notify_kodi(ep_obj.pretty_name_with_quality(), common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def notify_subtitle_download(self, ep_obj, lang):
         """Send the subtitle download message."""

--- a/medusa/notifiers/kodi.py
+++ b/medusa/notifiers/kodi.py
@@ -427,15 +427,15 @@ class Notifier(object):
             self._notify_kodi(ep_name, common.notifyStrings[(common.NOTIFY_SNATCH,
                                                              common.NOTIFY_SNATCH_PROPER)[is_proper]])
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         """Send the download message."""
         if app.KODI_NOTIFY_ONDOWNLOAD:
-            self._notify_kodi(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            self._notify_kodi(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'), common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         """Send the subtitle download message."""
         if app.KODI_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify_kodi(ep_name + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
+            self._notify_kodi(ep_obj.pretty_name() + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
 
     def notify_git_update(self, new_version='??'):
         """Send update available message."""

--- a/medusa/notifiers/libnotify.py
+++ b/medusa/notifiers/libnotify.py
@@ -79,7 +79,7 @@ class Notifier(object):
 
     def notify_download(self, ep_obj):
         if app.LIBNOTIFY_NOTIFY_ONDOWNLOAD:
-            self._notify(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._notify(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang):
         if app.LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD:

--- a/medusa/notifiers/libnotify.py
+++ b/medusa/notifiers/libnotify.py
@@ -77,13 +77,13 @@ class Notifier(object):
         if app.LIBNOTIFY_NOTIFY_ONSNATCH:
             self._notify(common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]], ep_name)
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         if app.LIBNOTIFY_NOTIFY_ONDOWNLOAD:
-            self._notify(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_name)
+            self._notify(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.LIBNOTIFY_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD], ep_name + ': ' + lang)
+            self._notify(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD], ep_obj.pretty_name() + ': ' + lang)
 
     def notify_git_update(self, new_version='??'):
         if app.USE_LIBNOTIFY:

--- a/medusa/notifiers/plex.py
+++ b/medusa/notifiers/plex.py
@@ -76,9 +76,9 @@ class Notifier(object):
         if app.PLEX_NOTIFY_ONDOWNLOAD:
             self._notify_pht(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.PLEX_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify_pht(ep_name + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
+            self._notify_pht(ep_obj.pretty_name() + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
 
     def notify_git_update(self, new_version='??'):
         if app.NOTIFY_ON_UPDATE:

--- a/medusa/notifiers/prowl.py
+++ b/medusa/notifiers/prowl.py
@@ -44,8 +44,8 @@ class Notifier(object):
                     self._send_prowl(prowl_api=api, prowl_priority=None, event=common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]],
                                      message=ep_name + ' :: ' + time.strftime(app.DATE_PRESET + ' ' + app.TIME_PRESET))
 
-    def notify_download(self, ep_name):
-        ep_name = ss(ep_name)
+    def notify_download(self, ep_obj):
+        ep_name = ss(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
         if app.PROWL_NOTIFY_ONDOWNLOAD:
             show = self._parse_episode(ep_name)
             recipients = self._generate_recipients(show)
@@ -56,8 +56,8 @@ class Notifier(object):
                     self._send_prowl(prowl_api=api, prowl_priority=None, event=common.notifyStrings[common.NOTIFY_DOWNLOAD],
                                      message=ep_name + ' :: ' + time.strftime(app.DATE_PRESET + ' ' + app.TIME_PRESET))
 
-    def notify_subtitle_download(self, ep_name, lang):
-        ep_name = ss(ep_name)
+    def notify_subtitle_download(self, ep_obj, lang):
+        ep_name = ss(ep_obj.pretty_name())
         if app.PROWL_NOTIFY_ONSUBTITLEDOWNLOAD:
             show = self._parse_episode(ep_name)
             recipients = self._generate_recipients(show)

--- a/medusa/notifiers/prowl.py
+++ b/medusa/notifiers/prowl.py
@@ -45,7 +45,7 @@ class Notifier(object):
                                      message=ep_name + ' :: ' + time.strftime(app.DATE_PRESET + ' ' + app.TIME_PRESET))
 
     def notify_download(self, ep_obj):
-        ep_name = ss(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+        ep_name = ss(ep_obj.pretty_name_with_quality())
         if app.PROWL_NOTIFY_ONDOWNLOAD:
             show = self._parse_episode(ep_name)
             recipients = self._generate_recipients(show)

--- a/medusa/notifiers/pushalot.py
+++ b/medusa/notifiers/pushalot.py
@@ -33,20 +33,20 @@ class Notifier(object):
                 message=ep_name
             )
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         if app.PUSHALOT_NOTIFY_ONDOWNLOAD:
             self._sendPushalot(
                 pushalot_authorizationtoken=None,
                 event=common.notifyStrings[common.NOTIFY_DOWNLOAD],
-                message=ep_name
+                message=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
             )
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.PUSHALOT_NOTIFY_ONSUBTITLEDOWNLOAD:
             self._sendPushalot(
                 pushalot_authorizationtoken=None,
                 event=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD],
-                message='{}:{}'.format(ep_name, lang)
+                message='{}:{}'.format(ep_obj.pretty_name(), lang)
             )
 
     def notify_git_update(self, new_version='??'):

--- a/medusa/notifiers/pushalot.py
+++ b/medusa/notifiers/pushalot.py
@@ -38,7 +38,7 @@ class Notifier(object):
             self._sendPushalot(
                 pushalot_authorizationtoken=None,
                 event=common.notifyStrings[common.NOTIFY_DOWNLOAD],
-                message=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
+                message=ep_obj.pretty_name_with_quality()
             )
 
     def notify_subtitle_download(self, ep_obj, lang):

--- a/medusa/notifiers/pushbullet.py
+++ b/medusa/notifiers/pushbullet.py
@@ -49,20 +49,20 @@ class Notifier(object):
                 message=ep_name
             )
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         if app.PUSHBULLET_NOTIFY_ONDOWNLOAD:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ' : ' + ep_name,
-                message=ep_name
+                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ' : ' + ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'),
+                message=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
             )
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD] + ' : ' + ep_name + ' : ' + lang,
-                message=ep_name + ': ' + lang
+                event=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD] + ' : ' + ep_obj.pretty_name() + ' : ' + lang,
+                message=ep_obj.pretty_name() + ': ' + lang
             )
 
     def notify_git_update(self, new_version='??'):

--- a/medusa/notifiers/pushbullet.py
+++ b/medusa/notifiers/pushbullet.py
@@ -53,8 +53,8 @@ class Notifier(object):
         if app.PUSHBULLET_NOTIFY_ONDOWNLOAD:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ' : ' + ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'),
-                message=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
+                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ' : ' + ep_obj.pretty_name_with_quality(),
+                message=ep_obj.pretty_name_with_quality()
             )
 
     def notify_subtitle_download(self, ep_obj, lang):

--- a/medusa/notifiers/pushbullet.py
+++ b/medusa/notifiers/pushbullet.py
@@ -45,7 +45,7 @@ class Notifier(object):
         if app.PUSHBULLET_NOTIFY_ONSNATCH:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]] + ' : ' + ep_name,
+                event=common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]] + ': ' + ep_name,
                 message=ep_name
             )
 
@@ -53,7 +53,7 @@ class Notifier(object):
         if app.PUSHBULLET_NOTIFY_ONDOWNLOAD:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ' : ' + ep_obj.pretty_name_with_quality(),
+                event=common.notifyStrings[common.NOTIFY_DOWNLOAD] + ': ' + ep_obj.pretty_name_with_quality(),
                 message=ep_obj.pretty_name_with_quality()
             )
 
@@ -61,7 +61,7 @@ class Notifier(object):
         if app.PUSHBULLET_NOTIFY_ONSUBTITLEDOWNLOAD:
             self._sendPushbullet(
                 pushbullet_api=None,
-                event=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD] + ' : ' + ep_obj.pretty_name() + ' : ' + lang,
+                event=common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD] + ': ' + ep_obj.pretty_name() + ': ' + lang,
                 message=ep_obj.pretty_name() + ': ' + lang
             )
 

--- a/medusa/notifiers/pushover.py
+++ b/medusa/notifiers/pushover.py
@@ -142,7 +142,7 @@ class Notifier(object):
 
     def notify_download(self, ep_obj, title=notifyStrings[NOTIFY_DOWNLOAD]):
         if app.PUSHOVER_NOTIFY_ONDOWNLOAD:
-            self._notifyPushover(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._notifyPushover(title, ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         if app.PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD:

--- a/medusa/notifiers/pushover.py
+++ b/medusa/notifiers/pushover.py
@@ -140,13 +140,13 @@ class Notifier(object):
         if app.PUSHOVER_NOTIFY_ONSNATCH:
             self._notifyPushover(title, ep_name)
 
-    def notify_download(self, ep_name, title=notifyStrings[NOTIFY_DOWNLOAD]):
+    def notify_download(self, ep_obj, title=notifyStrings[NOTIFY_DOWNLOAD]):
         if app.PUSHOVER_NOTIFY_ONDOWNLOAD:
-            self._notifyPushover(title, ep_name)
+            self._notifyPushover(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
+    def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         if app.PUSHOVER_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notifyPushover(title, ep_name + ': ' + lang)
+            self._notifyPushover(title, ep_obj.pretty_name() + ': ' + lang)
 
     def notify_git_update(self, new_version='??'):
         if app.USE_PUSHOVER:

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -41,7 +41,7 @@ class Notifier(object):
         if app.SLACK_NOTIFY_DOWNLOAD:
             message = common.notifyStrings[common.NOTIFY_DOWNLOAD]
             self._notify_slack('{message} : {ep_name}'.format(message=message,
-                                                              ep_name=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
+                                                              ep_name=ep_obj.pretty_name_with_quality()
                                                               ))
 
     def notify_subtitle_download(self, ep_obj, lang):

--- a/medusa/notifiers/slack.py
+++ b/medusa/notifiers/slack.py
@@ -32,7 +32,7 @@ class Notifier(object):
             message = common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]]
             self._notify_slack('{message} : {ep_name}'.format(message=message, ep_name=ep_name))
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         """
         Send a notification to a slack channel when an episode is downloaded.
 
@@ -40,9 +40,11 @@ class Notifier(object):
         """
         if app.SLACK_NOTIFY_DOWNLOAD:
             message = common.notifyStrings[common.NOTIFY_DOWNLOAD]
-            self._notify_slack('{message} : {ep_name}'.format(message=message, ep_name=ep_name))
+            self._notify_slack('{message} : {ep_name}'.format(message=message,
+                                                              ep_name=ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')
+                                                              ))
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         """
         Send a notification to a Slack channel when subtitles for an episode are downloaded.
 
@@ -51,7 +53,7 @@ class Notifier(object):
         """
         if app.SLACK_NOTIFY_SUBTITLEDOWNLOAD:
             message = common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD]
-            self._notify_slack('{message} {ep_name}: {lang}'.format(message=message, ep_name=ep_name, lang=lang))
+            self._notify_slack('{message} {ep_name}: {lang}'.format(message=message, ep_name=ep_obj.pretty_name(), lang=lang))
 
     def notify_git_update(self, new_version='??'):
         """

--- a/medusa/notifiers/synology_notifier.py
+++ b/medusa/notifiers/synology_notifier.py
@@ -20,13 +20,14 @@ class Notifier(object):
         if app.SYNOLOGYNOTIFIER_NOTIFY_ONSNATCH:
             self._send_synologyNotifier(ep_name, common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]])
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         if app.SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD:
-            self._send_synologyNotifier(ep_name, common.notifyStrings[common.NOTIFY_DOWNLOAD])
+            self._send_synologyNotifier(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'),
+                                        common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         if app.SYNOLOGYNOTIFIER_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._send_synologyNotifier(ep_name + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
+            self._send_synologyNotifier(ep_obj.pretty_name() + ': ' + lang, common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD])
 
     def notify_git_update(self, new_version='??'):
         if app.USE_SYNOLOGYNOTIFIER:

--- a/medusa/notifiers/synology_notifier.py
+++ b/medusa/notifiers/synology_notifier.py
@@ -22,7 +22,7 @@ class Notifier(object):
 
     def notify_download(self, ep_obj):
         if app.SYNOLOGYNOTIFIER_NOTIFY_ONDOWNLOAD:
-            self._send_synologyNotifier(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'),
+            self._send_synologyNotifier(ep_obj.pretty_name_with_quality(),
                                         common.notifyStrings[common.NOTIFY_DOWNLOAD])
 
     def notify_subtitle_download(self, ep_obj, lang):

--- a/medusa/notifiers/telegram.py
+++ b/medusa/notifiers/telegram.py
@@ -100,7 +100,7 @@ class Notifier(object):
         if app.TELEGRAM_NOTIFY_ONSNATCH:
             self._notify_telegram(title, ep_name)
 
-    def notify_download(self, ep_name, title=notifyStrings[NOTIFY_DOWNLOAD]):
+    def notify_download(self, ep_obj, title=notifyStrings[NOTIFY_DOWNLOAD]):
         """
         Sends a Telegram notification when an episode is downloaded
 
@@ -108,9 +108,9 @@ class Notifier(object):
         :param title: The title of the notification to send
         """
         if app.TELEGRAM_NOTIFY_ONDOWNLOAD:
-            self._notify_telegram(title, ep_name)
+            self._notify_telegram(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
 
-    def notify_subtitle_download(self, ep_name, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
+    def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         """
         Sends a Telegram notification when subtitles for an episode are downloaded
 
@@ -119,7 +119,7 @@ class Notifier(object):
         :param title: The title of the notification to send
         """
         if app.TELEGRAM_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify_telegram(title, '%s: %s' % (ep_name, lang))
+            self._notify_telegram(title, '%s: %s' % (ep_obj.pretty_name(), lang))
 
     def notify_git_update(self, new_version='??'):
         """

--- a/medusa/notifiers/telegram.py
+++ b/medusa/notifiers/telegram.py
@@ -108,7 +108,7 @@ class Notifier(object):
         :param title: The title of the notification to send
         """
         if app.TELEGRAM_NOTIFY_ONDOWNLOAD:
-            self._notify_telegram(title, ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+            self._notify_telegram(title, ep_obj.pretty_name_with_quality())
 
     def notify_subtitle_download(self, ep_obj, lang, title=notifyStrings[NOTIFY_SUBTITLE_DOWNLOAD]):
         """

--- a/medusa/notifiers/tweet.py
+++ b/medusa/notifiers/tweet.py
@@ -40,16 +40,17 @@ class Notifier(object):
         if app.TWITTER_NOTIFY_ONSNATCH:
             self._notify_twitter('{0}: {1}'.format(common.notifyStrings[(common.NOTIFY_SNATCH, common.NOTIFY_SNATCH_PROPER)[is_proper]], ep_name))
 
-    def notify_download(self, ep_name):
+    def notify_download(self, ep_obj):
         """
         Send a notification that an episode was downloaded.
 
         :param ep_name: The name of the episode downloaded
         """
         if app.TWITTER_NOTIFY_ONDOWNLOAD:
-            self._notify_twitter('{0}: {1}'.format(common.notifyStrings[common.NOTIFY_DOWNLOAD], ep_name))
+            self._notify_twitter('{0}: {1}'.format(common.notifyStrings[common.NOTIFY_DOWNLOAD],
+                                                   ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')))
 
-    def notify_subtitle_download(self, ep_name, lang):
+    def notify_subtitle_download(self, ep_obj, lang):
         """
         Send a notification that subtitles for an episode were downloaded.
 
@@ -57,7 +58,8 @@ class Notifier(object):
         :param lang: The language of the downloaded subtitles
         """
         if app.TWITTER_NOTIFY_ONSUBTITLEDOWNLOAD:
-            self._notify_twitter('{0} {1}: {2}'.format(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD], ep_name, lang))
+            self._notify_twitter('{0} {1}: {2}'.format(common.notifyStrings[common.NOTIFY_SUBTITLE_DOWNLOAD],
+                                                       ep_obj.pretty_name(), lang))
 
     def notify_git_update(self, new_version='??'):
         """

--- a/medusa/notifiers/tweet.py
+++ b/medusa/notifiers/tweet.py
@@ -48,7 +48,7 @@ class Notifier(object):
         """
         if app.TWITTER_NOTIFY_ONDOWNLOAD:
             self._notify_twitter('{0}: {1}'.format(common.notifyStrings[common.NOTIFY_DOWNLOAD],
-                                                   ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN')))
+                                                   ep_obj.pretty_name_with_quality()))
 
     def notify_subtitle_download(self, ep_obj, lang):
         """

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -1286,7 +1286,7 @@ class PostProcessor(object):
             history.log_download(cur_ep, self.file_path, new_ep_quality, self.release_group, new_ep_version)
 
         # send notifications
-        notifiers.notify_download(ep_obj._format_pattern('%SN - %Sx%0E - %EN - %QN'))
+        notifiers.notify_download(ep_obj)
         # do the library update for KODI
         notifiers.kodi_notifier.update_library(ep_obj.series.name)
         # do the library update for Plex

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1374,6 +1374,21 @@ class Episode(TV):
 
         return self._format_pattern('%SN - S%0SE%0E - %EN')
 
+    def pretty_name_with_quality(self):
+        """Return the name of this episode in a "pretty" human-readable format, with quality information.
+
+        Used for notifications.
+
+        :return: A string representing the episode's name, season/ep numbers and quality
+        :rtype: str
+        """
+        if self.series.anime and not self.series.scene:
+            return self._format_pattern('%SN - %AB - %EN - %QN')
+        elif self.series.air_by_date:
+            return self._format_pattern('%SN - %AD - %EN - %QN')
+
+        return self._format_pattern('%SN - %Sx%0E - %EN - %QN')
+
     def __ep_name(self):
         """Return the name of the episode to use during renaming.
 

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -503,7 +503,7 @@ class Episode(TV):
                            episode_num(self.season, self.episode, numbering='absolute')),
                 }
             )
-            notifiers.notify_subtitle_download(self.pretty_name(), subtitle_list)
+            notifiers.notify_subtitle_download(self, subtitle_list)
         else:
             log.info(
                 '{id}: No subtitles found for {series} {ep}', {


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This prepares the terrain for tackling a proper Discord notifier. 
Sending the episode object allows to use embeds in the Discord notifier, as we'll have easy access to season, episode number, quality and other information, and will probably allow us to make other notifiers nicer in the future as well.