### PR TITLE
Check version if /git-commit exists

### DIFF
--- a/medusa/version_checker.py
+++ b/medusa/version_checker.py
@@ -585,6 +585,10 @@ class GitUpdateManager(UpdateManager):
             self._cur_commit_hash = cur_commit_hash
             app.CUR_COMMIT_HASH = str(cur_commit_hash)
             return True
+        elif os.path.isfile('/git-commit'):
+            cur_commit_hash = open('/git-commit', 'r').read()
+            self._cur_commit_hash = str(cur_commit_hash)
+            app.CUR_COMMIT_HASH = str(cur_commit_hash)
         else:
             return False
 


### PR DESCRIPTION
For use in Docker scenarios - checks existence of newly created /git-commit file which has the hash for the Docker version's git pull. Not sure if this is v good but please do feel free to edit if not up to snuff.