### PR TITLE
Check cache for candidates when searching using backlog search.

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -239,7 +239,16 @@ class GenericProvider(object):
         )
 
     def search_results_in_cache(self, episodes, forced_search=False, download_current_quality=False):
-        """Search episodes based on param in cache."""
+        """
+        Search episodes based on param in cache
+
+        Search the cache (db) for this provider.
+        :param episodes: List of Episode objects.
+        :param forced_search: Flag if the search was triggered by a forced search.
+        :param download_current_quality: Flag if we want to include an already downloaded quality in the new search.
+
+        :return: A dict of search results, ordered by episode number.
+        """
         results = {}
         for episode in episodes:
             cache_results = self.cache.find_needed_episodes(
@@ -255,7 +264,20 @@ class GenericProvider(object):
 
     def find_search_results(self, series, episodes, search_mode, forced_search=False, download_current_quality=False,
                             manual_search=False, manual_search_type='episode'):
-        """Search episodes based on param."""
+        """
+        Search episodes based on param.
+
+        Search the provider using http queries.
+        :param series: Series object
+        :param episodes: List of Episode objects
+        :param search_mode: 'eponly' or 'sponly'
+        :param forced_search: Flag if the search was triggered by a forced search
+        :param download_current_quality: Flag if we want to include an already downloaded quality in the new search
+        :param manual_search: Flag if the search was triggered by a manual search
+        :param manual_search_type: How the manual search was started: For example an 'episode' or 'season'
+
+        :return: A dict of search results, ordered by episode number.
+        """
         self._check_auth()
         self.series = series
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -238,9 +238,9 @@ class GenericProvider(object):
             ))
         )
 
-    def search_results_in_cache(self, episodes, forced_search=False, download_current_quality=False):
+    def search_results_in_cache(self, episodes):
         """
-        Search episodes based on param in cache.
+        Search episodes based on param in cache. We're also checking if the quality is wanted.
 
         Search the cache (db) for this provider
         :param episodes: List of Episode objects
@@ -251,9 +251,7 @@ class GenericProvider(object):
         """
         results = {}
         for episode in episodes:
-            cache_results = self.cache.find_needed_episodes(
-                episode, forced_search=forced_search, down_cur_quality=download_current_quality
-            )
+            cache_results = self.cache.find_episodes(episode)
             if cache_results:
                 for episode_no in cache_results:
                     if episode_no not in results:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -240,25 +240,14 @@ class GenericProvider(object):
 
     def search_results_in_cache(self, episodes):
         """
-        Search episodes based on param in cache. We're also checking if the quality is wanted.
+        Search episodes based on param in cache.
 
         Search the cache (db) for this provider
         :param episodes: List of Episode objects
-        :param forced_search: Flag if the search was triggered by a forced search
-        :param download_current_quality: Flag if we want to include an already downloaded quality in the new search
 
         :return: A dict of search results, ordered by episode number
         """
-        results = {}
-        for episode in episodes:
-            cache_results = self.cache.find_episodes(episode)
-            if cache_results:
-                for episode_no in cache_results:
-                    if episode_no not in results:
-                        results[episode_no] = cache_results[episode_no]
-                    else:
-                        results[episode_no] += cache_results[episode_no]
-        return results
+        return self.cache.find_episodes(episodes)
 
     def find_search_results(self, series, episodes, search_mode, forced_search=False, download_current_quality=False,
                             manual_search=False, manual_search_type='episode'):

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -240,14 +240,14 @@ class GenericProvider(object):
 
     def search_results_in_cache(self, episodes, forced_search=False, download_current_quality=False):
         """
-        Search episodes based on param in cache
+        Search episodes based on param in cache.
 
-        Search the cache (db) for this provider.
-        :param episodes: List of Episode objects.
-        :param forced_search: Flag if the search was triggered by a forced search.
-        :param download_current_quality: Flag if we want to include an already downloaded quality in the new search.
+        Search the cache (db) for this provider
+        :param episodes: List of Episode objects
+        :param forced_search: Flag if the search was triggered by a forced search
+        :param download_current_quality: Flag if we want to include an already downloaded quality in the new search
 
-        :return: A dict of search results, ordered by episode number.
+        :return: A dict of search results, ordered by episode number
         """
         results = {}
         for episode in episodes:

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -238,6 +238,21 @@ class GenericProvider(object):
             ))
         )
 
