### PR TITLE
Flag files as ignoreable when they have been processed.

### DIFF
--- a/medusa/helpers/__init__.py
+++ b/medusa/helpers/__init__.py
@@ -92,6 +92,14 @@ def indent_xml(elem, level=0):
         if level and (not elem.tail or not elem.tail.strip()):
             elem.tail = i
 
+def is_ignore_file(file_path):
+    """
+    Checks if the file marks that another file should be ignored.
+    E.g., Movie.ignore tells the post-processor to ignore Movie.mkv or Movie.avi.
+    :param filename: Path of the file to check.
+    """
+    return get_extension(file_path) == "ignore"
+
 
 def is_media_file(filename):
     """Check if named file may contain media.


### PR DESCRIPTION
When a file is being processed it is not marked on the filesystem as processed. When a video file is in a rar it needs to be extracted to see if it should or should not be post-processed again.

A file with the basename and the extension `ignore` can shortcircuit this behaviour and avoid the unrar. 

The rationale behind this change is that this way you don't need to setup additional scripting to move freshly downloaded torrents from the download dir to the post-processing dir. This way the post-processing dir can just keep working in the download directory. 

This PR is a draft and is made to get some initial feedback on the idea. 

