### PR TITLE
Fix torrent hash from magnet to be unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix notify lists for prowl and email ([8535](https://github.com/pymedusa/Medusa/pull/8535))
 - Fix shows sorting by article sort using (the, a, an) was reversed in config-general ([8532](https://github.com/pymedusa/Medusa/pull/8532))
 - Fix sending torrents to qBittorrent api version > 2.0.0 ([8528](https://github.com/pymedusa/Medusa/pull/8528))
+- Fix decoding torrent hash from magnet links ([8563](https://github.com/pymedusa/Medusa/pull/8563))
 
 -----
 

--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -198,7 +198,8 @@ class GenericClient(object):
         if result.url.startswith('magnet:'):
             result.hash = re.findall(r'urn:btih:([\w]{32,40})', result.url)[0]
             if len(result.hash) == 32:
-                result.hash = b16encode(b32decode(result.hash)).lower()
+                hash_b16 = b16encode(b32decode(result.hash)).lower()
+                result.hash = hash_b16.decode('utf-8')
         else:
 
             try:


### PR DESCRIPTION
Fixes #8245

This isn't related to the first fix in any way. `bencode` had nothing to do with it this time 😉 