### PR TITLE
Fix 2 small mistakes in APIv2

### DIFF
--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -172,9 +172,6 @@ class BaseRequestHandler(RequestHandler):
 
         Only logs unhandled exceptions, as ``HTTPErrors`` are common for a RESTful API handler.
         """
-        if not app.WEB_LOG:
-            return
-
         if isinstance(value, HTTPError):
             return
 

--- a/medusa/server/api/v2/series.py
+++ b/medusa/server/api/v2/series.py
@@ -34,7 +34,7 @@ class SeriesHandler(BaseRequestHandler):
     #: path param
     path_param = ('path_param', r'\w+')
     #: allowed HTTP methods
-    allowed_methods = ('GET', 'PATCH', 'DELETE', )
+    allowed_methods = ('GET', 'POST', 'PATCH', 'DELETE', )
 
     def http_get(self, series_slug, path_param=None):
         """Query series information.


### PR DESCRIPTION
- Log exceptions regardless of `app.WEB_LOG`
- Fix `/api/v2/series` not documented to have the `POST` method implemented