### PR TITLE
Feature/fix parsing anime guessit

### DIFF
--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -250,7 +250,8 @@ class SearchResult(object):
         """Use this result to create an episode segment out of it."""
         if self.actual_season is not None and self.series:
             if self.actual_episodes:
-                self.episodes = [self.series.get_episode(self.actual_season, ep) for ep in self.actual_episodes]
+                episodes = (self.series.get_episode(self.actual_season, ep) for ep in self.actual_episodes)
+                self.episodes = [ep for ep in episodes if ep is not None]
                 if len(self.actual_episodes) == 1:
                     self.episode_number = self.actual_episodes[0]
                 else:
@@ -288,7 +289,8 @@ class SearchResult(object):
         # Multi or single episode result
         else:
             actual_episodes = [int(ep) for ep in sql_episodes.split('|')]
-            ep_objs = [series_obj.get_episode(actual_season, ep) for ep in actual_episodes]
+            episodes = (series_obj.get_episode(actual_season, ep) for ep in actual_episodes)
+            ep_objs = [ep for ep in episodes if ep is not None]
 
             self.actual_episodes = actual_episodes
             if len(actual_episodes) == 1:

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1028,7 +1028,7 @@ class AbsoluteEpisodeWithX265(Rule):
     priority = POST_PROCESS
     consequence = [RemoveMatch, AppendMatch]
     non_words_re = re.compile(r'\W')
-    re_episode_with_x = re.compile(r'[\d]+.x26\d')
+    re_episode_with_x = re.compile(r'(?P<season>[\d]+).(?P<encoder>x26\d)')
     episode_words = ('e', 'episode', 'ep')
 
     def when(self, matches, context):
@@ -1046,7 +1046,8 @@ class AbsoluteEpisodeWithX265(Rule):
 
         if context.get('show_type') != 'normal' and matches.named('season') and not matches.named('episode'):
             seasons = matches.named('season')
-            if self.re_episode_with_x.search(matches.input_string):
+            tag_sxx_exx = matches.tagged('SxxExx')[0].initiator.advanced['value']
+            if self.re_episode_with_x.search(tag_sxx_exx):
                 season = seasons[0]
                 absolute_episode = copy.copy(season)
                 absolute_episode.name = 'absolute_episode'

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -995,7 +995,7 @@ class AbsoluteEpisodeNumbers(Rule):
             return to_remove, to_append
 
 
-class AbsoluteEpisodeWithX265(Rule):
+class AbsoluteEpisodeWithX26Y(Rule):
     """An absolute episode number followed by a `.x` makes guessit parse it as a season.
 
     Medusa absolute episode numbers rule where the episode is followed by `.x`
@@ -1038,10 +1038,10 @@ class AbsoluteEpisodeWithX265(Rule):
         :type context: dict
         :return:
         """
-        # if it seems to be anime and it doesn't have season
         to_remove = []
         to_append = []
 
+        # if it seems to be anime and it doesn't have a season
         if context.get('show_type') == 'normal' or not matches.named('season') or matches.named('episode'):
             return
 
@@ -1746,7 +1746,7 @@ def rules():
         AnimeWithSeasonMultipleEpisodeNumbers,
         AnimeAbsoluteEpisodeNumbers,
         AbsoluteEpisodeNumbers,
-        AbsoluteEpisodeWithX265,
+        AbsoluteEpisodeWithX26Y,
         FixEpisodeTitleAsMultiSeason,
         OnePreGroupAsMultiEpisode,
         PartsAsEpisodeNumbers,

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -977,7 +977,7 @@ class AbsoluteEpisodeNumbers(Rule):
                         if hole and self.non_words_re.sub('', hole.value).lower() in self.episode_words:
                             # if version is present, then it's an anime
                             if (context.get('show_type') != 'anime'
-                                and not matches.named('version') and not matches.tagged('anime')):
+                                    and not matches.named('version') and not matches.tagged('anime')):
                                 # Some.Show.E07.1080p.HDTV.x265-GROUP
                                 # Some.Show.Episode.10.Some.Title.720p
                                 # not absolute episode

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1048,7 +1048,7 @@ class AbsoluteEpisodeWithX265(Rule):
         if not matches.tagged('SxxExx'):
             return
 
-        tag_sxx_exx = matches.tagged('SxxExx')[0].initiator.advanced['value']
+        tag_sxx_exx = matches.tagged('SxxExx')[-1].initiator.advanced['value']
         if self.re_episode_with_x.search(tag_sxx_exx):
             seasons = matches.named('season')
             season = seasons[0]

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -718,7 +718,9 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                     multi_results, single_results = collect_candidates(
                         found_results, cur_provider, multi_results, single_results
                     )
-                    found_eps = itertools.chain(*(result.episodes for result in multi_results + single_results))
+                    # FIXME: Adding result.episodes is a hack. We should evaluate if we can process multi_results with season packs here.
+                    # As a season pack does not nessecarily have episodes in them.
+                    found_eps = itertools.chain(*(result.episodes for result in multi_results + single_results if result.episodes))
                     needed_eps = [ep for ep in episodes if ep not in found_eps]
 
             except AuthException as error:

