### PR TITLE
qBittorrent client maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### New Features
 
 #### Improvements
+- Improved qBittorrent client ([#7474](https://github.com/pymedusa/Medusa/pull/7474))
 
 #### Fixes
 - Fixed season pack downloads occurring even if not needed ([#7472](https://github.com/pymedusa/Medusa/pull/7472))
@@ -70,7 +71,7 @@
 - Converted the footer to a Vue component ([#4520](https://github.com/pymedusa/Medusa/pull/4520))
 - Converted Edit Show to a Vue SFC ([#4486](https://github.com/pymedusa/Medusa/pull/4486)
 - Improved API v2 exception reporting on Python 2 ([#6931](https://github.com/pymedusa/Medusa/pull/6931))
-- Added support for qbittorrent api v2. Required from qbittorrent version > 3.2.0. ([#7040](https://github.com/pymedusa/Medusa/pull/7040))
+- Added support for qBittorrent API v2. Required from qBittorrent version 4.2.0. ([#7040](https://github.com/pymedusa/Medusa/pull/7040))
 - Removed the forced search queue item in favor of the backlog search queue item. ([#6718](https://github.com/pymedusa/Medusa/pull/6718))
 - Show Header: Improved visibility of local and global configured required and ignored words. ([#7085](https://github.com/pymedusa/Medusa/pull/7085))
 - Reduced frequency of file system access when not strictly required ([#7102](https://github.com/pymedusa/Medusa/pull/7102))

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -153,7 +153,14 @@ class QBittorrentAPI(GenericClient):
             'hashes': result.hash.lower(),
             label_key.lower(): label.replace(' ', '_'),
         }
-        return self._request(method='post', data=data, cookies=self.session.cookies)
+        ok = self._request(method='post', data=data, cookies=self.session.cookies)
+
+        if self.response.status_code == 409:
+            log.warning('{name}: Unable to set torrent label. You need to create the label '
+                        ' in {name} first.', {'name': self.name})
+            ok = False
+
+        return ok
 
     def _set_torrent_priority(self, result):
 

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -29,7 +29,7 @@ class QBittorrentAPI(GenericClient):
         :param password:
         :type password: string
         """
-        super(QBittorrentAPI, self).__init__('qbittorrent', host, username, password)
+        super(QBittorrentAPI, self).__init__('qBittorrent', host, username, password)
         self.url = self.host
         self.session.auth = HTTPDigestAuth(self.username, self.password)
 

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -44,10 +44,9 @@ class QBittorrentAPI(GenericClient):
             version = self.session.get(self.url, verify=app.TORRENT_VERIFY_CERT,
                                        cookies=self.session.cookies)
             # Make sure version is using the (major, minor, release) format
-            version = list(map(int, version.text.split('.')))
-            if len(version) < 2:
-                version.append(0)
-            return tuple(version)
+            version = tuple(map(int, version.text.split('.')))
+            # Fill up with zeros to get the correct format. e.g: (2, 3) => (2, 3, 0)
+            return version + (0,) * (3 - len(version))
         except (AttributeError, ValueError) as error:
             log.error('{name}: Unable to get API version. Error: {error!r}',
                       {'name': self.name, 'error': error})

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -35,6 +35,7 @@ class QBittorrentAPI(GenericClient):
         :type password: string
         """
         super(QBittorrentAPI, self).__init__('qBittorrent', host, username, password)
+        self.url = self.host
         # Auth for API v1.0.0 (qBittorrent v3.1.x and older)
         self.session.auth = HTTPDigestAuth(self.username, self.password)
 

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -63,7 +63,7 @@ class QBittorrentAPI(GenericClient):
         return version
 
     def _get_auth(self):
-        """Select between api v2 and legacy."""
+        """Authenticate with the client using the most recent API version available for use."""
         return self._get_auth_v2() or self._get_auth_legacy()
 
     def _get_auth_v2(self):


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

### Related:
- https://github.com/pymedusa/Medusa/issues/3134#issuecomment-561970205
- #7473
- #6974

### Fixes:
- [x] Warn when you need to create the label first. (Fixes #6974)
- [x] Warn when username/password is invalid. (Fixes #3134 / #7473)
- [x] Warn when your IP is banned by the client (after too many failed authentication attempts).
- [x] **I don't really like the way I hacked in all the API v2 login/API version code.**
	I'll try to figure out a better way to do this in this PR. Hopefully before the hotfix is released.
- [x] Use `urljoin`

---

### Tested with:

| qBittorrent version | Highest API version |
|---------------------|---------------------|
| v4.2.0 | v2.3.0 |
| v4.0.4 | v17 (v1.17.0) |
| v3.1.12 | v1 (v1.0.0) |

