### PR TITLE
Enable non-anime search on Nyaa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 #### Improvements
 - Vueified "config - notifications" page. Improved components: config-textbox, select-list, show-selector, config-textbox-number. Improved responsiveness of the notification page on smaller screens ([#4913](https://github.com/pymedusa/Medusa/pull/4913))
 - Allow the use of priorities in the Pushover notifier ([#5567](https://github.com/pymedusa/Medusa/pull/5567))
+- Allow Nyaa and Anidex to search for non-anime shows ([#5680](https://github.com/pymedusa/Medusa/pull/5680) & [#5680](https://github.com/pymedusa/Medusa/pull/5681))
 
 #### Fixes
 - Fixed test not working for Download Station ([#5561](https://github.com/pymedusa/Medusa/pull/5561))

--- a/medusa/providers/torrent/rss/nyaa.py
+++ b/medusa/providers/torrent/rss/nyaa.py
@@ -32,7 +32,7 @@ class NyaaProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.supports_absolute_numbering = True
-        self.anime_only = True
+        self.anime_only = False
         self.confirmed = False
 
         # Torrent Stats
@@ -48,7 +48,7 @@ class NyaaProvider(TorrentProvider):
 
         :param search_strings: A dict with mode (key) and the search value (value)
         :param age: Not used
-        :param ep_obj: Not used
+        :param ep_obj: An episode object
         :returns: A list of search results (structure)
         """
         results = []
@@ -56,7 +56,7 @@ class NyaaProvider(TorrentProvider):
         # Search Params
         search_params = {
             'page': 'rss',
-            'c': '1_0',  # All Anime
+            'c': '1_0' if ep_obj.series.is_anime else '4_0',  # All Anime
             'f': 0,  # No filter
             'q': '',
         }

--- a/medusa/providers/torrent/rss/nyaa.py
+++ b/medusa/providers/torrent/rss/nyaa.py
@@ -32,7 +32,6 @@ class NyaaProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.supports_absolute_numbering = True
-        self.anime_only = False
         self.confirmed = False
 
         # Torrent Stats
@@ -54,11 +53,9 @@ class NyaaProvider(TorrentProvider):
         results = []
 
         # Search Params
-        if ep_obj:
-            category = '1_0' if ep_obj.series.is_anime else '4_0',  # All Anime if is_anime, else All Live Action
-        else:
-            # If ep_obj is None, assume we want anime
-            category = '1_0'
+        category = '1_0'
+        if ep_obj and not ep_obj.series.is_anime:
+            category = '4_0'
 
         search_params = {
             'page': 'rss',

--- a/medusa/providers/torrent/rss/nyaa.py
+++ b/medusa/providers/torrent/rss/nyaa.py
@@ -54,9 +54,15 @@ class NyaaProvider(TorrentProvider):
         results = []
 
         # Search Params
+        if ep_obj:
+            category = '1_0' if ep_obj.series.is_anime else '4_0',  # All Anime if is_anime, else All Live Action
+        else:
+            # If ep_obj is None, assume we want anime
+            category = '1_0'
+
         search_params = {
             'page': 'rss',
-            'c': '1_0' if ep_obj.series.is_anime else '4_0',  # All Anime
+            'c': category,
             'f': 0,  # No filter
             'q': '',
         }


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Nyaa has a Live Action category, this allows the provider to make use of it by adapting the RSS URL depending if the series has the is_anime flag or not.