### PR TITLE
Catch error for using --set-remote-to on old git installations.

### DIFF
--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -154,9 +154,9 @@ class GitUpdateManager(UpdateManager):
             if output:
                 if 'stash' in output:
                     log.warning(u"Enable 'git reset' in settings or stash your changes in local files")
-                elif 'unknown option' in error and 'set-upstream-to' in error:
+                elif 'unknown option' in output and 'set-upstream-to' in output:
                     log.info("Can't set upstream to origin/{0} because your running an old version of git."
-                             "\nPlease upgrade your git installation to its latest version.", app.BRANCH)
+                             '\nPlease upgrade your git installation to its latest version.', app.BRANCH)
                 else:
                     log.warning(u'{cmd} returned : {output}', {'cmd': cmd, 'output': output})
             else:

--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -377,4 +377,7 @@ class GitUpdateManager(UpdateManager):
         self._run_git(self._git_path, 'config remote.{0}.pushurl {1}'.format(app.GIT_REMOTE, app.GIT_REMOTE_URL))
 
     def set_upstream_branch(self):
-        self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))
+        _, error, exit_status = self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))
+        if exit_status and 'unknown option' in error:
+            log.warning("Can't set upstream to origin/{0} because your running an old version of git."
+                        "\nPlease upgrade your git installation to it's latest version.", app.BRANCH)

--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -154,6 +154,9 @@ class GitUpdateManager(UpdateManager):
             if output:
                 if 'stash' in output:
                     log.warning(u"Enable 'git reset' in settings or stash your changes in local files")
+                elif 'unknown option' in error and 'set-upstream-to' in error:
+                    log.info("Can't set upstream to origin/{0} because your running an old version of git."
+                             "\nPlease upgrade your git installation to its latest version.", app.BRANCH)
                 else:
                     log.warning(u'{cmd} returned : {output}', {'cmd': cmd, 'output': output})
             else:
@@ -378,6 +381,3 @@ class GitUpdateManager(UpdateManager):
 
     def set_upstream_branch(self):
         _, error, exit_status = self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))
-        if exit_status and 'unknown option' in error:
-            log.info("Can't set upstream to origin/{0} because your running an old version of git."
-                        "\nPlease upgrade your git installation to its latest version.", app.BRANCH)

--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -379,5 +379,5 @@ class GitUpdateManager(UpdateManager):
     def set_upstream_branch(self):
         _, error, exit_status = self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))
         if exit_status and 'unknown option' in error:
-            log.warning("Can't set upstream to origin/{0} because your running an old version of git."
-                        "\nPlease upgrade your git installation to it's latest version.", app.BRANCH)
+            log.info("Can't set upstream to origin/{0} because your running an old version of git."
+                        "\nPlease upgrade your git installation to its latest version.", app.BRANCH)

--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -380,4 +380,4 @@ class GitUpdateManager(UpdateManager):
         self._run_git(self._git_path, 'config remote.{0}.pushurl {1}'.format(app.GIT_REMOTE, app.GIT_REMOTE_URL))
 
     def set_upstream_branch(self):
-        _, error, exit_status = self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))
+        self._run_git(self._git_path, 'branch {0} --set-upstream-to origin/{1}'.format(app.BRANCH, app.BRANCH))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
