### PR TITLE
Fix TNTVillage search

### DIFF
--- a/medusa/providers/torrent/html/tntvillage.py
+++ b/medusa/providers/torrent/html/tntvillage.py
@@ -96,11 +96,8 @@ class TNTVillageProvider(TorrentProvider):
         items = []
 
         with BS4Parser(data, 'html5lib') as html:
-            torrent_table = html.find('div', class_='showrelease_tb')
-            torrent_rows = []
-            for row in torrent_table:
-                if row.find('td', string='Titolo'):
-                    torrent_rows += row('tr')
+            torrent_table = html.find_all('div', class_='showrelease_tb')
+            torrent_rows = torrent_table[-1]('tr') if torrent_table else []
 
             # Continue only if at least one release is found
             if len(torrent_rows) < 2:

--- a/medusa/providers/torrent/html/tntvillage.py
+++ b/medusa/providers/torrent/html/tntvillage.py
@@ -97,7 +97,10 @@ class TNTVillageProvider(TorrentProvider):
 
         with BS4Parser(data, 'html5lib') as html:
             torrent_table = html.find('div', class_='showrelease_tb')
-            torrent_rows = torrent_table('tr') if torrent_table else []
+            torrent_rows = []
+            for row in torrent_table:
+                if row.find('td', string='Titolo'):
+                    torrent_rows += row('tr')
 
             # Continue only if at least one release is found
             if len(torrent_rows) < 2:


### PR DESCRIPTION
For some reason right now there are two "showrelease_tb" classes in the page, so maybe it's better to select the one with a meaningful <td> label.

- [X ] PR is based on the DEVELOP branch
- [X ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
