### PR TITLE
Fix size changed during iteration.

### DIFF
--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -161,8 +161,8 @@ def get_scene_exceptions_by_name(show_name):
     """Get the series_id, season and indexer of the scene exception."""
     # Flatten the exceptions_cache.
     scene_exceptions = set()
-    for exception_set in exceptions_cache.values():
-        for title_exception in exception_set.values():
+    for exception_set in list(exceptions_cache.values()):
+        for title_exception in list(exception_set.values()):
             scene_exceptions.update(title_exception)
 
     matches = set()


### PR DESCRIPTION
 `dict.values()` is a generator. So it can cause errors when the dict is changed during iteration.

Prevent this by casting to an array, before iterating. Most py2 backwards compatible solution.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fix for #7947 