### PR TITLE
FreeBSD - Run Medusa using the daemon utility

### DIFF
--- a/runscripts/init.freebsd
+++ b/runscripts/init.freebsd
@@ -21,6 +21,10 @@
 #			Default: /usr/local/medusa
 # medusa_datadir:	Data directory for Medusa (DB, Logs, config)
 #			Default is same as medusa_dir
+# medusa_restart_time: The amount of time before medusa restarts in seconds. 
+#			Defaults to 3 seconds 
+# medusa_python_dir: The directory where python is installed.
+#			Default: /usr/local/bin/python3.7
 
 . /etc/rc.subr
 
@@ -34,12 +38,18 @@ load_rc_config ${name}
 : ${medusa_group:="medusa"}
 : ${medusa_dir:="/usr/local/medusa"}
 : ${medusa_datadir:="${medusa_dir}"}
+: ${medusa_restart_time:=3}
+: ${medusa_python_dir="/usr/local/bin/python3.7"}
 
 pidfile="/var/run/PyMedusa/Medusa.pid"
-command="/usr/local/bin/python3"
-command_args="${medusa_dir}/start.py --datadir ${medusa_datadir} -d --pidfile ${pidfile} --quiet --nolaunch"
+pidfile_child="/var/run/PyMedusa/Medusa_child.pid"
+command="/usr/sbin/daemon"
+command_args="-cf -P ${pidfile} -p ${pidfile_child} -R ${medusa_restart_time} ${medusa_python_dir} ${medusa_dir}/start.py -q --nolaunch --pidfile /var/run/Pymedusa/child.pid --datadir ${medusa_datadir}"
 
 start_precmd="medusa_prestart"
+stop_precmd="medusa_prestop"
+stop_postcmd="medusa_poststop"
+
 medusa_prestart() {
 	if [ -f ${pidfile} ]; then
 		rm -f ${pidfile}
@@ -51,6 +61,18 @@ medusa_prestart() {
 	if [ ! -d ${medusa_datadir} ]; then
 		install -d -o ${medusa_user} -g ${medusa_group} ${medusa_datadir}
 	fi
+}
+
+medusa_prestop() {
+	if [ -r ${pidfile} ]; then
+		export _MEDUSAPID=$(check_pidfile ${pidfile} daemon)
+	fi
+}
+
+medusa_poststop() {	
+	_MEDUSA_CHILDREN=$(pgrep -g ${_MEDUSAPID})
+	echo "Waiting for child processes to stop."
+	wait_for_pids ${_MEDUSA_CHILDREN}
 }
 
 run_rc_command "$1"

--- a/runscripts/init.freebsd
+++ b/runscripts/init.freebsd
@@ -21,8 +21,6 @@
 #			Default: /usr/local/medusa
 # medusa_datadir:	Data directory for Medusa (DB, Logs, config)
 #			Default is same as medusa_dir
-# medusa_restart_time: The amount of time before medusa restarts in seconds. 
-#			Defaults to 3 seconds 
 # medusa_python_dir: The directory where python is installed.
 #			Default: /usr/local/bin/python3.7
 
@@ -38,13 +36,12 @@ load_rc_config ${name}
 : ${medusa_group:="medusa"}
 : ${medusa_dir:="/usr/local/medusa"}
 : ${medusa_datadir:="${medusa_dir}"}
-: ${medusa_restart_time:=3}
 : ${medusa_python_dir="/usr/local/bin/python3.7"}
 
 pidfile="/var/run/PyMedusa/Medusa.pid"
 pidfile_child="/var/run/PyMedusa/Medusa_child.pid"
 command="/usr/sbin/daemon"
-command_args="-cf -P ${pidfile} -p ${pidfile_child} -R ${medusa_restart_time} ${medusa_python_dir} ${medusa_dir}/start.py -q --nolaunch --pidfile /var/run/Pymedusa/child.pid --datadir ${medusa_datadir}"
+command_args="-cf -P ${pidfile} -p ${pidfile_child} ${medusa_python_dir} ${medusa_dir}/start.py -q --nolaunch --pidfile /var/run/Pymedusa/child.pid --datadir ${medusa_datadir}"
 
 start_precmd="medusa_prestart"
 stop_precmd="medusa_prestop"
@@ -72,6 +69,7 @@ medusa_prestop() {
 medusa_poststop() {	
 	_MEDUSA_CHILDREN=$(pgrep -g ${_MEDUSAPID})
 	echo "Waiting for child processes to stop."
+	kill -3 ${_MEDUSA_CHILDREN}
 	wait_for_pids ${_MEDUSA_CHILDREN}
 }
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

On FreeBSD (specifically FreeNAS in this case), changing from Python 2.7 to 3.7 resulted in an issue (#6891) where scheduled tasks would fail to report their status on the "Server Status" page. I determined this to be caused by using the `-d` flag when launching medusa. Removing this flag fixes that issue, but prevents Medusa from launching as a service.

This pull request changes the runscript for FreeBSD to use FreeBSD's included [daemon utility](https://www.freebsd.org/cgi/man.cgi?query=daemon&sektion=8) to run Medusa instead.
The daemon utility will handle automatically starting Medusa, as well as restarting it when it stops (this means that the "No Restart" setting under `General > Advanced Settings > Advanced Settings` must be used to prevent duplicate processes from starting).

This change also adds two new `sysrc` variables to use with the initscript. `medusa_python_dir` allows the user to specify which python version shoud be used to run medusa (defaults to `/usr/local/bin/python3.7` and indirectly fixes the FreeBSD part of #6892), and `medusa_restart_time` allows the user to specify how long the daemon utility should wait to restart medusa when it stops.