### PR TITLE
Fix username retrieval inside Docker container

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -969,6 +969,10 @@ class Application(object):
             try:
                 import pwd
                 app.OS_USER = pwd.getpwuid(os.getuid()).pw_name
+            except KeyError:
+                # In the case of a usage with Docker `user` feature, the username might not exist.
+                # See: https://docs.docker.com/engine/reference/run/#user
+                app.OS_USER = os.getuid()
             except ImportError:
                 try:
                     import getpass

--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -970,7 +970,7 @@ class Application(object):
                 import pwd
                 app.OS_USER = pwd.getpwuid(os.getuid()).pw_name
             except KeyError:
-                # In the case of a usage with Docker `user` feature, the username might not exist.
+                # In the case of a usage with Docker run `user` feature, the username might not exist.
                 # See: https://docs.docker.com/engine/reference/run/#user
                 app.OS_USER = os.getuid()
             except ImportError:


### PR DESCRIPTION
When running inside a Docker container with the `--user` Docker run option,
username might not exist. See: https://docs.docker.com/engine/reference/run/#user.
Fallback on the uid in this case.

- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
