### PR TITLE
Limit Python dependency versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -50,6 +50,10 @@
       {
         "packageNames": ["rarfile"],
         "allowedVersions": "<=3.1"
+      }, 
+      {
+        "packageNames": ["dogpile.cache"],
+        "allowedVersions": "<1"
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -54,6 +54,10 @@
       {
         "packageNames": ["dogpile.cache"],
         "allowedVersions": "<1"
+      },
+      {
+        "packageNames": ["validators"],
+        "allowedVersions": "<0.17.0"
       }
     ]
   }


### PR DESCRIPTION
- Limit `dogpile.cache` to `<1`
	[Dropped support for Python 2.7 **AND** Python 3.5](https://github.com/sqlalchemy/dogpile.cache/blob/8a2983731190a1f2491ca232eb791cf7b493acd4/docs/build/changelog.rst#L9-L20)
	Related to #8299 
- Limit `validators` to `<0.17.0`
	[Dropped support for Python 2.7](https://github.com/kvesteri/validators/blob/f441a098655cce2edf94a74b35556b1a17aea135/CHANGES.rst)
	Related to #8295 