### PR TITLE
Fix open file handles

### DIFF
--- a/medusa/themes/base.py
+++ b/medusa/themes/base.py
@@ -17,9 +17,8 @@ class Theme(object):
     """Base theme class."""
 
     def __init__(self, **kwargs):
-        self.name = kwargs.get('baseName')
+        self.name = kwargs.get('name')
         self.version = kwargs.get('version')
-        self.package_name = kwargs.get('name')
         self.dep_version = kwargs.get('depVersion')
         self.author = kwargs.get('author')
 
@@ -43,7 +42,6 @@ def read_themes():
             continue
 
         # create a theme object from the `package.json` data
-        package_json['baseName'] = os.path.basename(os.path.normpath(theme_path))
         themes.append(Theme(**package_json))
 
     return themes

--- a/medusa/themes/base.py
+++ b/medusa/themes/base.py
@@ -1,10 +1,10 @@
 """Base theme module."""
 from __future__ import unicode_literals
 
+import io
 import json
 import logging
 import os
-from builtins import object
 
 from medusa import app
 from medusa.logger.adapters.style import BraceAdapter
@@ -33,20 +33,18 @@ def read_themes():
     for theme_path in themes_from_fs:
         # validate the directory structure
         try:
-            result = validate_theme(theme_path)
+            package_json = validate_theme(theme_path)
         except Exception as error:
             log.error('Error reading theme {theme}, {error!r}', {'theme': theme_path, 'error': error})
             raise Exception('Error in one of the theme paths. Please fix the error and start medusa.')
 
-        if not result:
+        if not package_json:
             log.debug('Skipping reading theme {theme}, as the folder is empty', {'theme': theme_path})
             continue
 
-        # validate the package.json
-        package_json = json.load(open(os.path.join(theme_path, 'package.json')))
-        if theme_path:
-            package_json['baseName'] = os.path.basename(os.path.normpath(theme_path))
-            themes.append(Theme(**package_json))
+        # create a theme object from the `package.json` data
+        package_json['baseName'] = os.path.basename(os.path.normpath(theme_path))
+        themes.append(Theme(**package_json))
 
     return themes
 
@@ -71,7 +69,7 @@ def validate_theme(theme_path):
                             'Please refer to the medusa theming documentation.'.format(check_folder=check_folder))
 
     try:
-        with open(os.path.join(theme_path, 'package.json')) as pj:
+        with io.open(os.path.join(theme_path, 'package.json'), 'r', encoding='utf-8') as pj:
             package_json = json.load(pj)
     except IOError:
         raise Exception('Cannot read package.json. Please refer to the medusa theming documentation.')
@@ -86,4 +84,4 @@ def validate_theme(theme_path):
         raise Exception('You need to have at least a templates folder with mako temnplates, '
                         "or an index.html in your [theme's] root. Please refer to the medusa theming documentation.")
 
-    return True
+    return package_json


### PR DESCRIPTION
Found a note from some time ago:
```
// medusa_py3_warnings.txt

C:\Github\Medusa-Py3\medusa\themes\base.py:73: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Github\\Medusa-Py3\\themes\\dark\\package.json' mode='r' encoding='cp1255'>
  package_json = json.load(open(os.path.join(theme_path, 'package.json')))
C:\Github\Medusa-Py3\medusa\themes\base.py:45: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Github\\Medusa-Py3\\themes\\dark\\package.json' mode='r' encoding='cp1255'>
  package_json = json.load(open(os.path.join(theme_path, 'package.json')))
C:\Github\Medusa-Py3\medusa\themes\base.py:73: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Github\\Medusa-Py3\\themes\\light\\package.json' mode='r' encoding='cp1255'>
  package_json = json.load(open(os.path.join(theme_path, 'package.json')))
C:\Github\Medusa-Py3\medusa\themes\base.py:45: ResourceWarning: unclosed file <_io.TextIOWrapper name='C:\\Github\\Medusa-Py3\\themes\\light\\package.json' mode='r' encoding='cp1255'>
  package_json = json.load(open(os.path.join(theme_path, 'package.json')))
```