### PR TITLE
Change get_redirect_url() to retrieve the last redirect URL. Fixes #6610

### DIFF
--- a/medusa/providers/torrent/torrent_provider.py
+++ b/medusa/providers/torrent/torrent_provider.py
@@ -146,12 +146,13 @@ class TorrentProvider(GenericProvider):
         return pubdate
 
     def get_redirect_url(self, url):
-        """Get the address that the provided URL redirects to."""
+        """Get the final address that the provided URL redirects to."""
         log.debug('Retrieving redirect URL for {url}', {'url': url})
 
-        response = self.session.get(url, allow_redirects=False)
-        if response and response.headers.get('Location'):
-            return response.headers['Location']
+        response = self.session.get(url, stream=True)
+        if response:
+            response.close()
+            return response.url
 
         log.debug('Unable to retrieve redirect URL for {url}', {'url': url})
         return url


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
