### PR TITLE
Use correct version format for `vue-good-table`

### DIFF
--- a/themes-default/slim/package.json
+++ b/themes-default/slim/package.json
@@ -45,7 +45,7 @@
     "vue": "2.6.11",
     "vue-async-computed": "3.8.2",
     "vue-cookies": "1.7.0",
-    "vue-good-table": "https://codeload.github.com/p0psicles/vue-good-table/tar.gz/5cf396f70a5cee003d2541af381f87d4797a7a92",
+    "vue-good-table": "p0psicles/vue-good-table#5cf396f70a5cee003d2541af381f87d4797a7a92",
     "vue-images-loaded": "1.1.2",
     "vue-js-modal": "1.3.35",
     "vue-js-toggle-button": "1.3.3",

--- a/themes-default/slim/yarn.lock
+++ b/themes-default/slim/yarn.lock
@@ -12074,9 +12074,9 @@ vue-eslint-parser@^7.0.0:
     esquery "^1.0.1"
     lodash "^4.17.15"
 
-"vue-good-table@https://codeload.github.com/p0psicles/vue-good-table/tar.gz/5cf396f70a5cee003d2541af381f87d4797a7a92":
+vue-good-table@p0psicles/vue-good-table#5cf396f70a5cee003d2541af381f87d4797a7a92:
   version "2.19.1"
-  resolved "https://codeload.github.com/p0psicles/vue-good-table/tar.gz/5cf396f70a5cee003d2541af381f87d4797a7a92#afbd364ba16da41f088575ac71a549e05e5e798e"
+  resolved "https://codeload.github.com/p0psicles/vue-good-table/tar.gz/5cf396f70a5cee003d2541af381f87d4797a7a92"
   dependencies:
     date-fns "^2.0.0-beta.4"
     diacriticless "1.0.1"


### PR DESCRIPTION
Sorry, this is a better format than the "codeload" url when it comes to `renovate`.

https://docs.npmjs.com/files/package.json#github-urls