### PR TITLE
Fix associated files matching more files than wanted. Fixes #8051

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -209,7 +209,7 @@ class PostProcessor(object):
         files = self._search_files(file_path, subfolders=subfolders)
 
         # file path to the video file that is being processed (without extension)
-        processed_file_name = os.path.splitext(os.path.basename(file_path))[0].lower()
+        processed_file_name = os.path.splitext(os.path.basename(file_path))[0].lower() + '.'
 
         processed_names = (processed_file_name,)
         processed_names += tuple((_f for _f in (self._rar_basename(file_path, files),) if _f))
@@ -332,7 +332,7 @@ class PostProcessor(object):
                            u'Error: {message}'.format(name=rar, message=error), logger.WARNING)
                 continue
             if videofile in content:
-                return os.path.splitext(os.path.basename(rar))[0].lower()
+                return os.path.splitext(os.path.basename(rar))[0].lower() + '.'
 
     def _delete(self, files, associated_files=False):
         """


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Show.Name.1x1 was being matched to Show.Name.1x12, Show.Name.1x13, etc. 