### PR TITLE
Feature/always use indexer session

### DIFF
--- a/medusa/image_cache.py
+++ b/medusa/image_cache.py
@@ -142,6 +142,10 @@ def which_type(path):
         return
 
     height, width = image_dimension
+    if not width or not height:
+        log.debug('Skipping image. zero width or height {0}', path)
+        return
+
     aspect_ratio = width / height
     log.debug('Image aspect ratio: {0}', aspect_ratio)
 

--- a/medusa/indexers/base.py
+++ b/medusa/indexers/base.py
@@ -23,10 +23,8 @@ from medusa.indexers.exceptions import (
 )
 from medusa.indexers.ui import BaseUI, ConsoleUI
 from medusa.logger.adapters.style import BraceAdapter
-from medusa.statistics import weights
 from medusa.session.core import IndexerSession
-
-import requests
+from medusa.statistics import weights
 
 from six import integer_types, itervalues, string_types, text_type, viewitems
 

--- a/medusa/indexers/base.py
+++ b/medusa/indexers/base.py
@@ -24,6 +24,7 @@ from medusa.indexers.exceptions import (
 from medusa.indexers.ui import BaseUI, ConsoleUI
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.statistics import weights
+from medusa.session.core import IndexerSession
 
 import requests
 
@@ -88,7 +89,7 @@ class BaseIndexer(object):
         else:
             raise ValueError('Invalid value for Cache {0!r} (type was {1})'.format(cache, type(cache)))
 
-        self.config['session'] = session if session else requests.Session()
+        self.config['session'] = session if session else IndexerSession(cache_control={'cache_etags': False})
 
         self.config['episodes_enabled'] = episodes
         self.config['banners_enabled'] = banners

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1625,6 +1625,10 @@ class Series(TV):
             log.warning(u'{id}: IMDbPie error while loading show info: {error}',
                         {'id': self.series_id, 'error': error})
             imdb_info = None
+        except Exception as error:
+            log.warning(u'{id}: IMDbPie error while loading show info: {error}',
+                        {'id': self.series_id, 'error': error})
+            imdb_info = None
 
         if not imdb_info:
             log.debug(u"{id}: IMDb didn't return any info for {imdb_id}, skipping update.",

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1621,10 +1621,6 @@ class Series(TV):
 
         try:
             imdb_info = imdb_api.get_title(self.imdb_id)
-        except LookupError as error:
-            log.warning(u'{id}: IMDbPie error while loading show info: {error}',
-                        {'id': self.series_id, 'error': error})
-            imdb_info = None
         except Exception as error:
             log.warning(u'{id}: IMDbPie error while loading show info: {error}',
                         {'id': self.series_id, 'error': error})


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Make sure all indexers allways use the IndexerSession() class.

The Imdb request is raising an OsError exception. Using Exception to catch all, as I don't know what other exceptions can be thrown besides LookupError. Don't want it to impact the AddShow thread.
