### PR TITLE
Fix APIv2 exception while serializing allowed extensions to JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 - Fixed Jackett providers returning empty torrents on magnet redirect (2) ([#6827](https://github.com/pymedusa/Medusa/pull/6827))
+- Fixed APIv2 exception when serializing allowed extensions to JSON ([#6835](https://github.com/pymedusa/Medusa/pull/6835))
 
 -----
 

--- a/medusa/app.py
+++ b/medusa/app.py
@@ -289,7 +289,7 @@ class MedusaApp(object):
         self.TV_DOWNLOAD_DIR = None
         self.UNPACK = False
         self.SKIP_REMOVED_FILES = False
-        self.ALLOWED_EXTENSIONS = {'srt', 'nfo', 'sub', 'idx'}
+        self.ALLOWED_EXTENSIONS = ['srt', 'nfo', 'sub', 'idx']
 
         self.NZBS = False
         self.NZBS_UID = None


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This only occurred on fresh installs where the config hadn't been saved yet.
There is no reason to keep the allowed extensions as set (and they are converted to list after the first config save anyway).