### PR TITLE
Fix home page slowdown - layout imported twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Fixed exception in API v2 when an incorrect API key was provided, or none was provided ([#6703](https://github.com/pymedusa/Medusa/pull/6703))
 - Removed legacy log-censoring code for Newznab providers ([#6705](https://github.com/pymedusa/Medusa/pull/6705))
 - Fixed DelugeD remove torrents when ratio is reached (Python 2.7) ([#6702](https://github.com/pymedusa/Medusa/pull/6702))
+- Fixed home page slow down issue ([#6754](https://github.com/pymedusa/Medusa/pull/6754))
 
 ## 0.3.1 (2019-03-20)
 

--- a/themes-default/slim/views/home.mako
+++ b/themes-default/slim/views/home.mako
@@ -90,11 +90,17 @@
                 </ul>
                 <!-- Tab panes -->
                 <div id="showTabPanes">
+                    ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                    % if app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS:
                     <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                    % endif
                 </div><!-- #showTabPanes -->
             </div> <!-- #showTabs -->
             <template v-else>
+                ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                % if not (app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS):
                 <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                % endif
             </template>
         </div>
     </div>

--- a/themes/dark/templates/home.mako
+++ b/themes/dark/templates/home.mako
@@ -90,11 +90,17 @@
                 </ul>
                 <!-- Tab panes -->
                 <div id="showTabPanes">
+                    ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                    % if app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS:
                     <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                    % endif
                 </div><!-- #showTabPanes -->
             </div> <!-- #showTabs -->
             <template v-else>
+                ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                % if not (app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS):
                 <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                % endif
             </template>
         </div>
     </div>

--- a/themes/light/templates/home.mako
+++ b/themes/light/templates/home.mako
@@ -90,11 +90,17 @@
                 </ul>
                 <!-- Tab panes -->
                 <div id="showTabPanes">
+                    ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                    % if app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS:
                     <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                    % endif
                 </div><!-- #showTabPanes -->
             </div> <!-- #showTabs -->
             <template v-else>
+                ## Checking with Mako as well, so we don't import the home page layout multiple times.
+                % if not (app.ANIME_SPLIT_HOME and app.ANIME_SPLIT_HOME_IN_TABS):
                 <%include file="/partials/home/${app.HOME_LAYOUT}.mako"/>
+                % endif
             </template>
         </div>
     </div>


### PR DESCRIPTION
Should improve the performance of the home page by at least 50%.
Was bugged since v0.2.9
Fixes #5311 