### PR TITLE
Bugfix join notifier

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -876,7 +876,7 @@ class Application(object):
             app.PUSHBULLET_API = check_setting_str(app.CFG, 'Pushbullet', 'pushbullet_api', '', censor_log='low')
             app.PUSHBULLET_DEVICE = check_setting_str(app.CFG, 'Pushbullet', 'pushbullet_device', '')
 
-            app.USE_JOIN = bool(check_setting_int(app.CFG, 'Pushbullet', 'use_join', 0))
+            app.USE_JOIN = bool(check_setting_int(app.CFG, 'Join', 'use_join', 0))
             app.JOIN_NOTIFY_ONSNATCH = bool(check_setting_int(app.CFG, 'Join', 'join_notify_onsnatch', 0))
             app.JOIN_NOTIFY_ONDOWNLOAD = bool(check_setting_int(app.CFG, 'Join', 'join_notify_ondownload', 0))
             app.JOIN_NOTIFY_ONSUBTITLEDOWNLOAD = bool(check_setting_int(app.CFG, 'Join', 'join_notify_onsubtitledownload', 0))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fixed typo in __main__.py that was preventing join notifier settings being maintained after restart. 