### PR TITLE
Fix scene exceptions sometimes breaking mass update functionality

### DIFF
--- a/medusa/scene_exceptions.py
+++ b/medusa/scene_exceptions.py
@@ -230,13 +230,13 @@ def update_scene_exceptions(series_obj, scene_exceptions):
         # A change has been made to the scene exception list.
 
         # Prevent adding duplicate scene exceptions.
-        if exception['title'] not in exceptions_cache[(series_obj.indexer, series_obj.series_id)][exception['season']]:
+        if exception.title not in exceptions_cache[(series_obj.indexer, series_obj.series_id)][exception.season]:
             # Add to db
             main_db_con.action(
                 'INSERT INTO scene_exceptions '
                 '(indexer, series_id, title, season, custom) '
                 'VALUES (?,?,?,?,?)',
-                [series_obj.indexer, series_obj.series_id, exception['title'], exception['season'], exception['custom']]
+                [series_obj.indexer, series_obj.series_id, exception.title, exception.season, exception.custom]
             )
 
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Please note that **I am not a Python developer**: I am not sure whether this is the correct solution, please check me on this.

This PR resolves the issue in #9000. 

From what I gathered, the fields on the TitleException tuple are being accessed incorrectly, leading to the stacktrace you can find in the issue. This should be solved with these changes.
