### PR TITLE
Remove old regex pattern from `CensoredFormatter`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@
 - Fixed download of multi episode releases without single results ([#6537](https://github.com/pymedusa/Medusa/pull/6537))
 - Fixed "send to trash" option not doing anything (Python 3.6 and higher) ([#6625](https://github.com/pymedusa/Medusa/pull/6625))
 - Fixed setting episodes to archived in backlog overview ([#6636](https://github.com/pymedusa/Medusa/pull/6636))
-- Fixed exception in Elte-Tracker provider when no result is found ([#6680](https://github.com/pymedusa/Medusa/pull/6680))
+- Fixed exception in Elite-Tracker provider when no result is found ([#6680](https://github.com/pymedusa/Medusa/pull/6680))
 - Fixed exception in API v2 when an incorrect API key was provided, or none was provided ([#6703](https://github.com/pymedusa/Medusa/pull/6703))
+- Removed legacy log-censoring code for Newznab providers ([#6705](https://github.com/pymedusa/Medusa/pull/6705))
 
 ## 0.3.1 (2019-03-20)
 

--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -576,9 +576,6 @@ class CensoredFormatter(logging.Formatter, object):
 
     absurd_re = re.compile(r'[\d\w]')
 
-    # Needed because Newznab apikey isn't stored as key=value in a section.
-    apikey_re = re.compile(r'(?P<before>[&?]r|[&?]apikey|[&?]api_key)(?:=|%3D)([^&]*)(?P<after>[&\w]?)', re.IGNORECASE)
-
     def __init__(self, fmt=None, datefmt=None, encoding='utf-8'):
         """Constructor."""
         super(CensoredFormatter, self).__init__(fmt, datefmt)
@@ -614,8 +611,6 @@ class CensoredFormatter(logging.Formatter, object):
 
             for item in censored:
                 msg = msg.replace(item, '**********')  # must not give any hint about the length
-
-            msg = self.apikey_re.sub(r'\g<before>=**********\g<after>', msg)
 
         level = record.levelno
         if level in (WARNING, ERROR):


### PR DESCRIPTION
Newznab used to be a long string (`NEWZNAB_DATA`), and didn't have actual config sections, but that's changed now (#2970).
So now when `newznab`/`torznab` providers and loaded, the API key gets added to the censored items list.

The other reason for removing this is because the pattern isn't very accurate and can cause issues with logs.
For example, I noticed this with a log from `tornado`: https://regex101.com/r/09dy7L/3
You can see the different variations in which `apikey` is sometimes first, sometimes last, sometimes the only parameter,
And whatever is matched as "Group 2" (in red), will is replaced with asterisks (\*)