+    def search_results_in_cache(self, episodes, forced_search=False, download_current_quality=False):
+        """Search episodes based on param in cache."""
+        results = {}
+        for episode in episodes:
+            cache_results = self.cache.find_needed_episodes(
+                episode, forced_search=forced_search, down_cur_quality=download_current_quality
+            )
+            if cache_results:
+                for episode_no in cache_results:
+                    if episode_no not in results:
+                        results[episode_no] = cache_results[episode_no]
+                    else:
+                        results[episode_no] += cache_results[episode_no]
+        return results
+
     def find_search_results(self, series, episodes, search_mode, forced_search=False, download_current_quality=False,
                             manual_search=False, manual_search_type='episode'):
         """Search episodes based on param."""
@@ -249,18 +264,6 @@ class GenericProvider(object):
         season_search = (len(episodes) > 1 or manual_search_type == 'season') and search_mode == 'sponly'
 
         for episode in episodes:
-            if not manual_search:
-                cache_results = self.cache.find_needed_episodes(
-                    episode, forced_search=forced_search, down_cur_quality=download_current_quality
-                )
-                if cache_results:
-                    for episode_no in cache_results:
-                        if episode_no not in results:
-                            results[episode_no] = cache_results[episode_no]
-                        else:
-                            results[episode_no] += cache_results[episode_no]
-                    continue
-
             search_strings = []
             if season_search:
                 search_strings = self._get_season_search_strings(episode)
@@ -471,6 +474,7 @@ class GenericProvider(object):
                           ', '.join(map(str, search_result.parsed_result.episode_numbers)),
                           search_result.name,
                           search_result.url)
+
             if episode_number not in results:
                 results[episode_number] = [search_result]
             else:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -714,8 +714,8 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                             found_candidates_in_cache = True
 
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there
-                # was something usefull in cache.
-                if not search_results and not found_candidates_in_cache:
+                # was something useful in cache.
+                if not found_candidates_in_cache:
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
                                                                       down_cur_quality, manual_search, manual_search_type)
             except AuthException as error:
@@ -776,7 +776,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
 
 def collect_candidates(found_results, provider, multi_results, single_results, series_obj, episodes, down_cur_quality):
-    """Collect candidates for multi-episode or season results"""
+    """Collect candidates for episode, multi-episode or season results."""
     candidates = (candidate for result, candidate in iteritems(found_results[provider.name])
                   if result in (SEASON_RESULT, MULTI_EP_RESULT))
     candidates = list(itertools.chain(*candidates))
@@ -791,13 +791,13 @@ def collect_candidates(found_results, provider, multi_results, single_results, s
 
 def list_results_for_provider(search_results, found_results, provider):
     """
-    Add results for this provider to the search_results dict
+    Add results for this provider to the search_results dict.
 
     The structure is based on [provider_name][episode_number][search_result]
-    :param search_results: New dictionary with search results for this provider.
-    :param found_results: Dictionary with existing per provider search results.
-    :param provider: Provider object.
-    :return: Updated dict found_results.
+    :param search_results: New dictionary with search results for this provider
+    :param found_results: Dictionary with existing per provider search results
+    :param provider: Provider object
+    :return: Updated dict found_results
     """
     for cur_ep in search_results:
         if cur_ep in found_results[provider.name]:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -711,15 +711,15 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                         cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, cache_multi,
                                                                        cache_single, series_obj, down_cur_quality)
 
-                        # check if we got any candidates from cache add add them to the list.
+                        # Check if we got any candidates from cache add add them to the list.
                         # If we found candidates in cache, we don't need to search the provider.
                         if cache_multi:
                             cache_multi_results += cache_multi
                         if cache_single:
                             cache_single_results += cache_single
 
-                # For now we only search if we didn't get any results back from cache, but we might wanna check if there
-                # was something useful in cache.
+                # For now we only search if we didn't get any results back from cache,
+                # but we might wanna check if there was something useful in cache.
                 if not (cache_multi or cache_single):
                     log.debug(u'Could not find any candidates in cache, searching provider.')
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
@@ -768,7 +768,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
             continue
 
         # From our providers multi_episode and single_episode results, collect candidates.
