### PR TITLE
API v2 fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 #### Improvements
 - Converted the footer to a Vue component ([#4520](https://github.com/pymedusa/Medusa/pull/4520))
 - Converted Edit Show to a Vue SFC ([#4486](https://github.com/pymedusa/Medusa/pull/4486)
+- Improved API v2 exception reporting on Python 2 ([#6931](https://github.com/pymedusa/Medusa/pull/6931))
 
 #### Fixes
 - Fixed hdtorrent provider parse the publishing date with the day first ([#6847](https://github.com/pymedusa/Medusa/pull/6847))
 - Fixed release link on Help & Info page ([#6854](https://github.com/pymedusa/Medusa/pull/6854))
 - Fixed FreeMobile notifier message encode error ([#6867](https://github.com/pymedusa/Medusa/pull/6867))
+- Fixed charset on API v2 responses with plain text content ([#6931](https://github.com/pymedusa/Medusa/pull/6931))
 
 -----
 

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -23,8 +23,9 @@ import jwt
 from medusa import app
 from medusa.logger.adapters.style import BraceAdapter
 
-from six import ensure_text, iteritems, string_types, text_type, viewitems
+from six import PY2, ensure_text, iteritems, string_types, text_type, viewitems
 
+from tornado.concurrent import Future as TornadoFuture
 from tornado.gen import coroutine
 from tornado.httputil import url_concat
 from tornado.ioloop import IOLoop
@@ -60,8 +61,28 @@ def make_async(instance, method):
             return
 
         # Authentication check passed, run the method in a thread
-        prepared = partial(method, *args, **kwargs)
-        content = yield IOLoop.current().run_in_executor(executor, prepared)
+        if PY2:
+            # On Python 2, the original exception stack trace is not passed from the executor.
+            # This is a workaround based on https://stackoverflow.com/a/27413025/7597273
+            tornado_future = TornadoFuture()
+
+            def wrapper():
+                try:
+                    result = method(*args, **kwargs)
+                except:  # noqa: E722 [do not use bare 'except']
+                    tornado_future.set_exc_info(sys.exc_info())
+                else:
+                    tornado_future.set_result(result)
+
+            # `executor.submit()` returns a `concurrent.futures.Future`; wait for it to finish, but ignore the result
+            yield executor.submit(wrapper)
+            # When this future is yielded, any stored exceptions are raised (with the correct stack trace).
+            content = yield tornado_future
+        else:
+            # On Python 3+, exceptions contain their original stack trace.
+            prepared = partial(method, *args, **kwargs)
+            content = yield IOLoop.current().run_in_executor(executor, prepared)
+
         self.finish(content)
 
     # This creates a bound method `instance.async_call`,

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -9,7 +9,6 @@ import json
 import logging
 import sys
 import traceback
-from builtins import object
 from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from datetime import date, datetime

--- a/medusa/server/api/v2/base.py
+++ b/medusa/server/api/v2/base.py
@@ -160,7 +160,7 @@ class BaseRequestHandler(RequestHandler):
             error = exc_info[1].log_message or exc_info[1].reason
             response = self.api_response(status=status_code, error=error)
         elif app.DEVELOPER and exc_info:
-            self.set_header('content-type', 'text/plain')
+            self.set_header('content-type', 'text/plain; charset=UTF-8')
             self.set_status(500)
             for line in traceback.format_exception(*exc_info):
                 self.write(line)

--- a/medusa/server/api/v2/log.py
+++ b/medusa/server/api/v2/log.py
@@ -134,7 +134,7 @@ class LogHandler(BaseRequestHandler):
             return self._paginate(data_generator=data_generator)
         else:
             text = '\n'.join(data_generator())
-            return self._ok(stream=text, content_type='text/plain')
+            return self._ok(stream=text, content_type='text/plain; charset=UTF-8')
 
     def post(self):
         """Create a log line.


### PR DESCRIPTION
### Better stack trace for API v2 on Python 2

**The test:**
`raise Exception('test')` in [`medusa/server/api/v2/log.py @ LogHandler # get`](https://github.com/pymedusa/Medusa/blob/bd55cbeeb971f1668344e346e0ac85793ababde3/medusa/server/api/v2/log.py#L91)
**Before:**
```python-traceback
Traceback (most recent call last):
  File "c:\Dev\Medusa\ext\tornado\web.py", line 1592, in _execute
    result = yield result
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1133, in run
    value = future.result()
  File "c:\Dev\Medusa\ext\tornado\concurrent.py", line 261, in result
    raise_exc_info(self._exc_info)
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1141, in run
    yielded = self.gen.throw(*exc_info)
  File "c:\Dev\Medusa\medusa\server\api\v2\base.py", line 99, in async_call
    content = yield IOLoop.current().run_in_executor(executor, prepared)
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1133, in run
    value = future.result()
  File "c:\Dev\Medusa\ext\tornado\concurrent.py", line 261, in result
    raise_exc_info(self._exc_info)
  File "<string>", line 3, in raise_exc_info
Exception: test
```
**After:**
```python-traceback
Traceback (most recent call last):
  File "c:\Dev\Medusa\ext\tornado\web.py", line 1592, in _execute
    result = yield result
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1133, in run
    value = future.result()
  File "c:\Dev\Medusa\ext\tornado\concurrent.py", line 261, in result
    raise_exc_info(self._exc_info)
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1141, in run
    yielded = self.gen.throw(*exc_info)
  File "c:\Dev\Medusa\medusa\server\api\v2\base.py", line 80, in async_call
    content = yield tornado_future
  File "c:\Dev\Medusa\ext\tornado\gen.py", line 1133, in run
    value = future.result()
  File "c:\Dev\Medusa\ext\tornado\concurrent.py", line 261, in result
    raise_exc_info(self._exc_info)
  File "c:\Dev\Medusa\medusa\server\api\v2\base.py", line 71, in wrapper
    result = method(*args, **kwargs)
  File "c:\Dev\Medusa\medusa\server\api\v2\log.py", line 93, in get
    raise Exception('test')
Exception: test
```

### Fix `text/plain` response charset:
**Before:**
`2019-07-10 02:12:30 INFO     MAIN :: [f1dc11a] 76703: Unable to find IMDb info in the database: Pokֳ©mon`
**After:**
`2019-07-10 02:13:23 INFO     MAIN :: [f1dc11a] 76703: Unable to find IMDb info in the database: Pokémon`