### PR TITLE
Add cache for guessit

### DIFF
--- a/medusa/name_parser/cache.py
+++ b/medusa/name_parser/cache.py
@@ -43,16 +43,17 @@ class BaseCache(object):
         :rtype: object
         """
         with self.lock:
-            return self.thread_unsafe_get(name)
-
-    def thread_unsafe_get(self, name):
-        """Return a cache item from the cache. This function doesn't lock and is therefore not thread safe."""
-        if name in self.cache:
-            log.debug('Using cache item for {name}', {'name': name})
-            return self.cache[name]
+            if name in self.cache:
+                log.debug('Using cache item for {name}', {'name': name})
+                return self.cache[name]
 
     def remove(self, name):
         """Remove a cache item given name."""
         with self.lock:
             del self.cache[name]
             log.debug('Removed cache item for {name}', {'name': name})
+
+    def clear(self):
+        """Removes all items from the cache."""
+        with self.lock:
+            self.cache.clear()

--- a/medusa/name_parser/cache.py
+++ b/medusa/name_parser/cache.py
@@ -1,0 +1,54 @@
+from collections import OrderedDict
+from threading import Lock
+import logging
+
+from medusa.logger.adapters.style import BraceAdapter
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
+
+
+class BaseCache(object):
+    """Base cache."""
+
+    def __init__(self, max_size=1000):
+        """Initialize the cache with a maximum size."""
+        self.cache = OrderedDict()
+        self.max_size = max_size
+        self.lock = Lock()
+
+    def add(self, name, value):
+        """Add a cache item to the cache.
+
+        :param name:
+        :type name: str
+        :param value:
+        :type value: object
+        """
+        with self.lock:
+            while len(self.cache) >= self.max_size:
+                self.cache.popitem(last=False)
+            self.cache[name] = value
+
+    def get(self, name):
+        """Return a cache item from the cache.
+
+        :param name:
+        :type name: str
+        :return:
+        :rtype: object
+        """
+        with self.lock:
+            return self.thread_unsafe_get(name)
+
+    def thread_unsafe_get(self, name):
+        """Return a cache item from the cache. This function doesn't lock and is therefore not thread safe. """
+        if name in self.cache:
+            log.debug('Using cache item for {name}', {'name': name})
+            return self.cache[name]
+
+    def remove(self, name):
+        """Remove a cache item given name."""
+        with self.lock:
+            del self.cache[name]
+            log.debug('Removed cache item for {name}', {'name': name})

--- a/medusa/name_parser/cache.py
+++ b/medusa/name_parser/cache.py
@@ -1,6 +1,10 @@
+# coding=utf-8
+
+"""A thread-safe cache with a max size."""
+
+import logging
 from collections import OrderedDict
 from threading import Lock
-import logging
 
 from medusa.logger.adapters.style import BraceAdapter
 
@@ -42,7 +46,7 @@ class BaseCache(object):
             return self.thread_unsafe_get(name)
 
     def thread_unsafe_get(self, name):
-        """Return a cache item from the cache. This function doesn't lock and is therefore not thread safe. """
+        """Return a cache item from the cache. This function doesn't lock and is therefore not thread safe."""
         if name in self.cache:
             log.debug('Using cache item for {name}', {'name': name})
             return self.cache[name]

--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -4,12 +4,19 @@
 from __future__ import unicode_literals
 
 import re
+import logging
+
 from datetime import timedelta
 from time import time
 
 from medusa import app
 from medusa.name_parser.rules import default_api
+from medusa.name_parser.cache import BaseCache
 
+from medusa.logger.adapters.style import BraceAdapter
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
 
 EXPECTED_TITLES_EXPIRATION_TIME = timedelta(days=1).total_seconds()
 
@@ -75,7 +82,12 @@ def guessit(name, options=None):
                               expected_group=expected_groups,
                               allowed_languages=allowed_languages,
                               allowed_countries=allowed_countries))
-    result = default_api.guessit(name, options=final_options)
+
+    result = guessit_cache.get_or_invalidate(name, final_options)
+    if not result:
+        result = default_api.guessit(name, options=final_options)
+        guessit_cache.add(name, result)
+
     result['parsing_time'] = time() - start_time
     return result
 
@@ -109,3 +121,33 @@ def get_expected_titles(show_list):
             expected_titles.append(exception)
 
     return expected_titles