-        # only collect the candidates if we didn't got any from cache.
+        # Only collect the candidates if we didn't get any from cache.
         if not (cache_multi_results or cache_single_results):
             multi_results, single_results = collect_candidates(found_results, cur_provider, multi_results,
                                                                single_results, series_obj, down_cur_quality)

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -704,13 +704,13 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                     if search_results:
                         # From out providers multi_episode and single_episode results, collect candidates.
                         found_cache_results = list_results_for_provider(search_results, found_results, cur_provider)
-                        multi_results, single_results = collect_candidates(found_cache_results, cur_provider, multi_results,
+                        cache_multi_results, cache_single_results = collect_candidates(found_cache_results, cur_provider, multi_results,
                                                                            single_results, series_obj, episodes,
                                                                            down_cur_quality)
 
                         # check if we got any candidates from cache, and mark found candidates cache.
                         # If we found candidates in cache, we don't need to search the providers.
-                        if multi_results or single_results:
+                        if cache_multi_results or cache_single_results :
                             found_candidates_in_cache = True
 
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there
@@ -762,8 +762,12 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
             continue
 
         # From our providers multi_episode and single_episode results, collect candidates.
-        multi_results, single_results = collect_candidates(found_results, cur_provider, multi_results,
-                                                           single_results, series_obj, episodes, down_cur_quality)
+        # only collect the candidates if we didn't got any from cache.
+        if not (cache_multi_results or cache_single_results):
+            multi_results, single_results = collect_candidates(found_results, cur_provider, multi_results,
+                                                               single_results, series_obj, episodes, down_cur_quality)
+        else:
+            multi_results, single_results = cache_multi_results, cache_single_results
 
     # Remove provider from thread name before return results
     threading.currentThread().name = original_thread_name
@@ -842,7 +846,7 @@ def collect_single_candidates(candidates, results):
     return single_candidates + new_candidates
 
 
-def collect_multi_candidates(candidates, series_obj, episodes, down_cur_quality):
+def collect_multi_candidates(candidates, series_obj, down_cur_quality):
     """Collect mutli-episode and season result candidates."""
     multi_candidates = []
 

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -721,10 +721,11 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there
                 # was something useful in cache.
                 if not (cache_multi or cache_single):
+                    log.debug(u'Could not find any candidates in cache, searching provider.')
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
                                                                       down_cur_quality, manual_search, manual_search_type)
             except AuthException as error:
-                log.error(u'Authentication error: {0}', ex(error))
+                log.error(u'Authentication error: {0!r}', error)
                 break
 
             if search_results:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -647,6 +647,8 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
     manual_search_results = []
     multi_results = []
     single_results = []
+    cache_multi_results = []
+    cache_single_results = []
 
     # build name cache for show
     name_cache.build_name_cache(series_obj)
@@ -697,25 +699,24 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
             try:
                 search_results = []
-                found_candidates_in_cache = False
                 if not manual_search:
                     search_results = cur_provider.search_results_in_cache(episodes, forced_search, down_cur_quality)
 
                     if search_results:
                         # From out providers multi_episode and single_episode results, collect candidates.
                         found_cache_results = list_results_for_provider(search_results, found_results, cur_provider)
-                        cache_multi_results, cache_single_results = collect_candidates(found_cache_results, cur_provider, multi_results,
-                                                                           single_results, series_obj, episodes,
-                                                                           down_cur_quality)
+                        cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, multi_results,
+                                                                       single_results, series_obj, episodes, down_cur_quality)
 
-                        # check if we got any candidates from cache, and mark found candidates cache.
+                        # check if we got any candidates from cache add add them to the list.
                         # If we found candidates in cache, we don't need to search the providers.
-                        if cache_multi_results or cache_single_results :
-                            found_candidates_in_cache = True
+                        if cache_multi or cache_single:
+                            cache_multi_results += cache_multi
+                            cache_single_results += cache_single
 
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there
                 # was something useful in cache.
-                if not found_candidates_in_cache:
+                if not (cache_multi_results or cache_single_results):
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
                                                                       down_cur_quality, manual_search, manual_search_type)
             except AuthException as error:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -709,7 +709,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                         found_cache_results = list_results_for_provider(search_results, found_results, cur_provider)
                         # We're passing the empty lists, because we don't want to include previous candidates
                         cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, cache_multi,
