### PR TITLE
Add has_xem_numbering to Series class.

### DIFF
--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -238,6 +238,7 @@ class Series(TV):
             raise MultipleShowObjectsException("Can't create a show if it already exists")
 
         self._load_from_db()
+        self.has_xem_numbering = bool(self.xem_numbering)
 
     @classmethod
     def find_series(cls, predicate=None):
@@ -2042,6 +2043,8 @@ class Series(TV):
         if self.is_anime:
             data['config']['release']['blacklist'] = bw_list.blacklist
             data['config']['release']['whitelist'] = bw_list.whitelist
+
+        data['has_xem_numbering'] = self.has_xem_numbering
 
         # Fetch data from external sources
         if fetch:


### PR DESCRIPTION
* Only calculates on Series obj init.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
- [ ] Update changelog
- [ ] Update api-specification

@OmgImAlexis this is needed to show the xem icon on the poster layout.
We could make the xem_numbering available on the Series to_json. But that does a query on the tv_episodes table for that series. So every time you access the property Series.xem_numbering, you access the table.

Better would be to just query the series episodes directly. As it only does:

```'
SELECT season, episode, scene_season, scene_episode '
        'FROM tv_episodes '
        'WHERE indexer = ? AND showid = ? '
        'AND (scene_season or scene_episode) != 0 '
        'ORDER BY season, episode',
``` 