### PR TITLE
Fix email notifier name parser. Fixes #6526

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fixed extra scripts running with Python 3 ([#6428](https://github.com/pymedusa/Medusa/pull/6428))
 - Fixed Torrenting provider exception when offline ([#6430](https://github.com/pymedusa/Medusa/pull/6430))
 - Fixed snatching of air by date shows specials ([#6457](https://github.com/pymedusa/Medusa/pull/6457))
+- Fixed email notifier name parser warning for ABD episodes ([#6527](https://github.com/pymedusa/Medusa/pull/6527))
 
 ## 0.3.1 (2019-03-20)
 

--- a/medusa/notifiers/emailnotify.py
+++ b/medusa/notifiers/emailnotify.py
@@ -42,7 +42,7 @@ class Notifier(object):
 
     name_pattern = re.compile(
         r'(?P<show>.+?) - '
-        r'(?P<ep_id>S?\d+[Ex]\d+( - \d{3})?|\d{3}|\d{4}-\d{2}-\d{2}) - '
+        r'(?P<ep_id>S?\d+[Ex]\d+( - \d{3})?|\d{3}|\d{4} \d{2} \d{2}) - '
         r'(?P<episode>.*)'
     )
 

--- a/tests/notifiers/test_emailnotify.py
+++ b/tests/notifiers/test_emailnotify.py
@@ -99,26 +99,26 @@ from six import text_type
         }
     },
     {  # p11 - [%SN - %AD - %EN] - hypen in episode name
-        'ep_name': 'Archer - 2017-08-12 - Danger Island - Disheartening Situation',
+        'ep_name': 'Archer - 2017 08 12 - Danger Island - Disheartening Situation',
         'expected': {
             'show': 'Archer',
-            'ep_id': '2017-08-12',
+            'ep_id': '2017 08 12',
             'episode': 'Danger Island - Disheartening Situation'
         }
     },
     {  # p12 - [%SN - %AD - %EN]
-        'ep_name': 'Jersey Shore Family Vacation - 2018-04-20 - Meatball Down',
+        'ep_name': 'Jersey Shore Family Vacation - 2018 04 20 - Meatball Down',
         'expected': {
             'show': 'Jersey Shore Family Vacation',
-            'ep_id': '2018-04-20',
+            'ep_id': '2018 04 20',
             'episode': 'Meatball Down'
         }
     },
     {  # p13 - [%SN - %AD - %EN] - empty episode name
-        'ep_name': 'Jersey Shore Family Vacation - 2018-04-20 - ',
+        'ep_name': 'Jersey Shore Family Vacation - 2018 04 20 - ',
         'expected': {
             'show': 'Jersey Shore Family Vacation',
-            'ep_id': '2018-04-20',
+            'ep_id': '2018 04 20',
             'episode': ''
         }
     },


### PR DESCRIPTION
Fixes #6526 

It seems like I made a mistake when I wrote the parser (#4450).
`%AD` uses spaces, not dashes:
https://github.com/pymedusa/Medusa/blob/532abfa8fb462fd1aa31ebe0cd64e828abb2104a/medusa/tv/episode.py#L1542-L1545

```py
# Before:
from medusa.notifiers.emailnotify import Notifier
Notifier._parse_name('Jeopardy! - 2019 04 15 - Returning Champion Vs. , show # 7971 - 720p HDTV')
# WARNING:medusa.notifiers.emailnotify:Unable to parse "Jeopardy! - 2019 04 15 - Returning Champion Vs. , show # 7971 - 720p HDTV" for email notification
{'show': 'Jeopardy!', 'episode': '2019 04 15 - Returning Champion Vs. , show # 7971 - 720p HDTV'}

# After:
from medusa.notifiers.emailnotify import Notifier
Notifier._parse_name('Jeopardy! - 2019 04 15 - Returning Champion Vs. , show # 7971 - 720p HDTV')
{'show': 'Jeopardy!', 'ep_id': '2019 04 15', 'episode': 'Returning Champion Vs. , show # 7971 - 720p HDTV'}
```