### PR TITLE
Enable non-anime search on Anidex

### DIFF
--- a/medusa/providers/torrent/html/anidex.py
+++ b/medusa/providers/torrent/html/anidex.py
@@ -56,8 +56,14 @@ class AniDexProvider(TorrentProvider):
         """
         results = []
 
+        if ep_obj:
+            category = '1,2,3' if ep_obj.series.is_anime else '4,5'
+        else:
+            # If ep_obj is None, assume we want anime, since this in an anime-first tracker
+            category = '1,2,3'
+
         search_params = {
-            'id': '1,2,3' if ep_obj.series.is_anime else '4,5'
+            'id': category
         }
 
         for mode in search_strings:

--- a/medusa/providers/torrent/html/anidex.py
+++ b/medusa/providers/torrent/html/anidex.py
@@ -36,7 +36,7 @@ class AniDexProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.supports_absolute_numbering = True
-        self.anime_only = True
+        self.anime_only = False
 
         # Torrent Stats
         self.minseed = None
@@ -51,13 +51,13 @@ class AniDexProvider(TorrentProvider):
 
         :param search_strings: A dict with mode (key) and the search value (value)
         :param age: Not used
-        :param ep_obj: Not used
+        :param ep_obj: An episode object
         :returns: A list of search results (structure)
         """
         results = []
 
         search_params = {
-            'id': '1,2,3'
+            'id': '1,2,3' if ep_obj.series.is_anime else '4,5'
         }
 
         for mode in search_strings:

--- a/medusa/providers/torrent/html/anidex.py
+++ b/medusa/providers/torrent/html/anidex.py
@@ -36,7 +36,6 @@ class AniDexProvider(TorrentProvider):
 
         # Miscellaneous Options
         self.supports_absolute_numbering = True
-        self.anime_only = False
 
         # Torrent Stats
         self.minseed = None
@@ -56,11 +55,9 @@ class AniDexProvider(TorrentProvider):
         """
         results = []
 
-        if ep_obj:
-            category = '1,2,3' if ep_obj.series.is_anime else '4,5'
-        else:
-            # If ep_obj is None, assume we want anime, since this in an anime-first tracker
-            category = '1,2,3'
+        category = '1,2,3'
+        if ep_obj and not ep_obj.series.is_anime:
+            category = '4,5'
 
         search_params = {
             'id': category


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Anidex has a Live Action category, this allows the provider to make use of it by adapting the RSS URL depending if the series has the is_anime flag or not.