+
+
+class GuessItCache(BaseCache):
+    """GuessIt cache."""
+
+    def __init__(self):
+        """Initialize the cache with a maximum size."""
+        super().__init__(25000)
+        self.invalidation_object = None
+
+    def get_or_invalidate(self, name, obj):
+        """Return an item from the cache if the obj matches the previous invalidation object.
+        Clears the cache and returns None if not."""
+
+        with self.lock:
+            if not self.invalidation_object:
+                self.invalidation_object = obj
+
+            if self.invalidation_object == obj:
+                log.debug('Using guessit cache item for {name}', {'name': name})
+                return self.thread_unsafe_get(name)
+
+            log.debug('GuessIt cache was cleared due to invalidation object change: previous={previous} new={new}',
+                      {'previous': self.invalidation_object, 'new': obj})
+            self.invalidation_object = obj
+            self.cache.clear()
+            return None
+
+
+guessit_cache = GuessItCache()

--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -3,17 +3,15 @@
 """Guessit Name Parser."""
 from __future__ import unicode_literals
 
-import re
 import logging
-
+import re
 from datetime import timedelta
 from time import time
 
 from medusa import app
-from medusa.name_parser.rules import default_api
-from medusa.name_parser.cache import BaseCache
-
 from medusa.logger.adapters.style import BraceAdapter
+from medusa.name_parser.cache import BaseCache
+from medusa.name_parser.rules import default_api
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
@@ -132,9 +130,7 @@ class GuessItCache(BaseCache):
         self.invalidation_object = None
 
     def get_or_invalidate(self, name, obj):
-        """Return an item from the cache if the obj matches the previous invalidation object.
-        Clears the cache and returns None if not."""
-
+        """Return an item from the cache if the obj matches the previous invalidation object. Clears the cache and returns None if not."""
         with self.lock:
             if not self.invalidation_object:
                 self.invalidation_object = obj

--- a/medusa/name_parser/guessit_parser.py
+++ b/medusa/name_parser/guessit_parser.py
@@ -131,19 +131,18 @@ class GuessItCache(BaseCache):
 
     def get_or_invalidate(self, name, obj):
         """Return an item from the cache if the obj matches the previous invalidation object. Clears the cache and returns None if not."""
-        with self.lock:
-            if not self.invalidation_object:
-                self.invalidation_object = obj
-
-            if self.invalidation_object == obj:
-                log.debug('Using guessit cache item for {name}', {'name': name})
-                return self.thread_unsafe_get(name)
-
-            log.debug('GuessIt cache was cleared due to invalidation object change: previous={previous} new={new}',
-                      {'previous': self.invalidation_object, 'new': obj})
+        if not self.invalidation_object:
             self.invalidation_object = obj
-            self.cache.clear()
-            return None
+
+        if self.invalidation_object == obj:
+            log.debug('Using guessit cache item for {name}', {'name': name})
+            return self.get(name)
+
+        log.debug('GuessIt cache was cleared due to invalidation object change: previous={previous} new={new}',
+                  {'previous': self.invalidation_object, 'new': obj})
+        self.invalidation_object = obj
+        self.clear()
+        return None
 
 
 guessit_cache = GuessItCache()

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -600,7 +600,7 @@ class ParseResult(object):
 
 
 class BaseCache(object):
-    """Base cache"""
+    """Base cache."""
 
     def __init__(self, max_size=1000):
         """Initialize the cache with a maximum size."""
@@ -622,7 +622,7 @@ class BaseCache(object):
             self.cache[name] = value
 
     def get(self, name):
-        """Return a cache item from the cache
+        """Return a cache item from the cache.
 
         :param name:
         :type name: str
@@ -635,7 +635,7 @@ class BaseCache(object):
                 return self.cache[name]
 
     def remove(self, name):
-        """Remove a cache item given name"""
+        """Remove a cache item given name."""
         with self.lock:
             del self.cache[name]
             log.debug('Removed cache item for {name}', {'name': name})

--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -9,8 +9,6 @@ from collections import OrderedDict
 
 import guessit
 
-from medusa.name_parser.cache import BaseCache
-
 from medusa import (
     common,
     db,
@@ -26,6 +24,7 @@ from medusa.indexers.exceptions import (
     IndexerException,
 )
 from medusa.logger.adapters.style import BraceAdapter
+from medusa.name_parser.cache import BaseCache
 
 from six import iteritems
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review

First off, I don't have much experience with python nor writing pull requests, so I hope this is according to your standards

guessit is one of the slowest parts of the name parsing. This PR adds a cache for guessit results to improve performance if called repetitive. This happens for example when scheduled post-processing is used.

Normal name parsing already has a cache, however it's only used for successful parses (which makes sense as it also includes db searches). If there are many files in the torrent/nzb download folder which aren't related to medusa (basically any other torrent download) it will take a very long time, as files without a show will cause a parse to be unsuccessful.