--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -718,9 +718,7 @@ def search_providers(series_obj, episodes, forced_search=False, down_cur_quality
                     multi_results, single_results = collect_candidates(
                         found_results, cur_provider, multi_results, single_results
                     )
-                    # FIXME: Adding result.episodes is a hack. We should evaluate if we can process multi_results with season packs here.
-                    # As a season pack does not nessecarily have episodes in them.
-                    found_eps = itertools.chain(*(result.episodes for result in multi_results + single_results if result.episodes))
+                    found_eps = itertools.chain(*(result.episodes for result in multi_results + single_results))
                     needed_eps = [ep for ep in episodes if ep not in found_eps]
 
             except AuthException as error:

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -354,13 +354,15 @@ class Episode(TV):
             parse_result = NameParser(try_indexers=True).parse(filepath, cache_result=True)
             results = []
             if parse_result.series.is_anime and parse_result.ab_episode_numbers:
-                results = [parse_result.series.get_episode(absolute_number=episode_number, should_cache=False)
-                           for episode_number in parse_result.ab_episode_numbers]
+                episodes = (parse_result.series.get_episode(absolute_number=episode_number, should_cache=False)
+                            for episode_number in parse_result.ab_episode_numbers)
+                results = [ep for ep in episodes if ep is not None]
 
             if not parse_result.series.is_anime and parse_result.episode_numbers:
-                results = [parse_result.series.get_episode(season=parse_result.season_number,
-                                                           episode=episode_number, should_cache=False)
-                           for episode_number in parse_result.episode_numbers]
+                episodes = (parse_result.series.get_episode(season=parse_result.season_number,
+                                                            episode=episode_number, should_cache=False)
+                            for episode_number in parse_result.episode_numbers)
+                results = [ep for ep in episodes if ep is not None]
 
             for episode in results:
                 episode.related_episodes = list(results[1:])
@@ -1591,9 +1593,9 @@ class Episode(TV):
             '%E': str(self.episode),
             '%0E': '%02d' % self.episode,
             '%XS': str(self.scene_season),
-            '%0XS': '%02d' % try_int(self.scene_season, self.season),
+            '%0XS': '%02d' % self.scene_season,
             '%XE': str(self.scene_episode),
-            '%0XE': '%02d' % try_int(self.scene_episode, self.episode),
+            '%0XE': '%02d' % self.scene_episode,
             '%AB': '%(#)03d' % {'#': self.absolute_number},
             '%XAB': '%(#)03d' % {'#': self.scene_absolute_number},
             '%RN': release_name(self.release_name),

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -860,7 +860,7 @@ class Series(TV):
         absolute_number = try_int(absolute_number, None)
 
         # if we get an anime get the real season and episode
-        if not season and not episode:
+        if season is None and not episode:
             main_db_con = db.DBConnection()
             sql = None
             sql_args = None
@@ -870,8 +870,7 @@ class Series(TV):
                     'FROM tv_episodes '
                     'WHERE indexer = ? '
                     'AND showid = ? '
-                    'AND absolute_number = ? '
-                    'AND season != 0'
+                    'AND absolute_number = ?'
                 )
                 sql_args = [self.indexer, self.series_id, absolute_number]
                 log.debug(u'{id}: Season and episode lookup for {show} using absolute number {absolute}',

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4485,3 +4485,17 @@
   alternative_title: Redux presents The Uplifting Selection Vol
   source: Web
   type: episode
+
+? "[Raze].Jujutsu.Kaisen-09.x265.10bit.1080p.60fps"
+: title: Jujutsu Kaisen
+  episode: 9
+  absolute_episode: 9
+  release_group: Raze
+  alias: Jujutsu Kaisen
+  video_codec: H.265
+  video_encoder: x265
+  color_depth: 10-bit
+  screen_size: 1080p
+  frame_rate: 60fps
+  type: episode
+  release_name: "[Raze].Jujutsu.Kaisen-09.x265.10bit.1080p.60fps"

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4491,11 +4491,9 @@
   episode: 9
   absolute_episode: 9
   release_group: Raze
-  alias: Jujutsu Kaisen
   video_codec: H.265
   video_encoder: x265
   color_depth: 10-bit
   screen_size: 1080p
   frame_rate: 60fps
   type: episode
-  release_name: "[Raze].Jujutsu.Kaisen-09.x265.10bit.1080p.60fps"

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4497,3 +4497,14 @@
   screen_size: 1080p
   frame_rate: 60fps
   type: episode
+
+? "[QCE]Jujutsu.Kaisen.10.x264.AAC.720p"
+: title: Jujutsu Kaisen
+  episode: 10
+  absolute_episode: 10
+  release_group: QCE
+  video_codec: H.264
+  video_encoder: x264
+  audio_codec: AAC
+  screen_size: 720p
+  type: episode


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Should fix:
```
D:\development\Medusa\tests>python report_guessit.py "[Raze].Jujutsu.Kaisen-09.x265.10bit.1080p.60fps"
# guessit: 3.1.1  rebulk: 2.0.1
? [Raze].Jujutsu.Kaisen-09.x265.10bit.1080p.60fps
: release_group: Raze
  title: Jujutsu Kaisen
  season: 9
  video_codec: H.265
  video_encoder: x265
  color_depth: 10-bit
  screen_size: 1080p
  frame_rate: 60fps
  type: episode
```