### PR TITLE
Remove proper strings override for BTN provider

### DIFF
--- a/medusa/providers/torrent/json/btn.py
+++ b/medusa/providers/torrent/json/btn.py
@@ -70,9 +70,6 @@ class BTNProvider(TorrentProvider):
             'base_url': 'https://api.broadcasthe.net',
         }
 
-        # Proper Strings
-        self.proper_strings = []
-
         # Miscellaneous Options
         self.supports_absolute_numbering = True
 


### PR DESCRIPTION
Hardly a full rewrite of the provider, but this at least enables proper/repack searches for BTN. Verified this worked with at least the REPACK of the first episode of Star Trek: Picard.