### PR TITLE
Fix deprecated get_newest_commit_hash() reference. Fixes #6081

### DIFF
--- a/medusa/server/api/v1/core.py
+++ b/medusa/server/api/v1/core.py
@@ -1413,13 +1413,13 @@ class CMD_CheckVersion(ApiCall):
         data = {
             'current_version': {
                 'branch': check_version.get_branch(),
-                'commit': check_version.updater.get_cur_commit_hash(),
-                'version': check_version.updater.get_cur_version(),
+                'commit': check_version.updater.current_commit_hash,
+                'version': check_version.updater.current_version,
             },
             'latest_version': {
                 'branch': check_version.get_branch(),
-                'commit': check_version.updater.get_newest_commit_hash(),
-                'version': check_version.updater.get_newest_version(),
+                'commit': check_version.updater.newest_commit_hash,
+                'version': check_version.updater.newest_version,
             },
             'commits_offset': check_version.updater.commits_behind,
             'needs_update': needs_update,

--- a/medusa/updater/version_checker.py
+++ b/medusa/updater/version_checker.py
@@ -189,7 +189,7 @@ class CheckVersion(object):
         """
         try:
             self.updater.need_update()
-            cur_hash = str(self.updater.get_newest_commit_hash())
+            cur_hash = str(self.updater.newest_commit_hash)
             assert len(cur_hash) == 40, 'Commit hash wrong length: {length} hash: {hash}'.format(
                 length=len(cur_hash), hash=cur_hash)
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
