### PR TITLE
Fix Growl registration error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Fixed Download Station BraceAdapter exception ([#5573](https://github.com/pymedusa/Medusa/pull/5573))
 - Fixed saving multiple metadata providers ([#5576](https://github.com/pymedusa/Medusa/pull/5576))
 - Fixed show-selector for libraries with more than 1k shows ([#5623](https://github.com/pymedusa/Medusa/pull/5623))
+- Fixed Growl registration error ([#5684](https://github.com/pymedusa/Medusa/pull/5684))
 
 -----
 

--- a/medusa/notifiers/growl.py
+++ b/medusa/notifiers/growl.py
@@ -66,7 +66,7 @@ class Notifier(object):
         if message:
             notice.add_header('Notification-Text', message)
 
-        response = self._send(options['host'], options['port'], notice.encode('utf-8'), options['debug'])
+        response = self._send(options['host'], options['port'], notice.encode(), options['debug'])
         return True if isinstance(response, gntp.core.GNTPOK) else False
 
     @staticmethod
@@ -181,7 +181,7 @@ class Notifier(object):
             register.set_password(opts['password'])
 
         try:
-            return self._send(opts['host'], opts['port'], register.encode('utf-8'), opts['debug'])
+            return self._send(opts['host'], opts['port'], register.encode(), opts['debug'])
         except Exception as error:
             log.warning(
                 u'GROWL: Unable to send growl to {host}:{port} - {msg!r}',


### PR DESCRIPTION
Fixes #5683
Reverts the change made in #4657, because the encode functions are not string encode functions...
https://github.com/pymedusa/Medusa/blob/0c0a73583452f988c518adeafa75ee1f17987bdf/ext/gntp/core.py#L354
https://github.com/pymedusa/Medusa/blob/0c0a73583452f988c518adeafa75ee1f17987bdf/ext/gntp/core.py#L257