### PR TITLE
Fix error when torrent queueing is disabled on qBT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix Schedule page and Forced Search on Schedule page ([#7512](https://github.com/pymedusa/Medusa/pull/7512))
 - Fix manual search page release name bug ([#7517](https://github.com/pymedusa/Medusa/pull/7517))
 - Fix being unable to save post-processing config ([#7526](https://github.com/pymedusa/Medusa/pull/7526))
+- Fix qBittorrent error when torrent queueing is disabled ([#7541](https://github.com/pymedusa/Medusa/pull/7541))
 
 -----
 

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -198,7 +198,7 @@ class QBittorrentAPI(GenericClient):
         }
         ok = self._request(method='post', data=data, cookies=self.session.cookies)
 
-        if self.response.status_code == 403:
+        if self.response.status_code == (409 if self.api >= (2, 0, 0) else 403):
             log.info('{name}: Unable to set torrent priority because torrent queueing'
                      ' is disabled in {name} settings.', {'name': self.name})
             ok = True


### PR DESCRIPTION
Should fix #7539 (though I'm not 100% sure because there are no logs)
https://github.com/qbittorrent/qBittorrent/wiki/Web-API-Documentation#increase-torrent-priority