### PR TITLE
Fix Guessit issue titles

### DIFF
--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -403,7 +403,7 @@ class LogLine(object):
                 # Grab the <-Nth> item from the list (-1, -2, ..., -N)
                 line = self.traceback_lines[-offset]
 
-                # GuessIt errors have a template and tend to end in three lines that we don't want.
+                # Guessit errors have a template and tend to end in three lines that we don't want.
                 # The original exception is one line before these lines.
                 # --------------------------------------------------------------------
                 # Please report at https://github.com/guessit-io/guessit/issues.

--- a/medusa/logger/__init__.py
+++ b/medusa/logger/__init__.py
@@ -393,10 +393,35 @@ class LogLine(object):
     @property
     def issue_title(self):
         """Return the expected issue title for this logline."""
+        result = None
+
         if self.traceback_lines:
-            result = next((line for line in reversed(self.traceback_lines) if line.strip()), self.message)
-        else:
+            # Grab the first viable line from the end of the traceback lines
+            offset = 1
+            size = len(self.traceback_lines)
+            while offset < size:
+                # Grab the <-Nth> item from the list (-1, -2, ..., -N)
+                line = self.traceback_lines[-offset]
+
+                # GuessIt errors have a template and tend to end in three lines that we don't want.
+                # The original exception is one line before these lines.
+                # --------------------------------------------------------------------
+                # Please report at https://github.com/guessit-io/guessit/issues.
+                # ====================================================================
+                if line.startswith('=' * 20):
+                    offset += 3
+                    continue
+
+                if line.strip():
+                    result = line
+                    break
+
+                offset += 1
+
+        # Not found a single viable traceback line, fall back to the log message.
+        if not result:
             result = self.message
+
         return result[:1000]
 
     def to_json(self):

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -260,6 +260,84 @@ def test_read_loglines__with_traceback(logger, commit_hash, logfile):
             ]
         }
     },
+    {  # p4: GuessIt error
+       # NOTE: The traceback lines are truncated, but still true to GuessIt's template
+        'line': (
+            '2019-06-13 16:13:15 ERROR    FINDSUBTITLES :: [c1675ff] Exception generated: An internal error has occured in guessit.'
+            '\n===================== Guessit Exception Report ====================='
+            '\nversion=3.0.4.dev0'
+            '\nstring=Unit,.The.3x08.Play.16.HDTV-Caph.[tvu.org.ru].srt'
+            "\noptions={'type': 'episode'}"
+            '\n--------------------------------------------------------------------'
+            '\nTraceback (most recent call last):'
+            '\n  File "/home/pi/Medusa/ext/guessit/api.py", line 210, in guessit'
+            '\n    matches = self.rebulk.matches(string, options)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rebulk.py", line 288, in matches'
+            '\n    self._execute_rules(matches, context)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rebulk.py", line 319, in _execute_rules'
+            '\n    rules.execute_all_rules(matches, context)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rules.py", line 316, in execute_all_rules'
+            '\n    when_response = execute_rule(rule, matches, context)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rules.py", line 341, in execute_rule'
+            '\n    rule.then(matches, when_response, context)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rules.py", line 127, in then'
+            '\n    cons.then(matches, when_response, context)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/rules.py", line 140, in then'
+            '\n    matches.remove(match)'
+            '\n  File "/usr/lib/python3.7/_collections_abc.py", line 1004, in remove'
+            '\n    del self[self.index(value)]'
+            '\n  File "/home/pi/Medusa/ext/rebulk/match.py", line 569, in __delitem__'
+            '\n    self._remove_match(match)'
+            '\n  File "/home/pi/Medusa/ext/rebulk/match.py", line 137, in _remove_match'
+            '\n    _BaseMatches._base_remove(self._tag_dict[tag], match)'
+            '\nValueError: list.remove(x): x not in list'
+            '\n--------------------------------------------------------------------'
+            '\nPlease report at https://github.com/guessit-io/guessit/issues.'
+            '\n===================================================================='
+        ),
+        'expected': {
+            'message': 'Exception generated: An internal error has occured in guessit.',
+            'issue_title': 'ValueError: list.remove(x): x not in list',
+            'timestamp': datetime(year=2019, month=6, day=13, hour=16, minute=13, second=15),
+            'level_name': 'ERROR',
+            'thread_name': 'FINDSUBTITLES',
+            'thread_id': None,
+            'extra': None,
+            'curhash': 'c1675ff',
+            'traceback_lines': [
+                '===================== Guessit Exception Report =====================',
+                'version=3.0.4.dev0',
+                'string=Unit,.The.3x08.Play.16.HDTV-Caph.[tvu.org.ru].srt',
+                "options={'type': 'episode'}",
+                '--------------------------------------------------------------------',
+                'Traceback (most recent call last):',
+                '  File "/home/pi/Medusa/ext/guessit/api.py", line 210, in guessit',
+                '    matches = self.rebulk.matches(string, options)',
+                '  File "/home/pi/Medusa/ext/rebulk/rebulk.py", line 288, in matches',
+                '    self._execute_rules(matches, context)',
+                '  File "/home/pi/Medusa/ext/rebulk/rebulk.py", line 319, in _execute_rules',
+                '    rules.execute_all_rules(matches, context)',
+                '  File "/home/pi/Medusa/ext/rebulk/rules.py", line 316, in execute_all_rules',
+                '    when_response = execute_rule(rule, matches, context)',
+                '  File "/home/pi/Medusa/ext/rebulk/rules.py", line 341, in execute_rule',
+                '    rule.then(matches, when_response, context)',
+                '  File "/home/pi/Medusa/ext/rebulk/rules.py", line 127, in then',
+                '    cons.then(matches, when_response, context)',
+                '  File "/home/pi/Medusa/ext/rebulk/rules.py", line 140, in then',
+                '    matches.remove(match)',
+                '  File "/usr/lib/python3.7/_collections_abc.py", line 1004, in remove',
+                '    del self[self.index(value)]',
+                '  File "/home/pi/Medusa/ext/rebulk/match.py", line 569, in __delitem__',
+                '    self._remove_match(match)',
+                '  File "/home/pi/Medusa/ext/rebulk/match.py", line 137, in _remove_match',
+                '    _BaseMatches._base_remove(self._tag_dict[tag], match)',
+                'ValueError: list.remove(x): x not in list',
+                '--------------------------------------------------------------------',
+                'Please report at https://github.com/guessit-io/guessit/issues.',
+                '====================================================================',
+            ]
+        }
+    },
 ])
 def test_from_line(p):
     # Given

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -260,8 +260,8 @@ def test_read_loglines__with_traceback(logger, commit_hash, logfile):
             ]
         }
     },
-    {  # p4: GuessIt error
-       # NOTE: The traceback lines are truncated, but still true to GuessIt's template
+    {  # p4: Guessit error
+       # NOTE: The traceback lines are truncated, but still true to Guessit's template
         'line': (
             '2019-06-13 16:13:15 ERROR    FINDSUBTITLES :: [c1675ff] Exception generated: An internal error has occured in guessit.'
             '\n===================== Guessit Exception Report ====================='


### PR DESCRIPTION
Fixes issue titles such as: #3575
`[APP SUBMITTED]: ====================================================================`
to be the real last line of the stack trace, for example:
`ValueError: list.remove(x): x not in list`

I realize this is specific to Guessit, but I don't know if it's **too** specific.
Anyway I can't think of a more dynamic solution to this problem.