### PR TITLE
Start threads after daemonization

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -323,7 +323,7 @@ class Application(object):
 
         # Get PID
         app.PID = os.getpid()
-        
+
         # Initialize the config and our threads
         self.initialize(console_logging=self.console_logging)
 

--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -318,14 +318,14 @@ class Application(object):
 
         app.CFG = ConfigObj(app.CONFIG_FILE, encoding='UTF-8', default_encoding='UTF-8')
 
-        # Initialize the config and our threads
-        self.initialize(console_logging=self.console_logging)
-
         if self.run_as_daemon:
             self.daemonize()
 
         # Get PID
         app.PID = os.getpid()
+        
+        # Initialize the config and our threads
+        self.initialize(console_logging=self.console_logging)
 
         # Build from the DB to start with
         self.load_shows_from_db()


### PR DESCRIPTION
Fixes Python 3 showing threads as not alive.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
