### PR TITLE
Fix loading displayShow using python3 when app.DOWNLOAD_URL is used

### DIFF
--- a/themes-default/slim/views/displayShow.mako
+++ b/themes-default/slim/views/displayShow.mako
@@ -1,11 +1,17 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     import datetime
-    import urllib
     from medusa import app, helpers, subtitles, sbdatetime, network_timezones
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED, DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST
     from medusa.common import Quality, statusStrings, Overview
     from medusa.helper.common import pretty_file_size
+
+    try:
+        # python 2
+        from urllib import quote
+    except ImportError:
+        # python 3+
+        from urllib.parse import quote
 %>
 <%block name="scripts">
 <script type="text/x-template" id="show-template">
@@ -243,7 +249,7 @@
                                     for rootDir in app.ROOT_DIRS:
                                         if rootDir.startswith('/'):
                                             filename = filename.replace(rootDir, '')
-                                    filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
+                                    filename = app.DOWNLOAD_URL + quote(filename.encode('utf8'))
                                 %>
                                 <app-link href="${filename}">Download</app-link>
                             % endif

--- a/themes/dark/templates/displayShow.mako
+++ b/themes/dark/templates/displayShow.mako
@@ -1,11 +1,17 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     import datetime
-    import urllib
     from medusa import app, helpers, subtitles, sbdatetime, network_timezones
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED, DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST
     from medusa.common import Quality, statusStrings, Overview
     from medusa.helper.common import pretty_file_size
+
+    try:
+        # python 2
+        from urllib import quote
+    except ImportError:
+        # python 3+
+        from urllib.parse import quote
 %>
 <%block name="scripts">
 <script type="text/x-template" id="show-template">
@@ -243,7 +249,7 @@
                                     for rootDir in app.ROOT_DIRS:
                                         if rootDir.startswith('/'):
                                             filename = filename.replace(rootDir, '')
-                                    filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
+                                    filename = app.DOWNLOAD_URL + quote(filename.encode('utf8'))
                                 %>
                                 <app-link href="${filename}">Download</app-link>
                             % endif

--- a/themes/light/templates/displayShow.mako
+++ b/themes/light/templates/displayShow.mako
@@ -1,11 +1,17 @@
 <%inherit file="/layouts/main.mako"/>
 <%!
     import datetime
-    import urllib
     from medusa import app, helpers, subtitles, sbdatetime, network_timezones
     from medusa.common import SKIPPED, WANTED, UNAIRED, ARCHIVED, IGNORED, FAILED, DOWNLOADED, SNATCHED, SNATCHED_PROPER, SNATCHED_BEST
     from medusa.common import Quality, statusStrings, Overview
     from medusa.helper.common import pretty_file_size
+
+    try:
+        # python 2
+        from urllib import quote
+    except ImportError:
+        # python 3+
+        from urllib.parse import quote
 %>
 <%block name="scripts">
 <script type="text/x-template" id="show-template">
@@ -243,7 +249,7 @@
                                     for rootDir in app.ROOT_DIRS:
                                         if rootDir.startswith('/'):
                                             filename = filename.replace(rootDir, '')
-                                    filename = app.DOWNLOAD_URL + urllib.quote(filename.encode('utf8'))
+                                    filename = app.DOWNLOAD_URL + quote(filename.encode('utf8'))
                                 %>
                                 <app-link href="${filename}">Download</app-link>
                             % endif


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

DisplayShow was broken with py3. When app.DOWNLOAD_URL was used. Guess nobody uses that feature.
