### PR TITLE
Feature/torrent day custom url fix uk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   - Mark episodes as "watched"
   - Added pagination
   - Added search field, that searches columns like Title, File and Episode number
+- Added ability to use custom domain for TorrentDay provider ([#7326](https://github.com/pymedusa/Medusa/pull/7326))
 
 #### Fixes
 - Fixed AnimeBytes daily search, for multi-ep results ([#7190](https://github.com/pymedusa/Medusa/pull/7190))

--- a/medusa/providers/torrent/json/torrentday.py
+++ b/medusa/providers/torrent/json/torrentday.py
@@ -6,7 +6,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import validators
 
 import dirtyjson as djson
 
@@ -16,6 +15,8 @@ from medusa.logger.adapters.style import BraceAdapter
 from medusa.providers.torrent.torrent_provider import TorrentProvider
 
 from requests.compat import urljoin
+
+import validators
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
@@ -70,7 +71,7 @@ class TorrentDayProvider(TorrentProvider):
         :returns: A list of search results (structure)
         """
         results = []
-        
+
         if self.custom_url:
             if not validators.url(self.custom_url):
                 log.warning('Invalid custom url: {0}', self.custom_url)

--- a/medusa/providers/torrent/json/torrentday.py
+++ b/medusa/providers/torrent/json/torrentday.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import logging
 import re
+import validators
 
 import dirtyjson as djson
 
@@ -29,11 +30,7 @@ class TorrentDayProvider(TorrentProvider):
 
         # URLs
         self.url = 'https://www.torrentday.com'
-        self.urls = {
-            'login': urljoin(self.url, '/torrents/'),
-            'search': urljoin(self.url, '/t.json'),
-            'download': urljoin(self.url, '/download.php/')
-        }
+        self.custom_url = None
 
         # Proper Strings
 
@@ -73,6 +70,19 @@ class TorrentDayProvider(TorrentProvider):
         :returns: A list of search results (structure)
         """
         results = []
+        
+        if self.custom_url:
+            if not validators.url(self.custom_url):
+                log.warning('Invalid custom url: {0}', self.custom_url)
+                return results
+            self.url = self.custom_url
+
+        self.urls = {
+            'login': urljoin(self.url, '/torrents/'),
+            'search': urljoin(self.url, '/t.json'),
+            'download': urljoin(self.url, '/download.php/')
+        }
+
         if not self.login():
             return results
 


### PR DESCRIPTION
3rd times a charm, hopefully. Added the ability to use a custom URL for torrent day as Torrentday.com is blocked by UK ISPs,

https://www.reddit.com/r/PyMedusa/comments/dtcry1/torrentday_doesnt_work_medusa_uk/

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)