-                                                                       cache_single, series_obj, episodes, down_cur_quality)
+                                                                       cache_single, series_obj, down_cur_quality)
 
                         # check if we got any candidates from cache add add them to the list.
                         # If we found candidates in cache, we don't need to search the providers.
@@ -770,7 +770,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
         # only collect the candidates if we didn't got any from cache.
         if not (cache_multi_results or cache_single_results):
             multi_results, single_results = collect_candidates(found_results, cur_provider, multi_results,
-                                                               single_results, series_obj, episodes, down_cur_quality)
+                                                               single_results, series_obj, down_cur_quality)
         else:
             multi_results, single_results = cache_multi_results, cache_single_results
 
@@ -784,13 +784,13 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
         return combine_results(multi_results, single_results)
 
 
-def collect_candidates(found_results, provider, multi_results, single_results, series_obj, episodes, down_cur_quality):
+def collect_candidates(found_results, provider, multi_results, single_results, series_obj, down_cur_quality):
     """Collect candidates for episode, multi-episode or season results."""
     candidates = (candidate for result, candidate in iteritems(found_results[provider.name])
                   if result in (SEASON_RESULT, MULTI_EP_RESULT))
     candidates = list(itertools.chain(*candidates))
     if candidates:
-        multi_results += collect_multi_candidates(candidates, series_obj, episodes, down_cur_quality)
+        multi_results += collect_multi_candidates(candidates, series_obj, down_cur_quality)
 
     # Collect candidates for single-episode results
     single_results = collect_single_candidates(found_results[provider.name], single_results)

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -678,7 +678,6 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
             continue
 
         found_results[cur_provider.name] = {}
-
         search_count = 0
         search_mode = cur_provider.search_mode
 
@@ -699,14 +698,18 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
             try:
                 search_results = []
+                cache_multi = []
+                cache_single = []
+
                 if not manual_search:
-                    search_results = cur_provider.search_results_in_cache(episodes, forced_search, down_cur_quality)
+                    search_results = cur_provider.search_results_in_cache(episodes)
 
                     if search_results:
                         # From out providers multi_episode and single_episode results, collect candidates.
                         found_cache_results = list_results_for_provider(search_results, found_results, cur_provider)
-                        cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, multi_results,
-                                                                       single_results, series_obj, episodes, down_cur_quality)
+                        # We're passing the empty lists, because we don't want to include previous candidates
+                        cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, cache_multi,
+                                                                       cache_single, series_obj, episodes, down_cur_quality)
 
                         # check if we got any candidates from cache add add them to the list.
                         # If we found candidates in cache, we don't need to search the providers.
@@ -717,7 +720,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there
                 # was something useful in cache.
-                if not (cache_multi_results or cache_single_results):
+                if not (cache_multi or cache_single):
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
                                                                       down_cur_quality, manual_search, manual_search_type)
             except AuthException as error:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -710,8 +710,9 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
                         # check if we got any candidates from cache add add them to the list.
                         # If we found candidates in cache, we don't need to search the providers.
-                        if cache_multi or cache_single:
+                        if cache_multi:
                             cache_multi_results += cache_multi
+                        if cache_single:
                             cache_single_results += cache_single
 
                 # For now we only search if we didn't get any results back from cache, but we might wanna check if there

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -698,21 +698,21 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
 
             try:
                 search_results = []
+                cache_search_results = []
                 cache_multi = []
                 cache_single = []
 
                 if not manual_search:
-                    search_results = cur_provider.search_results_in_cache(episodes)
-
-                    if search_results:
-                        # From out providers multi_episode and single_episode results, collect candidates.
-                        found_cache_results = list_results_for_provider(search_results, found_results, cur_provider)
+                    cache_search_results = cur_provider.search_results_in_cache(episodes)
+                    if cache_search_results:
+                        # From our provider multi_episode and single_episode results, collect candidates.
+                        found_cache_results = list_results_for_provider(cache_search_results, found_results, cur_provider)
                         # We're passing the empty lists, because we don't want to include previous candidates
                         cache_multi, cache_single = collect_candidates(found_cache_results, cur_provider, cache_multi,
                                                                        cache_single, series_obj, down_cur_quality)
 
                         # check if we got any candidates from cache add add them to the list.
