### PR TITLE
Fix endswith first arg as int in guessit rule. Fixes #5995

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1095,7 +1095,7 @@ class FixParentFolderReplacingTitle(Rule):
 
                 if second_part.startswith(title[0].value):
                     season = matches.named('season')
-                    if season and not second_part.endswith(season[-1].initiator.value):
+                    if season and not second_part.endswith(str(season[-1].initiator.value)):
                         episode_title[0].name = 'title'
                         to_append = episode_title
                         to_remove = title


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
