### PR TITLE
Catch attributeerror

### DIFF
--- a/ext/readme.md
+++ b/ext/readme.md
@@ -61,7 +61,7 @@ ext | **`tornroutes`** | [0.5.1](https://pypi.org/project/tornroutes/0.5.1/) | *
 ext | **`trakt`** | [2.14.1](https://pypi.org/project/trakt/2.14.1/) | **`medusa`** | -
 ext | `trans` | [2.1.0](https://pypi.org/project/trans/2.1.0/) | `imdbpie` | File: `trans.py`
 ext | `ttl-cache` | [1.6](https://pypi.org/project/ttl-cache/1.6/) | **`medusa`** | File: `ttl_cache.py`
-ext | **`tvdbapiv2`** | pymedusa/[bf1272c](https://github.com/pymedusa/tvdbv2/tree/bf1272c9264c280c3048e89a1920e2bf5f386284) | **`medusa`** | -
+ext | **`tvdbapiv2`** | pymedusa/[d6d0e9d](https://github.com/pymedusa/tvdbv2/tree/d6d0e9d98071c2d646beb997b336edbb0e98dfb7) | **`medusa`** | -
 ext | **`urllib3`** | [1.24.1](https://pypi.org/project/urllib3/1.24.1/) | `requests` | -
 ext | **`validators`** | [0.18.2](https://pypi.org/project/validators/0.18.2/) | **`medusa`** | -
 ext | **`webencodings`** | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | -

--- a/ext/tvdbapiv2/rest.py
+++ b/ext/tvdbapiv2/rest.py
@@ -51,6 +51,9 @@ class RESTClientObject(object):
             else:
                 r = self.session.request(method, url, params=query_params, headers=headers)
 
+            if r is None:
+                raise RequestException('Missing response')
+
             r.raise_for_status()
 
         except RequestException as error:

--- a/medusa/indexers/tvmaze/api.py
+++ b/medusa/indexers/tvmaze/api.py
@@ -465,7 +465,9 @@ class TVmaze(BaseIndexer):
         results = []
         try:
             updates = self.tvmaze_api.show_updates()
-        except (ShowIndexError, UpdateNotFound):
+        except (AttributeError, ShowIndexError, UpdateNotFound):
+            # Tvmaze api depends on .status_code in.., but does not catch request exceptions.
+            # Therefor the AttributeError.
             return results
         except BaseError as e:
             log.warning('Getting show updates failed. Cause: {0}', e)

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,5 @@ tornado==6.1
 tornroutes==0.5.1
 trakt==2.14.1
 ttl-cache==1.6
-tvdbapiv2 @ https://codeload.github.com/pymedusa/tvdbv2/tar.gz/bf1272c9264c280c3048e89a1920e2bf5f386284
+tvdbapiv2 @ https://codeload.github.com/pymedusa/tvdbv2/tar.gz/d6d0e9d98071c2d646beb997b336edbb0e98dfb7
 validators==0.18.2


### PR DESCRIPTION
Tvmaze api depends on .status_code in.., but does not catch request exceptions.
Therefor the AttributeError.

fix #8848 #8902 

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
