### PR TITLE
Fix Elite-Tracker exception when no result is returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Fixed download of multi episode releases without single results ([#6537](https://github.com/pymedusa/Medusa/pull/6537))
 - Fixed "send to trash" option not doing anything (Python 3.6 and higher) ([#6625](https://github.com/pymedusa/Medusa/pull/6625))
 - Fixed setting episodes to archived in backlog overview ([#6636](https://github.com/pymedusa/Medusa/pull/6636))
+- Fixed exception in Elte-Tracker provider when no result is found ([#6680](https://github.com/pymedusa/Medusa/pull/6680))
 
 ## 0.3.1 (2019-03-20)
 

--- a/medusa/providers/torrent/html/elitetracker.py
+++ b/medusa/providers/torrent/html/elitetracker.py
@@ -119,7 +119,7 @@ class EliteTrackerProvider(TorrentProvider):
             torrent_rows = torrent_table('tr') if torrent_table else []
 
             # Continue only if at least one release is found
-            if torrent_rows[1].get_text(strip=True) == 'Aucun Resultat':
+            if torrent_rows[1].get_text(strip=True) == 'Aucun résultat':
                 log.debug('Data returned from provider does not contain any torrents')
                 return items
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Thanks to @jbnitro for providing access to the provider.