-                        # If we found candidates in cache, we don't need to search the providers.
+                        # If we found candidates in cache, we don't need to search the provider.
                         if cache_multi:
                             cache_multi_results += cache_multi
                         if cache_single:
@@ -724,14 +724,14 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                     log.debug(u'Could not find any candidates in cache, searching provider.')
                     search_results = cur_provider.find_search_results(series_obj, episodes, search_mode, forced_search,
                                                                       down_cur_quality, manual_search, manual_search_type)
+                    # Update the list found_results
+                    found_results = list_results_for_provider(search_results, found_results, cur_provider)
+
             except AuthException as error:
                 log.error(u'Authentication error: {0!r}', error)
                 break
 
-            if search_results:
-                # make a list of all the results for this provider
-                # Update the list found_results
-                found_results = list_results_for_provider(search_results, found_results, cur_provider)
+            if search_results or cache_search_results:
                 break
             elif not cur_provider.search_fallback or search_count == 2:
                 break

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -454,9 +454,23 @@ class Cache(object):
             'WHERE url=?'.format(provider=self.provider_id), [url]
         )[0]['count']
 
-    def find_needed_episodes(self, episode, forced_search=False,
-                             down_cur_quality=False):
-        """Find needed episodes."""
+    def find_needed_episodes(self, episode, forced_search=False, down_cur_quality=False):
+        """
+        Search cache for needed episodes.
+
+        NOTE: This is currently only used by the Daily Search.
+        The following checks are performed on the cache results:
+        * Use the episodes current quality / wanted quality to decide if we want it
+        * Filtered on ignored/required words, and non-tv junk
+        * Filter out non-anime results on Anime only providers
+        * Check if the series is still in our library
+
+        :param episode: Single or list of episode object(s)
+        :param forced_search: Flag to mark that this is searched through a forced search
+        :param down_cur_quality: Flag to mark that we want to include the episode(s) current quality
+
+        :return list of SearchResult objects.
+        """
         needed_eps = {}
         results = []
 
@@ -601,3 +615,142 @@ class Cache(object):
         self.searched = time()
 
         return needed_eps
