### PR TITLE
Update Init Scripts to python3

### DIFF
--- a/runscripts/init.debian
+++ b/runscripts/init.debian
@@ -35,7 +35,7 @@ fi
 ## APP_HOME=         #$APP_PATH, the location of start.py, the default is /opt/medusa
 ## APP_DATA=         #$DATA_DIR, the location of sickbeard.db, cache, logs, the default is /opt/medusa
 ## APP_PIDFILE=      #$PID_FILE, the location of medusa.pid, the default is /var/run/PyMedusa/Medusa.pid
-## PYTHON_BIN=      #$DAEMON, the location of the python binary, the default is /usr/bin/python2.7
+## PYTHON_BIN=      #$DAEMON, the location of the python binary, the default is /usr/bin/python3
 ## APP_OPTS=         #$EXTRA_DAEMON_OPTS, extra cli option for medusa, i.e. " --config=/home/medusa/config.ini"
 ## SSD_OPTS=        #$EXTRA_SSD_OPTS, extra start-stop-daemon option like " --group=users"
 ##
@@ -66,7 +66,7 @@ DATA_DIR=${APP_DATA-/opt/medusa}
 PID_FILE=${APP_PIDFILE-/var/run/PyMedusa/Medusa.pid}
 
 # path to python bin
-DAEMON=${PYTHON_BIN-/usr/bin/python2.7}
+DAEMON=${PYTHON_BIN-/usr/bin/python3}
 
 # Extra daemon option like: APP_OPTS=" --config=/home/medusa/config.ini"
 EXTRA_DAEMON_OPTS=${APP_OPTS-}

--- a/runscripts/init.fedora
+++ b/runscripts/init.fedora
@@ -28,7 +28,7 @@ homedir=${APP_HOME-/opt/medusa}
 datadir=${APP_DATA-/opt/medusa}
 pidfile=${APP_PIDFILE-/var/run/PyMedusa/Medusa.pid}
 nice=${APP_NICE-}
-python_bin=${PYTHON_BIN-/usr/bin/python2.7}
+python_bin=${PYTHON_BIN-/usr/bin/python3}
 ##
 
 pidpath=`dirname ${pidfile}`

--- a/runscripts/init.freebsd
+++ b/runscripts/init.freebsd
@@ -36,7 +36,7 @@ load_rc_config ${name}
 : ${medusa_datadir:="${medusa_dir}"}
 
 pidfile="/var/run/PyMedusa/Medusa.pid"
-command="/usr/local/bin/python2.7"
+command="/usr/local/bin/python3"
 command_args="${medusa_dir}/start.py --datadir ${medusa_datadir} -d --pidfile ${pidfile} --quiet --nolaunch"
 
 start_precmd="medusa_prestart"

--- a/runscripts/init.gentoo
+++ b/runscripts/init.gentoo
@@ -12,7 +12,7 @@
 # MEDUSA_USER=<user you want medusa to run under>
 # MEDUSA_GROUP=<group you want medusa to run under>
 # MEDUSA_DIR=<path to start.py>
-# PATH_TO_PYTHON_2=/usr/bin/python2
+# PATH_TO_PYTHON_3=/usr/bin/python3
 # MEDUSA_DATADIR=<directory that contains main.db file>
 # MEDUSA_CONFDIR=<directory that contains Medusa's config.ini file>
 #
