### PR TITLE
Fix torznab number of leechers

### DIFF
--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -178,7 +178,8 @@ class TorznabProvider(TorrentProvider):
                     seeders_attr = item.find('torznab:attr', attrs={'name': 'seeders'})
                     peers_attr = item.find('torznab:attr', attrs={'name': 'peers'})
                     seeders = int(seeders_attr.get('value', 0)) if seeders_attr else 1
-                    leechers = int(peers_attr.get('value', 0)) if peers_attr else 0
+                    peers = int(peers_attr.get('value', 0)) if peers_attr else 0
+                    leechers = peers-seeders if peers-seeders>0 else 0
 
                     # Filter unseeded torrent
                     if seeders < self.minseed:

--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -179,7 +179,7 @@ class TorznabProvider(TorrentProvider):
                     peers_attr = item.find('torznab:attr', attrs={'name': 'peers'})
                     seeders = int(seeders_attr.get('value', 0)) if seeders_attr else 1
                     peers = int(peers_attr.get('value', 0)) if peers_attr else 0
-                    leechers = peers - seeders if peers - seeders>0 else 0
+                    leechers = peers - seeders if peers - seeders > 0 else 0
 
                     # Filter unseeded torrent
                     if seeders < self.minseed:

--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -179,7 +179,7 @@ class TorznabProvider(TorrentProvider):
                     peers_attr = item.find('torznab:attr', attrs={'name': 'peers'})
                     seeders = int(seeders_attr.get('value', 0)) if seeders_attr else 1
                     peers = int(peers_attr.get('value', 0)) if peers_attr else 0
-                    leechers = peers-seeders if peers-seeders>0 else 0
+                    leechers = peers - seeders if peers - seeders>0 else 0
 
                     # Filter unseeded torrent
                     if seeders < self.minseed:


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Peers is the combination of both leechers and seeders, the provider was assuming it was the leechers count.