### PR TITLE
Add field `identfier` to provider cache tables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed provider btdb due date format change in layout ([#7250](https://github.com/pymedusa/Medusa/pull/7250))
 - Fixed exception when there is no anime XML ([#7256](https://github.com/pymedusa/Medusa/pull/7256))
 - Fixed BTDB manual search & updated Xthor domain ([#7303](https://github.com/pymedusa/Medusa/pull/7303))
+- Fixed duplicate manual search results for providers without unqiue URLs ([#7305](https://github.com/pymedusa/Medusa/pull/7305))
 
 -----
 

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -225,11 +225,7 @@ class SearchResult(object):
             # FIXME: Added repr parsing, as that prevents the logger from throwing an exception.
             # This can happen when there are unicode decoded chars in the release name.
             log.debug('Adding item from search to cache: {release_name!r}', release_name=self.name)
-            return cache.add_cache_entry(self.name, self.url, self.seeders,
-                                         self.leechers, self.size, self.pubdate,
-                                         parsed_result=self.parsed_result,
-                                         identifier=self.provider._get_identifier(self))
-        return None
+            return cache.add_cache_entry(self, parsed_result=self.parsed_result)
 
     def create_episode_object(self):
         """Use this result to create an episode segment out of it."""

--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -226,7 +226,9 @@ class SearchResult(object):
             # This can happen when there are unicode decoded chars in the release name.
             log.debug('Adding item from search to cache: {release_name!r}', release_name=self.name)
             return cache.add_cache_entry(self.name, self.url, self.seeders,
-                                         self.leechers, self.size, self.pubdate, parsed_result=self.parsed_result)
+                                         self.leechers, self.size, self.pubdate,
+                                         parsed_result=self.parsed_result,
+                                         identifier=self.provider._get_identifier(self))
         return None
 
     def create_episode_object(self):

--- a/medusa/databases/cache_db.py
+++ b/medusa/databases/cache_db.py
@@ -60,7 +60,6 @@ class InitialSchema(db.SchemaUpgrade):
         return self.connection.version
 
 
-
 class AddSceneExceptions(InitialSchema):
     def test(self):
         return self.hasTable('scene_exceptions')

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -781,7 +781,8 @@ class GenericProvider(object):
 
         return title, url
 
-    def _get_identifier(self, item):
+    @staticmethod
+    def _get_identifier(item):
         """
         Return the identifier for the item.
 

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -781,6 +781,18 @@ class GenericProvider(object):
 
         return title, url
 
+    def _get_identifier(self, item):
+        """
+        Return the identifier for the item.
+
+        By default this is the url. Providers can overwrite this, when needed.
+        """
+        if isinstance(item, SearchResult):
+            return item.url
+
+        # Daily Search does not create SearchResult objects.
+        return item['link']
+
     @property
     def recent_results(self):
         """Return recent RSS results from provier."""

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -787,11 +787,7 @@ class GenericProvider(object):
 
         By default this is the url. Providers can overwrite this, when needed.
         """
-        if isinstance(item, SearchResult):
-            return item.url
-
-        # Daily Search does not create SearchResult objects.
-        return item['link']
+        return item.url
 
     @property
     def recent_results(self):

--- a/medusa/providers/nzb/binsearch.py
+++ b/medusa/providers/nzb/binsearch.py
@@ -11,6 +11,7 @@ from os.path import join
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
+from medusa.classes import SearchResult
 from medusa.helper.common import convert_size, sanitize_filename
 from medusa.helpers import download_file
 from medusa.logger.adapters.style import BraceAdapter
@@ -287,6 +288,18 @@ class BinSearchProvider(NZBProvider):
         :return: size in bytes or -1
         """
         return item.get('size', -1)
+
+    def _get_identifier(self, item):
+        """
+        Return the identifier for the item.
+
+        By default this is the url. Providers can overwrite this, when needed.
+        """
+        if isinstance(item, SearchResult):
+            return '{name}_{size}'.format(name=item.name, size=item.size)
+
+        # Daily Search does not create SearchResult objects.
+        return '{name}_{size}'.format(name=item['title'], size=item['size'])
 
 
 provider = BinSearchProvider()

--- a/medusa/providers/nzb/binsearch.py
+++ b/medusa/providers/nzb/binsearch.py
@@ -288,7 +288,8 @@ class BinSearchProvider(NZBProvider):
         """
         return item.get('size', -1)
 
-    def _get_identifier(self, item):
+    @staticmethod
+    def _get_identifier(item):
         """
         Return the identifier for the item.
 

--- a/medusa/providers/nzb/binsearch.py
+++ b/medusa/providers/nzb/binsearch.py
@@ -11,7 +11,6 @@ from os.path import join
 
 from medusa import tv
 from medusa.bs4_parser import BS4Parser
-from medusa.classes import SearchResult
 from medusa.helper.common import convert_size, sanitize_filename
 from medusa.helpers import download_file
 from medusa.logger.adapters.style import BraceAdapter
@@ -295,11 +294,7 @@ class BinSearchProvider(NZBProvider):
 
         By default this is the url. Providers can overwrite this, when needed.
         """
-        if isinstance(item, SearchResult):
-            return '{name}_{size}'.format(name=item.name, size=item.size)
-
-        # Daily Search does not create SearchResult objects.
-        return '{name}_{size}'.format(name=item['title'], size=item['size'])
+        return '{name}_{size}'.format(name=item.name, size=item.size)
 
 
 provider = BinSearchProvider()

--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -226,6 +226,15 @@ class TorznabProvider(TorrentProvider):
         """Return custom rss torrent providers."""
         return [TorznabProvider(custom_provider) for custom_provider in providers]
 
+    @staticmethod
+    def _get_identifier(item):
+        """
+        Return the identifier for the item.
+
+        By default this is the url. Providers can overwrite this, when needed.
+        """
+        return '{name}_{size}'.format(name=item.name, size=item.size)
+
     def image_name(self):
         """
         Check if we have an image for this provider already.

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -198,6 +198,14 @@ class Cache(object):
         """Check item auth."""
         return True
 
+    def _get_identifier(self, item):
+        """
+        Return the identifier for the item.
+
+        By default this is the url. Providers can overwrite this, when needed.
+        """
+        return self.provider._get_identifier(item)
+
     def update_cache(self, search_start_time):
         """Update provider cache."""
         # check if we should update
@@ -264,7 +272,8 @@ class Cache(object):
                           item.name)
                 result = self.add_cache_entry(
                     item.name, item.url, item.seeders,
-                    item.leechers, item.size, item.pubdate
+                    item.leechers, item.size, item.pubdate,
+                    identifier=self._get_identifier(item)
                 )
                 if result is not None:
                     results.append(result)
@@ -303,6 +312,7 @@ class Cache(object):
         seeders, leechers = self._get_result_info(item)
         size = self._get_size(item)
         pubdate = self._get_pubdate(item)
+        identifier = self._get_identifier(item)
 
         self._check_item_auth(title, url)
 
@@ -310,8 +320,9 @@ class Cache(object):
             title = self._translate_title(title)
             url = self._translate_link_url(url)
 
-            return self.add_cache_entry(title, url, seeders,
-                                        leechers, size, pubdate)
+            return self.add_cache_entry(
+                title, url, seeders, leechers, size, pubdate, identifier=identifier
+            )
 
         else:
             log.debug('The data returned from the {0} feed is incomplete,'

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -430,7 +430,9 @@ class Cache(object):
             # Store proper_tags as proper1|proper2|proper3
             proper_tags = '|'.join(parse_result.proper_tags)
 
-            if not self.item_in_cache(url):
+            identifier = identifier or url
+
+            if not self.item_in_cache(identifier):
                 log.debug('Added item: {0} to cache: {1} with url: {2}', name, self.provider_id, url)
                 return [
                     'INSERT INTO [{name}] '
@@ -440,7 +442,7 @@ class Cache(object):
                     'VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)'.format(
                         name=self.provider_id
                     ),
-                    [identifier or url, name, season, episode_text, parse_result.series.series_id, url,
+                    [identifier, name, season, episode_text, parse_result.series.series_id, url,
                      cur_timestamp, quality, release_group, version,
                      seeders, leechers, size, pubdate, proper_tags, cur_timestamp, parse_result.series.indexer]
                 ]
@@ -456,16 +458,16 @@ class Cache(object):
                     ),
                     [name, url, season, episode_text, parse_result.series.indexer, parse_result.series.series_id,
                      cur_timestamp, quality, release_group, version,
-                     seeders, leechers, size, pubdate, proper_tags, identifier or url]
+                     seeders, leechers, size, pubdate, proper_tags, identifier]
                 ]
 
-    def item_in_cache(self, url, identifier=None):
+    def item_in_cache(self, identifier):
         """Check if the url is already available for the specific provider."""
         cache_db_con = self._get_db()
         return cache_db_con.select(
             'SELECT COUNT(url) as count '
             'FROM [{provider}] '
-            'WHERE identifier=?'.format(provider=self.provider_id), [identifier or url]
+            'WHERE identifier=?'.format(provider=self.provider_id), [identifier]
         )[0]['count']
 
     def find_needed_episodes(self, episodes, forced_search=False, down_cur_quality=False):


### PR DESCRIPTION
Currently by default use the url for the identifier. In future this can be overwritten per provider.
NOTE! **This change will remove all provider cache tables, you will lose your cache**

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This could in the future fix providers like jacket and binsearch #7304 