### PR TITLE
Fix running of Scheduler with specific start time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fixed starting medusa failed running python3.8 on windows ([#7940](https://github.com/pymedusa/Medusa/pull/7940))
 - Fixed Speed.cd provider login ([#7941](https://github.com/pymedusa/Medusa/pull/7941))
 - Fixed [#7959](https://github.com/pymedusa/Medusa/issues/7959) - UI bug on schedule calendar view ([#7962](https://github.com/pymedusa/Medusa/pull/7962))
+- Fixed running Scheduler with specific start time ([#7963](https://github.com/pymedusa/Medusa/pull/7963))
 
 -----
 

--- a/medusa/scheduler.py
+++ b/medusa/scheduler.py
@@ -41,13 +41,12 @@ class Scheduler(threading.Thread):
             if self.start_time is None:
                 return self.cycleTime - (datetime.datetime.now() - self.lastRun)
             else:
-                time_now = datetime.datetime.now()
-                start_time_today = datetime.datetime.combine(time_now.date(), self.start_time)
-                if time_now >= start_time_today:
-                    start_time_tomorrow = start_time_today + datetime.timedelta(days=1)
-                    return start_time_tomorrow - time_now
-                else:
-                    return start_time_today - time_now
+                last_run = self.lastRun
+                start_time_next = datetime.datetime.combine(last_run.date(), self.start_time)
+                if last_run > start_time_next:
+                    start_time_next += self.cycleTime
+
+                return start_time_next - datetime.datetime.now()
         else:
             return datetime.timedelta(seconds=0)
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fixes https://github.com/pymedusa/Medusa/issues/7961