### PR TITLE
addShow: Start backlog search in forced queue, instead scheduled queue.

### DIFF
--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -107,7 +107,7 @@ class BacklogSearcher(object):
             if series_obj.paused:
                 continue
 
-            segments = self._get_segments(series_obj, from_date)
+            segments = series_obj.get_wanted_segments(from_date=from_date)
 
             for season, segment in iteritems(segments):
                 self.currentSearchInfo = {'title': '{series_name} Season {season}'.format(series_name=series_obj.name,
@@ -146,50 +146,6 @@ class BacklogSearcher(object):
 
         self._last_backlog = last_backlog
         return self._last_backlog
-
-    @staticmethod
-    def _get_segments(series_obj, from_date):
-        """Get episodes that should be backlog searched."""
-        wanted = {}
-        if series_obj.paused:
-            log.debug(u'Skipping backlog for {0} because the show is paused', series_obj.name)
-            return wanted
-
-        log.debug(u'Seeing if we need anything from {0}', series_obj.name)
-
-        con = db.DBConnection()
-        sql_results = con.select(
-            'SELECT status, quality, season, episode, manually_searched '
-            'FROM tv_episodes '
-            'WHERE airdate > ?'
-            ' AND indexer = ? '
-            ' AND showid = ?',
-            [from_date.toordinal(), series_obj.indexer, series_obj.series_id]
-        )
-
-        # check through the list of statuses to see if we want any
-        for episode in sql_results:
-            cur_status, cur_quality = int(episode['status'] or UNSET), int(episode['quality'] or Quality.NA)
-            should_search, should_search_reason = Quality.should_search(
-                cur_status, cur_quality, series_obj, episode['manually_searched']
-            )
-            if not should_search:
-                continue
-            log.debug(
-                u'Found needed backlog episodes for: {show} {ep}. Reason: {reason}', {
-                    'show': series_obj.name,
-                    'ep': episode_num(episode['season'], episode['episode']),
-                    'reason': should_search_reason,
-                }
-            )
-            ep_obj = series_obj.get_episode(episode['season'], episode['episode'])
-
-            if ep_obj.season not in wanted:
-                wanted[ep_obj.season] = [ep_obj]
-            else:
-                wanted[ep_obj.season].append(ep_obj)
-
-        return wanted
 
     @staticmethod
     def _set_last_backlog(when):

--- a/medusa/search/backlog.py
+++ b/medusa/search/backlog.py
@@ -10,8 +10,6 @@ from builtins import object
 from builtins import str
 
 from medusa import app, db, scheduler, ui
-from medusa.common import Quality, UNSET
-from medusa.helper.common import episode_num
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.search.queue import BacklogQueueItem
 

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -605,14 +605,17 @@ class QueueItemAdd(ShowQueueItem):
         # if they set default ep status to WANTED then run the backlog to search for episodes
         if self.show.default_ep_status == WANTED:
             log.info('Launching backlog for this show since its episodes are WANTED')
-            for season, segment in viewitems(self.show.get_wanted_segments()):
+            wanted_segments = self.show.get_wanted_segments()
+            for season, segment in viewitems(wanted_segments):
                 cur_backlog_queue_item = BacklogQueueItem(self.show, segment)
                 app.forced_search_queue_scheduler.action.add_item(cur_backlog_queue_item)
 
-                log.info('Sending backlog for {show} season {season} '
-                         'because some episodes were set to wanted'.format(
-                    show=self.show.name, season=season
-                ))
+                log.info(
+                    'Sending forced backlog for {show} season {season}'
+                    ' because some episodes were set to wanted'.format(
+                        show=self.show.name, season=season
+                    )
+                )
 
         self.show.write_metadata()
         self.show.update_metadata()

--- a/medusa/show_queue.py
+++ b/medusa/show_queue.py
@@ -61,6 +61,9 @@ from medusa.indexers.indexer_exceptions import (
     IndexerShowNotFoundInLanguage,
 )
 from medusa.logger.adapters.style import BraceAdapter
+from medusa.search.queue import (
+    BacklogQueueItem
+)
 from medusa.tv import Series
 
 from requests import RequestException
@@ -238,14 +241,14 @@ class ShowQueue(generic_queue.GenericQueue):
 
         return queueItemObj
 
-    def addShow(self, indexer, indexer_id, showDir, default_status=None, quality=None, season_folders=None,
+    def addShow(self, indexer, indexer_id, show_dir, default_status=None, quality=None, season_folders=None,
                 lang=None, subtitles=None, anime=None, scene=None, paused=None, blacklist=None, whitelist=None,
                 default_status_after=None, root_dir=None):
 
         if lang is None:
             lang = app.INDEXER_DEFAULT_LANGUAGE
 
-        queueItemObj = QueueItemAdd(indexer, indexer_id, showDir, default_status, quality, season_folders, lang,
+        queueItemObj = QueueItemAdd(indexer, indexer_id, show_dir, default_status, quality, season_folders, lang,
                                     subtitles, anime, scene, paused, blacklist, whitelist, default_status_after,
                                     root_dir)
 
@@ -312,13 +315,13 @@ class ShowQueueItem(generic_queue.QueueItem):
 
 
 class QueueItemAdd(ShowQueueItem):
-    def __init__(self, indexer, indexer_id, showDir, default_status, quality, season_folders, lang, subtitles, anime,
+    def __init__(self, indexer, indexer_id, show_dir, default_status, quality, season_folders, lang, subtitles, anime,
                  scene, paused, blacklist, whitelist, default_status_after, root_dir):
 
-        if isinstance(showDir, binary_type):
-            self.showDir = text_type(showDir, 'utf-8')
+        if isinstance(show_dir, binary_type):
+            self.show_dir = text_type(show_dir, 'utf-8')
         else:
-            self.showDir = showDir
+            self.show_dir = show_dir
 
         self.indexer = indexer
         self.indexer_id = indexer_id
@@ -349,7 +352,7 @@ class QueueItemAdd(ShowQueueItem):
         the dir that the show is being added to.
         """
         if self.show is None:
-            return self.showDir
+            return self.show_dir
         return self.show.name
 
     show_name = property(_getName)
@@ -371,8 +374,8 @@ class QueueItemAdd(ShowQueueItem):
 
         log.info(
             'Starting to add show by {0}',
-            ('ShowDir: {0}'.format(self.showDir)
-             if self.showDir else
+            ('show_dir: {0}'.format(self.show_dir)
+             if self.show_dir else
              'Indexer Id: {0}'.format(self.indexer_id))
         )
 
@@ -392,18 +395,18 @@ class QueueItemAdd(ShowQueueItem):
 
             # Let's try to create the show Dir if it's not provided. This way we force the show dir
             # to build build using the Indexers provided series name
-            if not self.showDir and self.root_dir:
+            if not self.show_dir and self.root_dir:
                 show_name = get_showname_from_indexer(self.indexer, self.indexer_id, self.lang)
                 if show_name:
-                    self.showDir = os.path.join(self.root_dir, sanitize_filename(show_name))
-                    dir_exists = make_dir(self.showDir)
+                    self.show_dir = os.path.join(self.root_dir, sanitize_filename(show_name))
+                    dir_exists = make_dir(self.show_dir)
                     if not dir_exists:
-                        log.info("Unable to create the folder {0}, can't add the show", self.showDir)
+                        log.info("Unable to create the folder {0}, can't add the show", self.show_dir)
                         return
 
-                    chmod_as_parent(self.showDir)
+                    chmod_as_parent(self.show_dir)
                 else:
-                    log.info("Unable to get a show {0}, can't add the show", self.showDir)
+                    log.info("Unable to get a show {0}, can't add the show", self.show_dir)
                     return
 
             # this usually only happens if they have an NFO in their show dir which gave us a Indexer ID that
@@ -411,14 +414,14 @@ class QueueItemAdd(ShowQueueItem):
             if getattr(s, 'seriesname', None) is None:
                 log.error(
                     'Show in {path} has no name on {indexer}, probably searched with the wrong language.',
-                    {'path': self.showDir, 'indexer': indexerApi(self.indexer).name}
+                    {'path': self.show_dir, 'indexer': indexerApi(self.indexer).name}
                 )
 
                 ui.notifications.error(
                     'Unable to add show',
                     'Show in {path} has no name on {indexer}, probably the wrong language.'
                     ' Delete .nfo and manually add the correct language.'.format(
-                        path=self.showDir, indexer=indexerApi(self.indexer).name)
+                        path=self.show_dir, indexer=indexerApi(self.indexer).name)
                 )
                 self._finishEarly()
                 return
@@ -439,21 +442,24 @@ class QueueItemAdd(ShowQueueItem):
                 self._finishEarly()
 
                 # Clean up leftover if the newly created directory is empty.
-                delete_empty_folders(self.showDir)
+                delete_empty_folders(self.show_dir)
                 return
 
         # TODO: Add more specific indexer exceptions, that should provide the user with some accurate feedback.
-        except IndexerShowNotFound:
+        except IndexerShowNotFound as error:
             log.warning(
                 '{id}: Unable to look up the show in {path} using id {id} on {indexer}.'
-                ' Delete metadata files from the folder and try adding it again.',
-                {'id': self.indexer_id, 'path': self.showDir, 'indexer': indexerApi(self.indexer).name}
+                ' Delete metadata files from the folder and try adding it again.\n'
+                'With error: {error}',
+                {'id': self.indexer_id, 'path': self.show_dir,
+                 'indexer': indexerApi(self.indexer).name,
+                 'error': error}
             )
             ui.notifications.error(
                 'Unable to add show',
                 'Unable to look up the show in {path} using id {id} on {indexer}.'
                 ' Delete metadata files from the folder and try adding it again.'.format(
-                    path=self.showDir, id=self.indexer_id, indexer=indexerApi(self.indexer).name)
+                    path=self.show_dir, id=self.indexer_id, indexer=indexerApi(self.indexer).name)
             )
             self._finishEarly()
             return
@@ -479,7 +485,7 @@ class QueueItemAdd(ShowQueueItem):
             ui.notifications.error(
                 'Unable to add show',
                 'Unable to look up the show in {path} on {indexer} using ID {id}.'.format(
-                    path=self.showDir, indexer=indexerApi(self.indexer).name, id=self.indexer_id)
+                    path=self.show_dir, indexer=indexerApi(self.indexer).name, id=self.indexer_id)
             )
             self._finishEarly()
             return
@@ -491,7 +497,7 @@ class QueueItemAdd(ShowQueueItem):
             self.show = newShow
 
             # set up initial values
-            self.show.location = self.showDir
+            self.show.location = self.show_dir
             self.show.subtitles = self.subtitles if self.subtitles is not None else app.SUBTITLES_DEFAULT
             self.show.quality = self.quality if self.quality else app.QUALITY_DEFAULT
             self.show.season_folders = self.season_folders if self.season_folders is not None \
@@ -539,12 +545,12 @@ class QueueItemAdd(ShowQueueItem):
         except MultipleShowObjectsException:
             log.warning(
                 'The show in {show_dir} is already in your show list, skipping',
-                {'show_dir': self.showDir}
+                {'show_dir': self.show_dir}
             )
             ui.notifications.error(
                 'Show skipped',
                 'The show in {show_dir} is already in your show list'.format(
-                    show_dir=self.showDir)
+                    show_dir=self.show_dir)
             )
             self._finishEarly()
             return
@@ -597,10 +603,16 @@ class QueueItemAdd(ShowQueueItem):
             log.debug(traceback.format_exc())
 
         # if they set default ep status to WANTED then run the backlog to search for episodes
-        # FIXME: This needs to be a backlog queue item!!!
         if self.show.default_ep_status == WANTED:
             log.info('Launching backlog for this show since its episodes are WANTED')
-            app.backlog_search_scheduler.action.search_backlog([self.show])
+            for season, segment in viewitems(self.show.get_wanted_segments()):
+                cur_backlog_queue_item = BacklogQueueItem(self.show, segment)
+                app.forced_search_queue_scheduler.action.add_item(cur_backlog_queue_item)
+
+                log.info('Sending backlog for {show} season {season} '
+                         'because some episodes were set to wanted'.format(
+                    show=self.show.name, season=season
+                ))
 
         self.show.write_metadata()
         self.show.update_metadata()

--- a/medusa/system/schedulers.py
+++ b/medusa/system/schedulers.py
@@ -75,7 +75,7 @@ def _queued_show_to_json(item):
         show_title = item.show.name
     except AttributeError:
         if item.action_id == ShowQueueActions.ADD:
-            show_dir = item.showDir
+            show_dir = item.show_dir
 
     if item.priority == QueuePriorities.LOW:
         priority = 'low'

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -2503,7 +2503,7 @@ class Series(TV):
                       {'show': self.name})
             return False
 
-    def get_wanted_segments(self, from_date=datetime.date.fromordinal(1)):
+    def get_wanted_segments(self, from_date=None):
         """Get episodes that should be backlog searched."""
         wanted = {}
         if self.paused:
@@ -2511,6 +2511,8 @@ class Series(TV):
             return wanted
 
         log.debug(u'Seeing if we need anything from {0}', self.name)
+
+        from_date = from_date or datetime.date.fromordinal(1)
 
         con = db.DBConnection()
         sql_results = con.select(

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -2503,6 +2503,49 @@ class Series(TV):
                       {'show': self.name})
             return False
 
+    def get_wanted_segments(self, from_date=datetime.date.fromordinal(1)):
+        """Get episodes that should be backlog searched."""
+        wanted = {}
+        if self.paused:
+            log.debug(u'Skipping backlog for {0} because the show is paused', self.name)
+            return wanted
+
+        log.debug(u'Seeing if we need anything from {0}', self.name)
+
+        con = db.DBConnection()
+        sql_results = con.select(
+            'SELECT status, quality, season, episode, manually_searched '
+            'FROM tv_episodes '
+            'WHERE airdate > ?'
+            ' AND indexer = ? '
+            ' AND showid = ?',
+            [from_date.toordinal(), self.indexer, self.series_id]
+        )
+
+        # check through the list of statuses to see if we want any
+        for episode in sql_results:
+            cur_status, cur_quality = int(episode['status'] or UNSET), int(episode['quality'] or Quality.NA)
+            should_search, should_search_reason = Quality.should_search(
+                cur_status, cur_quality, self, episode['manually_searched']
+            )
+            if not should_search:
+                continue
+            log.debug(
+                u'Found needed backlog episodes for: {show} {ep}. Reason: {reason}', {
+                    'show': self.name,
+                    'ep': episode_num(episode['season'], episode['episode']),
+                    'reason': should_search_reason,
+                }
+            )
+            ep_obj = self.get_episode(episode['season'], episode['episode'])
+
+            if ep_obj.season not in wanted:
+                wanted[ep_obj.season] = [ep_obj]
+            else:
+                wanted[ep_obj.season].append(ep_obj)
+
+        return wanted
+
     def pause(self):
         """Pause the series."""
         self.paused = True

--- a/themes-default/slim/views/status.mako
+++ b/themes-default/slim/views/status.mako
@@ -132,7 +132,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if app.show_queue_scheduler.action.currentItem.action_id == ShowQueueActions.ADD:
-                                <td>${app.show_queue_scheduler.action.currentItem.showDir}</td>
+                                <td>${app.show_queue_scheduler.action.currentItem.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif
@@ -164,7 +164,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if item.action_id == ShowQueueActions.ADD:
-                                <td>${item.showDir}</td>
+                                <td>${item.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif

--- a/themes/dark/templates/status.mako
+++ b/themes/dark/templates/status.mako
@@ -132,7 +132,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if app.show_queue_scheduler.action.currentItem.action_id == ShowQueueActions.ADD:
-                                <td>${app.show_queue_scheduler.action.currentItem.showDir}</td>
+                                <td>${app.show_queue_scheduler.action.currentItem.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif
@@ -164,7 +164,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if item.action_id == ShowQueueActions.ADD:
-                                <td>${item.showDir}</td>
+                                <td>${item.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif

--- a/themes/light/templates/status.mako
+++ b/themes/light/templates/status.mako
@@ -132,7 +132,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if app.show_queue_scheduler.action.currentItem.action_id == ShowQueueActions.ADD:
-                                <td>${app.show_queue_scheduler.action.currentItem.showDir}</td>
+                                <td>${app.show_queue_scheduler.action.currentItem.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif
@@ -164,7 +164,7 @@
                             <td>${showname}</td>
                         % except Exception:
                             % if item.action_id == ShowQueueActions.ADD:
-                                <td>${item.showDir}</td>
+                                <td>${item.show_dir}</td>
                             % else:
                                 <td></td>
                             % endif


### PR DESCRIPTION
* In stead of the scheduled search queue.
* Moved _get_segments function to Series class.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

fix #7422 