### PR TITLE
Fix Emby notifier error on Python 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `uniqueid` to Kodi 12+ show metadata ([#7483](https://github.com/pymedusa/Medusa/pull/7483))
 
 #### Fixes
+- Fix Emby notifier error on Python 3 ([#7497](https://github.com/pymedusa/Medusa/pull/7497))
 
 -----
 

--- a/medusa/notifiers/emby.py
+++ b/medusa/notifiers/emby.py
@@ -56,8 +56,8 @@ class Notifier(object):
             )
             resp.raise_for_status()
 
-            if resp.content:
-                log.debug('EMBY: HTTP response: {0}', resp.content.replace('\n', ''))
+            if resp.text:
+                log.debug('EMBY: HTTP response: {0}', resp.text.replace('\n', ''))
 
             log.info('EMBY: Successfully sent a test notification.')
             return True
@@ -127,8 +127,8 @@ class Notifier(object):
                 )
                 resp.raise_for_status()
 
-                if resp.content:
-                    log.debug('EMBY: HTTP response: {0}', resp.content.replace('\n', ''))
+                if resp.text:
+                    log.debug('EMBY: HTTP response: {0}', resp.text.replace('\n', ''))
 
                 log.info('EMBY: Successfully sent a "Series Library Updated" command.')
                 return True


### PR DESCRIPTION
From #7486
```python-traceback
Traceback (most recent call last):
  File "/app/medusa/medusa/server/web/core/base.py", line 251, in async_call
    result = function(**kwargs)
  File "/app/medusa/medusa/server/web/home/handler.py", line 434, in testEMBY
    result = notifiers.emby_notifier.test_notify(unquote_plus(host), emby_apikey)
  File "/app/medusa/medusa/notifiers/emby.py", line 80, in test_notify
    return self._notify_emby('This is a test notification from Medusa', host, emby_apikey)
  File "/app/medusa/medusa/notifiers/emby.py", line 60, in _notify_emby
    log.debug('EMBY: HTTP response: {0}', resp.content.replace('\n', ''))
TypeError: a bytes-like object is required, not 'str'
```

Fixes #7339 too, it seems.
