### PR TITLE
Fix API v2 exception on incorrect API key. Fixes #5425

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed "send to trash" option not doing anything (Python 3.6 and higher) ([#6625](https://github.com/pymedusa/Medusa/pull/6625))
 - Fixed setting episodes to archived in backlog overview ([#6636](https://github.com/pymedusa/Medusa/pull/6636))
 - Fixed exception in Elte-Tracker provider when no result is found ([#6680](https://github.com/pymedusa/Medusa/pull/6680))
+- Fixed exception in API v2 when an incorrect API key was provided, or none was provided ([#6703](https://github.com/pymedusa/Medusa/pull/6703))
 
 ## 0.3.1 (2019-03-20)
 

--- a/medusa/server/api/v2/auth.py
+++ b/medusa/server/api/v2/auth.py
@@ -30,9 +30,9 @@ class AuthHandler(BaseRequestHandler):
     #: allowed HTTP methods
     allowed_methods = ('POST', )
 
-    def prepare(self):
-        """Prepare."""
-        pass
+    def _check_authentication(self):
+        """Override authentication check for the authentication endpoint."""
+        return None
 
     def http_post(self, *args, **kwargs):
         """Request JWT."""

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -154,8 +154,8 @@ class BaseRequestHandler(RequestHandler):
         exc_info = kwargs.get('exc_info', None)
 
         if exc_info and isinstance(exc_info[1], HTTPError):
-            error = exc_info[1]
-            response = self.api_response(status=status_code, error=error.reason)
+            error = exc_info[1].log_message or exc_info[1].reason
+            response = self.api_response(status=status_code, error=error)
         elif app.DEVELOPER and exc_info:
             self.set_header('content-type', 'text/plain')
             self.set_status(500)

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -328,11 +328,8 @@ class BaseRequestHandler(RequestHandler):
             self._raise_bad_request_error('Invalid limit parameter')
 
     def _paginate(self, data=None, data_generator=None, sort=None):
-        try:
-            arg_page = self._get_page()
-            arg_limit = self._get_limit()
-        except HTTPError as error:
-            return self._bad_request(error.message)
+        arg_page = self._get_page()
+        arg_limit = self._get_limit()
 
         headers = {
             'X-Pagination-Page': arg_page,

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -166,6 +166,24 @@ class BaseRequestHandler(RequestHandler):
 
         self.finish(response)
 
+    def log_exception(self, typ, value, tb):
+        """
+        Customize logging of uncaught exceptions.
+
+        Only logs unhandled exceptions, as ``HTTPErrors`` are common for a RESTful API handler.
+        """
+        if not app.WEB_LOG:
+            return
+
+        if isinstance(value, HTTPError):
+            return
+
+        log.error('Uncaught exception: {summary}\n{req!r}', {
+            'summary': self._request_summary(),
+            'req': self.request,
+            'exc_info': (typ, value, tb),
+        })
+
     def options(self, *args, **kwargs):
         """OPTIONS HTTP method."""
         self._no_content()

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -56,11 +56,8 @@ class BaseRequestHandler(RequestHandler):
     #: parent resource handler
     parent_handler = None
 
-    def prepare(self):
+    def _check_authentication(self):
         """Check if JWT or API key is provided and valid."""
-        if self.request.method == 'OPTIONS':
-            return
-
         api_key = self.get_argument('api_key', default=None) or self.request.headers.get('X-Api-Key')
         if api_key and api_key == app.API_KEY:
             return
@@ -94,7 +91,8 @@ class BaseRequestHandler(RequestHandler):
 
         def blocking_call():
             try:
-                return method(*args, **kwargs)
+                result = self._check_authentication()
+                return method(*args, **kwargs) if result is None else result
             except Exception as error:
                 self._handle_request_exception(error)
 

--- a/tests/apiv2/test_auth.py
+++ b/tests/apiv2/test_auth.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+"""Test /authentication route and authentication checks."""
+from __future__ import unicode_literals
+
+import json
+
+import pytest
+
+
+@pytest.mark.gen_test
+def test_no_api_key(http_client, create_url):
+    # given
+    expected = {'error': 'No authorization token.'}
+
+    url = create_url('/log', api_key=None)
+
+    # when
+    response = yield http_client.fetch(url, raise_error=False)
+
+    # then
+    assert response.code == 401
+    assert expected == json.loads(response.body)
+
+
+@pytest.mark.gen_test
+def test_bad_api_key(http_client, create_url):
+    # given
+    expected = {'error': 'No authorization token.'}
+
+    url = create_url('/log', api_key='123')
+
+    # when
+    response = yield http_client.fetch(url, raise_error=False)
+
+    # then
+    assert response.code == 401
+    assert expected == json.loads(response.body)


### PR DESCRIPTION
Fixes #5425, added 2 small tests for that
Fixes RESTful `HTTPError`s causing real exceptions.