### PR TITLE
Rework `bencodepy` integration

### DIFF
--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -12,7 +12,7 @@ from builtins import object
 from builtins import str
 from hashlib import sha1
 
-from bencodepy import Bencode, BencodeDecodeError
+from bencodepy import BencodeDecodeError, DEFAULT as BENCODE
 
 from medusa import app, db
 from medusa.helper.common import http_code_description
@@ -203,10 +203,9 @@ class GenericClient(object):
 
             try:
                 # `bencodepy` is monkeypatched in `medusa.init`
-                bc = Bencode(encoding='utf-8')
-                torrent_bdecode = bc.decode(result.content, allow_extra_data=True)
+                torrent_bdecode = BENCODE.decode(result.content, allow_extra_data=True)
                 info = torrent_bdecode['info']
-                result.hash = sha1(bc.encode(info)).hexdigest()
+                result.hash = sha1(BENCODE.encode(info)).hexdigest()
             except (BencodeDecodeError, KeyError):
                 log.warning(
                     'Unable to bdecode torrent. Invalid torrent: {name}. '

--- a/medusa/providers/torrent/rss/rsstorrent.py
+++ b/medusa/providers/torrent/rss/rsstorrent.py
@@ -9,7 +9,7 @@ import logging
 import os
 import re
 
-from bencodepy import Bencode
+from bencodepy import DEFAULT as BENCODE
 
 from medusa import (
     app,
@@ -132,8 +132,7 @@ class TorrentRssProvider(TorrentProvider):
                 torrent_file = self.session.get_content(url)
                 try:
                     # `bencodepy` is monkeypatched in `medusa.init`
-                    bc = Bencode(encoding='utf-8')
-                    bc.decode(torrent_file, allow_extra_data=True)
+                    BENCODE.decode(torrent_file, allow_extra_data=True)
                 except Exception as error:
                     self.dump_html(torrent_file)
                     return {'result': False,

--- a/medusa/providers/torrent/torrent_provider.py
+++ b/medusa/providers/torrent/torrent_provider.py
@@ -11,7 +11,7 @@ from base64 import b16encode, b32decode
 from os.path import join
 from random import shuffle
 
-from bencodepy import Bencode, BencodeDecodeError
+from bencodepy import BencodeDecodeError, DEFAULT as BENCODE
 
 from feedparser.util import FeedParserDict
 
@@ -123,10 +123,9 @@ class TorrentProvider(GenericProvider):
             return False
 
         try:
-            bc = Bencode(encoding='utf-8')
             with open(file_name, 'rb') as f:
                 # `bencodepy` is monkeypatched in `medusa.init`
-                meta_info = bc.decode(f.read(), allow_extra_data=True)
+                meta_info = BENCODE.decode(f.read(), allow_extra_data=True)
             return 'info' in meta_info and meta_info['info']
         except BencodeDecodeError as error:
             log.debug('Failed to validate torrent file: {name}. Error: {error}',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -3,11 +3,44 @@
 
 from __future__ import unicode_literals
 
-import bencodepy
+from bencodepy import BencodeDecodeError, DEFAULT as BENCODE
 
 from medusa import init  # noqa: F401 [unused]
 
 import pytest
+
+
+TEST_TORRENT_CONTENT = (
+    b'd8:announce23:udp://explodie.org:696913:announce-listll23:udp://explodie.org:6969el34:udp://tracker.coppersurfer'
+    b'.tk:6969el31:udp://tracker.empire-js.us:1337el40:udp://tracker.leechers-paradise.org:6969el33:udp://tracker.open'
+    b'trackr.org:1337el26:wss://tracker.btorrent.xyzel25:wss://tracker.fastcast.nzel32:wss://tracker.openwebtorrent.co'
+    b'mee7:comment23:This is a test torrent.10:created by18:qBittorrent v4.2.513:creation datei1595424635e4:infod6:len'
+    b'gthi8525e4:name9:readme.md12:piece lengthi16384e6:pieces20:\n_y\x0c\xfa\xb9^&2\xe3`!\x12\x1f\x14&z7AIe8:url-list'
+    b'31:https://webtorrent.io/torrents/e'
+)
+TEST_TORRENT_DECODED = {
+    'announce': 'udp://explodie.org:6969',
+    'announce-list': [
+        ['udp://explodie.org:6969'],
+        ['udp://tracker.coppersurfer.tk:6969'],
+        ['udp://tracker.empire-js.us:1337'],
+        ['udp://tracker.leechers-paradise.org:6969'],
+        ['udp://tracker.opentrackr.org:1337'],
+        ['wss://tracker.btorrent.xyz'],
+        ['wss://tracker.fastcast.nz'],
+        ['wss://tracker.openwebtorrent.com'],
+    ],
+    'comment': 'This is a test torrent.',
+    'created by': 'qBittorrent v4.2.5',
+    'creation date': 1595424635,
+    'info': {
+        'length': 8525,
+        'name': 'readme.md',
+        'piece length': 16384,
+        'pieces': b'\n_y\x0c\xfa\xb9^&2\xe3`!\x12\x1f\x14&z7AI',
+    },
+    'url-list': 'https://webtorrent.io/torrents/',
+}
 
 
 @pytest.mark.parametrize('p', [
@@ -22,7 +55,7 @@ import pytest
         'value': b'd5:hello5:world7:numbersli1ei2eeeEXTRA_DATA_HERE',
         'expected': None,
         'allow_extra_data': False,
-        'raises_exc': bencodepy.BencodeDecodeError,
+        'raises_exc': BencodeDecodeError,
         'exc_message': r'.+\(data after valid prefix\)'
     },
     {  # p2: unicode with *allowed* extra data
@@ -36,22 +69,29 @@ import pytest
         'value': 'd5:hello5:world7:numbersli1ei2eeeEXTRA_DATA_HERE',
         'expected': None,
         'allow_extra_data': False,
-        'raises_exc': bencodepy.BencodeDecodeError,
+        'raises_exc': BencodeDecodeError,
         'exc_message': r'.+\(data after valid prefix\)'
     },
     {  # p4: invalid data
         'value': 'Heythere',
         'expected': None,
         'allow_extra_data': False,
-        'raises_exc': bencodepy.BencodeDecodeError,
+        'raises_exc': BencodeDecodeError,
         'exc_message': r'not a valid bencoded string'
     },
     {  # p5: none
         'value': None,
         'expected': None,
         'allow_extra_data': False,
-        'raises_exc': bencodepy.BencodeDecodeError,
+        'raises_exc': BencodeDecodeError,
         'exc_message': r'not a valid bencoded string'
+    },
+    {  # p6: example torrent
+        'value': TEST_TORRENT_CONTENT,
+        'expected': TEST_TORRENT_DECODED,
+        'allow_extra_data': True,
+        'raises_exc': None,
+        'exc_message': r''
     }
 ])
 def test_bdecode_monkeypatch(p):
@@ -64,11 +104,9 @@ def test_bdecode_monkeypatch(p):
     raises_exc = p['raises_exc']
 
     # When + Then
-    bc = bencodepy.Bencode(encoding='utf-8')
-
     if raises_exc is not None:
         with pytest.raises(raises_exc, match=exc_message):
-            actual = bc.decode(value, allow_extra_data=allow_extra_data)
+            actual = BENCODE.decode(value, allow_extra_data=allow_extra_data)
     else:
-        actual = bc.decode(value, allow_extra_data=allow_extra_data)
+        actual = BENCODE.decode(value, allow_extra_data=allow_extra_data)
         assert expected == actual


### PR DESCRIPTION
Fixes #8257 

I specifically made sure this part worked, by using an actual torrent file. Hash matched against https://torrenteditor.com.
https://github.com/pymedusa/Medusa/blob/494fa1ea5fd8267f9f71db24afd71ec685be6a2b/medusa/clients/torrent/generic.py#L206-L208

And I added a test torrent to the tests.