### PR TITLE
Fix for an reintroduced bug: Failed to send torrent to qBittorrent if theres an accent in the file name (#4218)

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -157,10 +157,7 @@ class QBittorrentAPI(GenericClient):
         command = 'api/v2/torrents/add' if self.api >= (2, 0, 0) else 'command/upload'
         self.url = urljoin(self.host, command)
         files = {
-            'torrents': (
-                '{result}.torrent'.format(result=result.name),
-                result.content,
-            ),
+            'torrents': result.content
         }
         return self._request(method='post', files=files, cookies=self.session.cookies)
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This is an fix for an bug that was fixed in #4219 and then reintroduced in #7040
The problem happens when there's an torrent with accents in file name, it will not be sent to qbittorrent, as already discussed in the pull request #4219 the filename in the api call is not necessary (tested again in v2 and still work without it) and cause it to fail when there's accents.