### PR TITLE
Add workaround for animebytes caching issue

### DIFF
--- a/medusa/providers/torrent/json/animebytes.py
+++ b/medusa/providers/torrent/json/animebytes.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 
 import logging
 import re
+from datetime import datetime, timedelta, timezone
 
 from medusa import tv
 from medusa.helper.common import convert_size
@@ -285,6 +286,11 @@ class AnimeBytes(TorrentProvider):
                 seeders = row.get('Seeders')
                 leechers = row.get('Leechers')
                 pubdate = self.parse_pubdate(row.get('UploadTime'))
+
+                # This is a workaround for an animebytes caching issue where newly created torrents are cached with
+                # zero seeders and leechers
+                if seeders == 0 and leechers == 0 and datetime.now(timezone.utc) - pubdate < timedelta(hours=1):
+                    seeders = 1
 
                 # Filter unseeded torrent
                 if seeders < self.minseed:


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Animebytes caches all their peer numbers, causing new torrents to have zero seeders and leechers. This adds a workaround by manually setting the seeders to one if a torrent is more recent than one hour and has zero seeders and leechers. 