### PR TITLE
Perfect match for subtitles is too strict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### New Features
 
 #### Improvements
+- Improved perfect match for subtitles downloading by making it a bit less strict ([#5729](https://github.com/pymedusa/Medusa/issues/5729))
 
 #### Fixes
 - Fixed ImportError when using Download Station client ([#5748](https://github.com/pymedusa/Medusa/pull/5748))

--- a/medusa/subtitles.py
+++ b/medusa/subtitles.py
@@ -563,18 +563,17 @@ def merge_subtitles(existing_subtitles, new_subtitles):
 def get_min_score():
     """Return the min score to be used by subliminal.
 
-    Perfect match = hash - resolution (subtitle for 720p is the same as for 1080p) - video_codec - audio_codec
+    Perfect match = series + year + season + episode + release_group
     Non-perfect match = series + year + season + episode
 
     :return: min score to be used to download subtitles
     :rtype: int
     """
+    min_score = episode_scores['series'] + episode_scores['year'] + episode_scores['season'] + episode_scores['episode']
     if app.SUBTITLES_PERFECT_MATCH:
-        return episode_scores['hash'] - (episode_scores['resolution'] +
-                                         episode_scores['video_codec'] +
-                                         episode_scores['audio_codec'])
+        min_score += episode_scores['release_group']
 
-    return episode_scores['series'] + episode_scores['year'] + episode_scores['season'] + episode_scores['episode']
+    return min_score
 
 
 def get_current_subtitles(tv_episode):

--- a/tests/test_subtitles.py
+++ b/tests/test_subtitles.py
@@ -370,6 +370,28 @@ def test_merge_subtitles__with_multi_disabled_and_single_new_language(monkeypatc
     assert ['eng', 'pob', 'und'] == actual
 
 
+def test_get_min_score__with_perfect_match_enabled(monkeypatch):
+    # Given
+    monkeypatch.setattr(app, 'SUBTITLES_PERFECT_MATCH', True)
+
+    # When
+    actual = sut.get_min_score()
+
+    # Then
+    assert 345 == actual
+
+
+def test_get_min_score__with_perfect_match_disabled(monkeypatch):
+    # Given
+    monkeypatch.setattr(app, 'SUBTITLES_PERFECT_MATCH', False)
+
+    # When
+    actual = sut.get_min_score()
+
+    # Then
+    assert 330 == actual
+
+
 def test_get_subtitles_dir__no_subtitles_dir(monkeypatch):
     # Given
     monkeypatch.setattr(app, 'SUBTITLES_DIR', '')


### PR DESCRIPTION
Change perfect match in order to make it less strict as discussed in #5729.