+
+    def find_episodes(self, episode):
+        """
+        Search cache for episodes.
+
+        NOTE: This is currently only used by the Backlog/Forced Search. As we determine the candidates there.
+        The following checks are performed on the cache results:
+        * Use the episodes current quality / wanted quality to decide if we want it
+        * Filtered on ignored/required words, and non-tv junk
+        * Filter out non-anime results on Anime only providers
+        * Check if the series is still in our library
+
+        :param episode: Single or list of episode object(s)
+        :param forced_search: Flag to mark that this is searched through a forced search
+        :param down_cur_quality: Flag to mark that we want to include the episode(s) current quality
+
+        :return list of SearchResult objects.
+        """
+        cache_results = {}
+        results = []
+
+        cache_db_con = self._get_db()
+        if not episode:
+            sql_results = cache_db_con.select(
+                'SELECT * FROM [{name}]'.format(name=self.provider_id))
+        elif not isinstance(episode, list):
+            sql_results = cache_db_con.select(
+                'SELECT * FROM [{name}] '
+                'WHERE indexer = ? AND'
+                '      indexerid = ? AND'
+                '      season = ? AND'
+                '      episodes LIKE ?'.format(name=self.provider_id),
+                [episode.series.indexer, episode.series.series_id, episode.season,
+                 '%|{0}|%'.format(episode.episode)]
+            )
+        else:
+            for ep_obj in episode:
+                results.append([
+                    'SELECT * FROM [{name}] '
+                    'WHERE indexer = ? AND '
+                    '      indexerid = ? AND'
+                    '      season = ? AND'
+                    '      episodes LIKE ?'.format(
+                        name=self.provider_id
+                    ),
+                    [ep_obj.series.indexer, ep_obj.series.series_id, ep_obj.season,
+                     '%|{0}|%'.format(ep_obj.episode)]]
+                )
+
+            if results:
+                # Only execute the query if we have results
+                sql_results = cache_db_con.mass_action(results, fetchall=True)
+                sql_results = list(itertools.chain(*sql_results))
+            else:
+                sql_results = []
+                log.debug(
+                    '{id}: No cached results in {provider} for series {show_name!r} episode {ep}', {
+                        'id': episode[0].series.series_id,
+                        'provider': self.provider.name,
+                        'show_name': episode[0].series.name,
+                        'ep': episode_num(episode[0].season, episode[0].episode),
+                    }
+                )
+
+        # for each cache entry
+        for cur_result in sql_results:
+            if cur_result['indexer'] is None:
+                log.debug('Ignoring result: {0}, missing indexer. This is probably a result added'
+                          ' prior to medusa version 0.2.0', cur_result['name'])
+                continue
+
+            search_result = self.provider.get_result()
+
+            # get the show, or ignore if it's not one of our shows
+            series_obj = Show.find_by_id(app.showList, int(cur_result['indexer']), int(cur_result['indexerid']))
+            if not series_obj:
+                continue
+
+            # skip if provider is anime only and show is not anime
+            if self.provider.anime_only and not series_obj.is_anime:
+                log.debug('{0} is not an anime, skipping', series_obj.name)
+                continue
+
+            # build a result object
+            search_result.quality = int(cur_result['quality'])
+            search_result.release_group = cur_result['release_group']
+            search_result.version = cur_result['version']
+            search_result.name = cur_result['name']
+            search_result.url = cur_result['url']
+            search_result.season = int(cur_result['season'])
+            search_result.actual_season = search_result.season
+
+            sql_episodes = cur_result['episodes'].strip('|')
+            # TODO: Add support for season results
+            # Season result
+            if not sql_episodes:
+                ep_objs = series_obj.get_all_episodes(search_result.season)
+                actual_episodes = [ep.episode for ep in ep_objs]
+                episode_number = SEASON_RESULT
+            # Multi or single episode result
+            else:
+                actual_episodes = [int(ep) for ep in sql_episodes.split('|')]
+                ep_objs = [series_obj.get_episode(search_result.season, ep) for ep in actual_episodes]
+                if len(actual_episodes) == 1:
+                    episode_number = actual_episodes[0]
+                else:
+                    episode_number = MULTI_EP_RESULT
+
+            search_result.episodes = ep_objs
+            search_result.actual_episodes = actual_episodes
+
+            log.debug(
+                '{id}: Using cached results from {provider} for series {show_name!r} episode {ep}', {
+                    'id': search_result.episodes[0].series.series_id,
+                    'provider': self.provider.name,
+                    'show_name': search_result.episodes[0].series.name,
+                    'ep': episode_num(search_result.episodes[0].season, search_result.episodes[0].episode),
+                }
+            )
+
+            # Map the remaining attributes
+            search_result.series = series_obj
+            search_result.seeders = cur_result['seeders']
+            search_result.leechers = cur_result['leechers']
+            search_result.size = cur_result['size']
+            search_result.pubdate = cur_result['pubdate']
+            search_result.proper_tags = cur_result['proper_tags'].split('|') if cur_result['proper_tags'] else ''
+            search_result.content = None
+
+            # add it to the list
+            if episode_number not in cache_results:
+                cache_results[episode_number] = [search_result]
+            else:
+                cache_results[episode_number].append(search_result)
+
+        # datetime stamp this search so cache gets cleared
+        self.searched = time()
+
+        return cache_results

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -622,14 +622,9 @@ class Cache(object):
 
         NOTE: This is currently only used by the Backlog/Forced Search. As we determine the candidates there.
         The following checks are performed on the cache results:
-        * Use the episodes current quality / wanted quality to decide if we want it
-        * Filtered on ignored/required words, and non-tv junk
         * Filter out non-anime results on Anime only providers
         * Check if the series is still in our library
-
         :param episode: Single or list of episode object(s)
-        :param forced_search: Flag to mark that this is searched through a forced search
-        :param down_cur_quality: Flag to mark that we want to include the episode(s) current quality
 
         :return list of SearchResult objects.
         """


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

fix #5582 

### This should be extensively tested before merging.
ASIS: In each backlog for every episode search, we check the cache if we get anything back. If so, we dont bother searching the provider. This makes the searching process heavily dependent on the Daily/RSS search.

With this change, we also check if the results from cache, include any candidates, where we also check quality, required words, release groups, etc.

If the results do not have any candidates, we start a search for the provider.