### PR TITLE
Fix Torrentz2 size parsing confusing GB with MB

### DIFF
--- a/medusa/providers/torrent/xml/torrentz2.py
+++ b/medusa/providers/torrent/xml/torrentz2.py
@@ -145,8 +145,8 @@ class Torrentz2Provider(TorrentProvider):
 
     @staticmethod
     def _split_description(description):
-        match = re.findall(r'[0-9]+', description)
-        return int(match[0]) * 1024 ** 2, int(match[1]), int(match[2])
+        match = re.findall(r'(\d+|\d+ \w+)(?= \w+:)', description)
+        return match[0], int(match[1]), int(match[2])
 
 
 provider = Torrentz2Provider()


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fixes https://github.com/pymedusa/Medusa/issues/7077