### PR TITLE
Fix missing qBittorrent category/label logs error

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -181,7 +181,7 @@ class QBittorrentAPI(GenericClient):
         if self.response.status_code == 409:
             log.warning('{name}: Unable to set torrent label. You need to create the label '
                         ' in {name} first.', {'name': self.name})
-            ok = False
+            ok = True
 
         return ok
 


### PR DESCRIPTION
I forgot that if this command returns a false-y value, it logs an error.
https://github.com/pymedusa/Medusa/blob/29c11f38143d52dbee7ca0067dab22fcc3e90268/medusa/clients/torrent/generic.py#L266-L268

Ref: #7474