### PR TITLE
Fix trying to use error.response while None for Telegram. Fixes #6065

### DIFF
--- a/medusa/notifiers/telegram.py
+++ b/medusa/notifiers/telegram.py
@@ -68,7 +68,7 @@ class Notifier(object):
             success = True
         except RequestException as error:
             message = 'Unknown IO error: %s' % error
-            if hasattr(error, 'response'):
+            if hasattr(error, 'response') and error.response is not None:
                 error_message = {
                     400: 'Missing parameter(s). Double check your settings or if the channel/user exists.',
                     401: 'Authentication failed.',


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
