### PR TITLE
Added a break, to prevent snatching multiple results.

### DIFF
--- a/medusa/search/queue.py
+++ b/medusa/search/queue.py
@@ -405,6 +405,7 @@ class ForcedSearchQueueItem(generic_queue.QueueItem):
 
                     # Give the CPU a break
                     time.sleep(common.cpu_presets[app.CPU_PRESET])
+                    break
 
             elif self.manual_search and search_result:
                 self.results = search_result
@@ -586,6 +587,7 @@ class BacklogQueueItem(generic_queue.QueueItem):
 
                         # give the CPU a break
                         time.sleep(common.cpu_presets[app.CPU_PRESET])
+                        break
                 else:
                     log.info('No needed episodes found during backlog search for: {name}',
                              {'name': self.show.name})


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

@medariox i'm really confused here.
Did we change something which resulted in this function being able to return multiple results for the same episode?
https://github.com/pymedusa/Medusa/blob/master/medusa/search/core.py#L634

Because this comment throws me off. As it says we only use the first. But there is no code, that makes sure of that.
https://github.com/pymedusa/Medusa/blob/master/medusa/search/queue.py#L551

I tested this. And the backlog search, returns an array with multiple search_result objects, for the same episode.