### PR TITLE
Add healthz endpoint

### DIFF
--- a/medusa/server/web/core/__init__.py
+++ b/medusa/server/web/core/__init__.py
@@ -20,6 +20,7 @@ from medusa.server.web.core.base import (
 from medusa.server.web.core.calendar import CalendarHandler
 from medusa.server.web.core.error_logs import ErrorLogs
 from medusa.server.web.core.file_browser import WebFileBrowser
+from medusa.server.web.core.healthz import Healthz
 from medusa.server.web.core.history import History
 from medusa.server.web.core.schedule import Schedule
 from medusa.server.web.core.token import TokenHandler

--- a/medusa/server/web/core/healthz.py
+++ b/medusa/server/web/core/healthz.py
@@ -1,0 +1,29 @@
+# coding=utf-8
+"""Route to healthcheck (healthz) endpoint."""
+
+from __future__ import unicode_literals
+
+from medusa.server.web.core.base import WebRoot
+from medusa.system.schedulers import generate_schedulers
+
+from tornroutes import route
+
+
+@route('/healthz(/?.*)')
+class Healthz(WebRoot):
+    """Route to healthcheck (healthz) endpoint."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize class with default constructor."""
+        super(WebRoot, self).__init__(*args, **kwargs)
+
+    def index(self):
+        """Render healthz endpoint based."""
+        response = 'Schedules no beuno:\n'
+
+        for gen in generate_schedulers():
+            if not gen['isAlive']:
+                response += gen['name'] + '\n'
+                self.set_status(500)
+
+        self.finish(response)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR adds a `healthz` endpoint that responds with a 200 status code if all schedulers are alive and either doesn't respond (if Medusa isn't running) or returns a general HTTP/500 if any of the schedules have failed.

Hi, this is my first PR for Medusa, I've been using it for ages now and it's been great, then recently I started running it in my rpi kubernetes cluster, I got a dodgy file that killed the thread the post processor ran in, hence me needing to implement a health-check endpoint.  It's not the best code in the world, so probably needs some refining, but I'm keen to get some feedback and with a bit of work get this merged.