### PR TITLE
Fix deluged move_torrent() when seed location is specified in the configuration

### DIFF
--- a/medusa/clients/torrent/deluged.py
+++ b/medusa/clients/torrent/deluged.py
@@ -109,6 +109,11 @@ class DelugeDAPI(GenericClient):
         """
         if not app.TORRENT_SEED_LOCATION or not info_hash:
             return
+
+        if not self.connect():
+            log.warning('Error while moving torrent. Could not connect to daemon.')
+            return
+
         return self.drpc.move_storage(info_hash, app.TORRENT_SEED_LOCATION)
 
     def _set_torrent_label(self, result):
@@ -237,7 +242,7 @@ class DelugeRPC(object):
         """
         try:
             self.connect()
-            self.client.core.move_storage(torrent_id, location)
+            self.client.core.move_storage([torrent_id], location)
         except Exception:
             return False
         else:


### PR DESCRIPTION
The deluge RPC client is not initialized on a deluged API client until after the call to `connect()`, so we need to ensure `connect()` is called to initialize the RPC client and verify the authentication before calling any RPC methods. `move_torrent()` is called on a fresh deluged client from `process_tv.py` without any other previous connection attempt.

The RPC method for moving torrents (`core.move_storage`) also takes a list of torrent IDs instead of a single ID, so pass a list (of one) to the call instead.

This fix has been tested and verified.