@@ -42,7 +42,7 @@ start() {
         --group "${MEDUSA_GROUP}" \
         --background \
         --pidfile "$(get_pidfile)" \
-        --exec "${PATH_TO_PYTHON_2}" \
+        --exec "${PATH_TO_PYTHON_3}" \
         -- \
         "${MEDUSA_DIR}/start.py" \
         -d \

--- a/runscripts/init.systemd
+++ b/runscripts/init.systemd
@@ -24,21 +24,21 @@
 ### Example Using Medusa as daemon with pid file
 # Type=forking
 # PIDFile=/var/run/PyMedusa/Medusa.pid
-# ExecStart=/usr/bin/python2.7 /opt/medusa/start.py -q --daemon --nolaunch --pidfile=/var/run/PyMedusa/Medusa.pid --datadir=/opt/medusa
+# ExecStart=/usr/bin/python3 /opt/medusa/start.py -q --daemon --nolaunch --pidfile=/var/run/PyMedusa/Medusa.pid --datadir=/opt/medusa
 
 ## Example Using Medusa as daemon without pid file
 # Type=forking
 # GuessMainPID=no
-# ExecStart=/usr/bin/python2.7 /opt/medusa/start.py -q --daemon --nolaunch --datadir=/opt/medusa
+# ExecStart=/usr/bin/python3 /opt/medusa/start.py -q --daemon --nolaunch --datadir=/opt/medusa
 
 ### Example Using simple
 # Type=simple
-# ExecStart=/usr/bin/python2.7 /opt/medusa/start.py -q --nolaunch
+# ExecStart=/usr/bin/python3 /opt/medusa/start.py -q --nolaunch
 
 ### Example Using simple with EnvironmentFile where APP_DATA=/home/medusa/.medusa in /etc/medusa.conf
 # Type=simple
 # EnvironmentFile=/etc/medusa.conf
-# ExecStart=/usr/bin/python2.7 /opt/medusa/start.py -q --nolaunch --datadir=${APP_DATA}
+# ExecStart=/usr/bin/python3 /opt/medusa/start.py -q --nolaunch --datadir=${APP_DATA}
 
 ### Configuration
 
@@ -51,7 +51,7 @@ User=medusa
 Group=medusa
 
 Type=simple
-ExecStart=/usr/bin/python2.7 /opt/medusa/start.py -q --nolaunch --datadir=/opt/medusa
+ExecStart=/usr/bin/python3 /opt/medusa/start.py -q --nolaunch --datadir=/opt/medusa
 TimeoutStopSec=25
 KillMode=process
 Restart=on-failure

--- a/runscripts/init.ubuntu
+++ b/runscripts/init.ubuntu
@@ -35,7 +35,7 @@ DESC=Medusa
 ## APP_HOME=         #$APP_PATH, the location of start.py, the default is /opt/medusa
 ## APP_DATA=         #$DATA_DIR, the location of sickbeard.db, cache, logs, the default is /opt/medusa
 ## APP_PIDFILE=      #$PID_FILE, the location of medusa.pid, the default is /var/run/PyMedusa/Medusa.pid
-## PYTHON_BIN=      #$DAEMON, the location of the python binary, the default is /usr/bin/python2.7
+## PYTHON_BIN=      #$DAEMON, the location of the python binary, the default is /usr/bin/python3
 ## APP_OPTS=         #$EXTRA_DAEMON_OPTS, extra cli option for medusa, i.e. " --config=/home/medusa/config.ini"
 ## SSD_OPTS=        #$EXTRA_SSD_OPTS, extra start-stop-daemon option like " --group=users"
 ##
@@ -57,7 +57,7 @@ DATA_DIR=${APP_DATA-/opt/medusa}
 PID_FILE=${APP_PIDFILE-/var/run/PyMedusa/Medusa.pid}
 
 # path to python bin
-DAEMON=${PYTHON_BIN-/usr/bin/python2.7}
+DAEMON=${PYTHON_BIN-/usr/bin/python3}
 
 # Extra daemon option like: APP_OPTS=" --config=/home/medusa/config.ini"
 EXTRA_DAEMON_OPTS=${APP_OPTS-}


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR attempts to close #6892. Instead of hardcoding a specific version of /usr/bin/python3.x, I used the generic /usr/bin/python3. I have only tested this with systemd using OSMC, but the changes seemed minimal enough. Used the wiki as a base for changes made. Feel free to disregard this PR if it isn't up to standards.

I did not touch solaris11 or upstart init scripts as neither made reference to python.