### PR TITLE
Fix dynamic provider import for Python 3.5

### DIFF
--- a/medusa/providers/__init__.py
+++ b/medusa/providers/__init__.py
@@ -5,9 +5,9 @@ from __future__ import unicode_literals
 
 import importlib
 import pkgutil
+import sys
 from builtins import next
 from builtins import zip
-from os import sys
 from random import shuffle
 
 from medusa import app

--- a/medusa/providers/__init__.py
+++ b/medusa/providers/__init__.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import importlib
-import os
 import pkgutil
 from builtins import next
 from builtins import zip
@@ -14,18 +13,32 @@ from random import shuffle
 from medusa import app
 
 
-torrent_kinds = ['html', 'json', 'rss', 'torznab', 'xml']
-dirname = os.path.dirname(__file__)
-modules = [os.path.join(dirname, 'torrent', kind) for kind in torrent_kinds] + [os.path.join(dirname, 'nzb')]
+def import_providers(package_name):
+    provider_names = []
 
-provider_names = []
-for (module_loader, name, ispkg) in pkgutil.iter_modules(modules):
-    base = os.path.basename(module_loader.path)
-    if base != 'nzb':
-        base = os.path.basename(os.path.dirname(module_loader.path)) + '.' + base
-    module = importlib.import_module('.' + name, __package__ + '.' + base)
-    if getattr(module, 'provider', None):
-        provider_names.append(name)
+    def import_submodules(subpackage_name):
+        package = sys.modules[subpackage_name]
+
+        results = {}
+        for loader, name, is_pkg in pkgutil.iter_modules(package.__path__):
+            full_name = subpackage_name + '.' + name
+            module = importlib.import_module(full_name)
+            if getattr(module, 'provider', None):
+                provider_names.append(name)
+
+            results[full_name] = module
+            if is_pkg:
+                valid_pkg = import_submodules(full_name)
+                if valid_pkg:
+                    results.update(valid_pkg)
+
+        return results
+
+    import_submodules(package_name)
+    return provider_names
+
+
+provider_names = import_providers(__name__)
 
 
 def sorted_provider_list(randomize=False):

--- a/medusa/providers/torrent/__init__.py
+++ b/medusa/providers/torrent/__init__.py
@@ -2,3 +2,28 @@
 
 """Initialize all torrent providers."""
 from __future__ import unicode_literals
+
+import importlib
+import pkgutil
+import sys
+
+
+def import_submodules(package_name):
+    package = sys.modules[package_name]
+
+    results = {}
+    for loader, name, is_pkg in pkgutil.iter_modules(package.__path__):
+        full_name = package_name + '.' + name
+        module = importlib.import_module(full_name)
+        setattr(sys.modules[__name__], name, module)
+
+        results[full_name] = module
+        if is_pkg:
+            valid_pkg = import_submodules(full_name)
+            if valid_pkg:
+                results.update(valid_pkg)
+
+    return results
+
+
+import_submodules(__name__)

--- a/medusa/providers/torrent/__init__.py
+++ b/medusa/providers/torrent/__init__.py
@@ -2,18 +2,3 @@
 
 """Initialize all torrent providers."""
 from __future__ import unicode_literals
-
-import importlib
-import os
-import pkgutil
-import sys
-
-
-torrent_kinds = ['html', 'json', 'rss', 'torznab', 'xml']
-dirname = os.path.dirname(__file__)
-modules = [os.path.join(dirname, kind) for kind in torrent_kinds]
-
-for (module_loader, name, ispkg) in pkgutil.iter_modules(modules):
-    base = os.path.basename(module_loader.path)
-    module = importlib.import_module('.' + name, __package__ + '.' + base)
-    setattr(sys.modules[__name__], name, module)

--- a/setup.cfg
+++ b/setup.cfg
@@ -111,6 +111,7 @@ flake8-ignore =
     medusa/nzb_splitter.py D100 D202 D400
     medusa/process_tv.py D100 D101 D102
     medusa/providers/__init__.py D103
+    medusa/providers/torrent/__init__.py D103
     medusa/recompiled/__init__.py D104
     medusa/recompiled/tags.py D100
     medusa/rss_feeds.py D100 D103 N802


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Old code didn't work with Python 3.5 for some reason.