### PR TITLE
Fix exception when release groups aren't available for anime shows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed exception when there is no anime XML ([#7256](https://github.com/pymedusa/Medusa/pull/7256))
 - Fixed BTDB manual search & updated Xthor domain ([#7303](https://github.com/pymedusa/Medusa/pull/7303))
 - Fixed duplicate manual search results for providers without unqiue URLs ([#7305](https://github.com/pymedusa/Medusa/pull/7305))
+- Fixed exception when release groups aren't available for anime shows ([#7333](https://github.com/pymedusa/Medusa/pull/7333))
 
 -----
 

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -260,7 +260,7 @@ def filter_results(results):
         series_obj = cur_result.series
 
         # build the black and white list
-        if series_obj.is_anime:
+        if series_obj.is_anime and series_obj.release_groups:
             if not series_obj.release_groups.is_valid(cur_result):
                 continue
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Likely happens when show is added as non-anime and switched to anime afterwards.
Fixes https://github.com/pymedusa/Medusa/issues/7328 https://github.com/pymedusa/Medusa/issues/5458
