### PR TITLE
Bring back code to use season images for TVDB API

### DIFF
--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -481,9 +481,17 @@ class TVDBv2(BaseIndexer):
                 image_attributes = self._object_to_dict(image, key_mapping)
 
                 bid = image_attributes.pop('id')
-                if bid not in _images[image_type][resolution]:
-                    _images[image_type][resolution][bid] = {}
-                base_path = _images[image_type][resolution][bid]
+
+                if image_type in ['season', 'seasonwide']:
+                    if int(image.sub_key) not in _images[image_type][resolution]:
+                        _images[image_type][resolution][int(image.sub_key)] = {}
+                    if bid not in _images[image_type][resolution][int(image.sub_key)]:
+                        _images[image_type][resolution][int(image.sub_key)][bid] = {}
+                    base_path = _images[image_type][resolution][int(image.sub_key)][bid]
+                else:
+                    if bid not in _images[image_type][resolution]:
+                        _images[image_type][resolution][bid] = {}
+                    base_path = _images[image_type][resolution][bid]
 
                 for k, v in viewitems(image_attributes):
                     if k is None or v is None:

--- a/medusa/indexers/tvdbv2/tvdbv2_api.py
+++ b/medusa/indexers/tvdbv2/tvdbv2_api.py
@@ -483,11 +483,12 @@ class TVDBv2(BaseIndexer):
                 bid = image_attributes.pop('id')
 
                 if image_type in ['season', 'seasonwide']:
-                    if int(image.sub_key) not in _images[image_type][resolution]:
-                        _images[image_type][resolution][int(image.sub_key)] = {}
-                    if bid not in _images[image_type][resolution][int(image.sub_key)]:
-                        _images[image_type][resolution][int(image.sub_key)][bid] = {}
-                    base_path = _images[image_type][resolution][int(image.sub_key)][bid]
+                    sub_key = int(image.sub_key)
+                    if sub_key not in _images[image_type][resolution]:
+                        _images[image_type][resolution][sub_key] = {}
+                    if bid not in _images[image_type][resolution][sub_key]:
+                        _images[image_type][resolution][sub_key][bid] = {}
+                    base_path = _images[image_type][resolution][sub_key][bid]
                 else:
                     if bid not in _images[image_type][resolution]:
                         _images[image_type][resolution][bid] = {}


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

It had been removed because theTVDB API was faulty. They fixed it now so we can keep getting the season images.