### PR TITLE
Remove get_scene_exceptions() call from massUpdateShow handler.

### DIFF
--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -51,8 +51,7 @@ from medusa.helpers.anidb import get_release_groups_for_anime
 from medusa.indexers.api import indexerApi
 from medusa.indexers.utils import indexer_name_to_id
 from medusa.scene_exceptions import (
-    get_all_scene_exceptions,
-    get_scene_exceptions,
+    get_all_scene_exceptions
 )
 from medusa.scene_numbering import (
     get_scene_absolute_numbering,

--- a/medusa/server/web/home/handler.py
+++ b/medusa/server/web/home/handler.py
@@ -956,8 +956,6 @@ class Home(WebRoot):
             errors += 1
             return errors
 
-        series_obj.aliases = get_scene_exceptions(series_obj)
-
         season_folders = config.checkbox_to_value(season_folders)
         dvd_order = config.checkbox_to_value(dvd_order)
         paused = config.checkbox_to_value(paused)

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -665,7 +665,11 @@ class Series(TV):
 
     @aliases.setter
     def aliases(self, exceptions):
-        """Set the series aliases."""
+        """
+        Set the series aliases.
+
+        :param exceptions: Array of dictionaries.
+        """
         update_scene_exceptions(self, exceptions)
         self._aliases = set(chain(*itervalues(get_all_scene_exceptions(self))))
         build_name_cache(self)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fix #9000 