### PR TITLE
Docker image support Python3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,20 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
+RUN apk add --no-cache python3 && \
+    python3 -m ensurepip && \
+    rm -r /usr/lib/python*/ensurepip && \
+    pip3 install --upgrade pip setuptools && \
+    if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
+    if [[ ! -e /usr/bin/python ]]; then rm /usr/bin/python; fi && \
+    ln -sf /usr/bin/python3.6 /usr/bin/python && \
+    rm -r /root/.cache
+
 # install packages
 RUN \
  apk add --no-cache \
-	--repository http://nl.alpinelinux.org/alpine/edge/community \
-	mediainfo gdbm py-gdbm
+        --repository http://nl.alpinelinux.org/alpine/edge/community \
+        mediainfo
 
 # install app
 COPY . /app/medusa/


### PR DESCRIPTION
Not sure this is ready for primetime unless we feel 3.6 support is. I don't notice much of a speed change but feel free to test and send notes. This probably could be more elegantly refactored into a tag for Docker to choose :latest or :python3 or :python2 but that's beyond me at the moment time wise :)

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
