### PR TITLE
IssueSubmitter: Ignore issues marked as duplicates

### DIFF
--- a/medusa/issue_submitter.py
+++ b/medusa/issue_submitter.py
@@ -123,6 +123,9 @@ class IssueSubmitter(object):
             # Skip pull requests without calling GitHub for more information
             if issue._pull_request is not GithubObject.NotSet:
                 continue
+            # Skip issues marked as duplicates
+            if any(label.name.lower() == 'duplicate' for label in issue.labels):
+                continue
             issue_title = issue.title
             if issue_title.startswith(cls.TITLE_PREFIX):
                 issue_title = issue_title[len(cls.TITLE_PREFIX):]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 """Configuration for pytest."""
 from __future__ import unicode_literals
+
+import json
 import logging
 import os
 from logging.handlers import RotatingFileHandler
@@ -299,16 +301,17 @@ def github_repo():
 
 @pytest.fixture
 def create_github_issue(monkeypatch):
-    def create(title, body=None, locked=False, number=1, **kwargs):
+    def create(title, body=None, locked=False, number=1, labels=[], **kwargs):
         raw_data = {
             'title': title,
             'body': body,
             'number': number,
-            'locked': locked
+            'locked': locked,
+            'labels': [dict(name=label) for label in labels]
         }
         raw_data.update(kwargs)
         # Set url to a unique value, because that's how issues are compared
-        raw_data['url'] = text_type(hash(tuple(raw_data.values())))
+        raw_data['url'] = text_type(hash(json.dumps(raw_data)))
         return Issue(Mock(), Mock(), raw_data, True)
 
     return create

--- a/tests/test_issue_submitter.py
+++ b/tests/test_issue_submitter.py
@@ -221,24 +221,29 @@ def test_find_similar_issues(monkeypatch, logger, github_repo, read_loglines, cr
         3: 'Really strange this one',
         4: 'Missing time zone for network: USA Network',
         5: "AttributeError: 'NoneType' object has no attribute 'findall'",
+        6: 'Am I a duplicate?',
     }
     for line in itervalues(lines):
         logger.warning(line)
     loglines = list(read_loglines)
 
     raw_issues = [
-        (1, '[APP SUBMITTED]: Really strange that one', False),
-        (2, 'Some Issue like This', False),
-        (3, 'Fix Some Issue like This', True),  # Pull request
-        (4, '[APP SUBMITTED]: Missing time zone for network: Hub Network', False),
-        (5, '[APP SUBMITTED]: Missing time zone for network: USA Network', False),
-        (6, "AttributeError: 'NoneType' object has no attribute 'findall'", False),
-        (7, "AttributeError: 'NoneType' object has no attribute 'lower'", False),
+        # (number, title, labels, pull_request)
+        (1, '[APP SUBMITTED]: Really strange that one', [], False),
+        (2, 'Some Issue like This', [], False),
+        (3, 'Fix Some Issue like This', [], True),  # Pull request
+        (4, '[APP SUBMITTED]: Missing time zone for network: Hub Network', [], False),
+        (5, '[APP SUBMITTED]: Missing time zone for network: USA Network', [], False),
+        (6, "AttributeError: 'NoneType' object has no attribute 'findall'", [], False),
+        (7, "AttributeError: 'NoneType' object has no attribute 'lower'", [], False),
+        (8, 'Am I a duplicate?', ['Bug', 'Duplicate'], False),
+        (9, 'Am I a duplicate?', [], False),
+        (10, 'Am I a duplicate?', ['Duplicate'], False),
     ]
     issues = dict()
-    for (number, title, pull_request) in raw_issues:
+    for (number, title, labels, pull_request) in raw_issues:
         kwargs = {} if not pull_request else {'pull_request': 'mock'}
-        issues[number] = create_github_issue(title=title, number=number, **kwargs)
+        issues[number] = create_github_issue(title=title, number=number, labels=labels, **kwargs)
 
     monkeypatch.setattr(github_repo, 'get_issues', lambda *args, **kwargs: itervalues(issues))
 
@@ -247,6 +252,7 @@ def test_find_similar_issues(monkeypatch, logger, github_repo, read_loglines, cr
         lines[3]: issues[1],
         lines[4]: issues[5],
         lines[5]: issues[6],
+        lines[6]: issues[9],
     }
 
     # When


### PR DESCRIPTION
Should fix:
> @sharkykh if it's closed as a dupe is there any way we can get the comment added to the original instead of the newer issue? Do we maybe need to lock the dupes so it'll try the old one?
>>_Originally posted by **OmgImAlexis** in https://github.com/pymedusa/Medusa/issues/4080#issuecomment-404773126_

>@sharkykh would it be worth the effort to merge these errors into a single one for the submitter?
>>_Originally posted by **OmgImAlexis** in https://github.com/pymedusa/Medusa/issues/5146#issuecomment-419632111_

I added this to the tests, but didn't actually try to submit an issue. The test seems good enough.