### PR TITLE
Allow torrent client move when process_method is 'copy' (2)

### DIFF
--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -1313,7 +1313,7 @@ class PostProcessor(object):
         self._run_extra_scripts(ep_obj)
 
         if not self.nzb_name and all([app.USE_TORRENTS, app.TORRENT_SEED_LOCATION,
-                                      self.process_method in ('hardlink', 'symlink', 'reflink', 'keeplink')]):
+                                      self.process_method in ('hardlink', 'symlink', 'reflink', 'keeplink', 'copy')]):
             # Store self.info_hash and self.release_name so later we can remove from client if setting is enabled
             if self.info_hash:
                 existing_release_names = app.RECENTLY_POSTPROCESSED.get(self.info_hash, [])

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -213,7 +213,7 @@ class ProcessResult(object):
                 self.log_and_output('Missed file: {missed_file}', level=logging.WARNING, **{'missed_file': missed_file})
 
         if all([app.USE_TORRENTS, app.TORRENT_SEED_LOCATION,
-                self.process_method in ('hardlink', 'symlink', 'reflink')]):
+                self.process_method in ('hardlink', 'symlink', 'reflink', 'copy')]):
             for info_hash, release_names in list(iteritems(app.RECENTLY_POSTPROCESSED)):
                 if self.move_torrent(info_hash, release_names):
                     app.RECENTLY_POSTPROCESSED.pop(info_hash, None)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

See https://github.com/pymedusa/Medusa/pull/8936