### PR TITLE
Add ESLint rules

### DIFF
--- a/themes-default/slim/.eslintrc.js
+++ b/themes-default/slim/.eslintrc.js
@@ -68,6 +68,10 @@ module.exports = {
             'error',
             4,
         ],
+        'vue/html-quotes': [
+            'error',
+            'double',
+        ],
         'vue/name-property-casing': [
             'error',
             'kebab-case',

--- a/themes-default/slim/.eslintrc.js
+++ b/themes-default/slim/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
         'unicorn',
         'import',
         'vue',
+        '@sharkykh/vue-extra',
         'jest',
         'eslint-comments',
     ],
@@ -105,6 +106,14 @@ module.exports = {
         {
             files: 'src/**',
             rules: {
+                '@sharkykh/vue-extra/component-not-registered': [
+                    'error',
+                    [
+                        'router-link',
+                        'router-view',
+                        'vue-snotify',
+                    ],
+                ],
                 'import/extensions': [
                     'error',
                     'always',

--- a/themes-default/slim/package.json
+++ b/themes-default/slim/package.json
@@ -59,6 +59,7 @@
     "@babel/preset-env": "7.5.4",
     "@babel/runtime": "7.5.4",
     "@mapbox/stylelint-processor-arbitrary-tags": "0.2.0",
+    "@sharkykh/eslint-plugin-vue-extra": "0.1.1",
     "@vue/test-utils": "1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.2",

--- a/themes-default/slim/yarn.lock
+++ b/themes-default/slim/yarn.lock
@@ -1118,6 +1118,11 @@
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz#2b5a3ab3f918cca48a8c754c08168e3f03eba61b"
   integrity sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==
 
+"@sharkykh/eslint-plugin-vue-extra@0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@sharkykh/eslint-plugin-vue-extra/-/eslint-plugin-vue-extra-0.1.1.tgz#a06dbdc828a3cf41982bcb073f5eb2e609da98bf"
+  integrity sha512-kBVpr33UhVWD29SRJf18eZE96zvk6A2O+iR96MB1wTFYMbydBCZzPG5ZuPE9fWUznmHPUmMyO1rbPf0B90gyBA==
+
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"


### PR DESCRIPTION
- Enable [`vue/html-quotes`](https://eslint.vuejs.org/rules/html-quotes.html) (require double quotes in SFC templates)
- Add simple component not registered lint check:
	In SFCs it will raise an error if you try to use a component in the template without importing and registering it in `components: { ... }`. [Dynamic components are not yet supported.](https://github.com/sharkykh/eslint-plugin-vue-extra/issues/1)
```vue
<template>
    <!-- ✓ router-link is allowed (configuration option) -->
    <router-link to="home/">Home</router-link>
    <!-- ✗ Component "app-link" is used but not registered -->
    <app-link href="home/">Home</app-link>
    <!-- No error - dynamic components are not yet supported. -->
    <component is="app-link">Home</component>
</template>

<script>
export default {
	name: 'app',
};
</script>
```