### PR TITLE
Fix guessit exception when episode initiator is int

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -672,7 +672,7 @@ class AnimeWithSeasonMultipleEpisodeNumbers(Rule):
         if not (2 <= len(episodes) <= 4):
             return
 
-        unique_eps = set([ep.initiator.value.lower() for ep in episodes])
+        unique_eps = set([str(ep.initiator.value).lower() for ep in episodes])
         if len(unique_eps) != 2:
             return
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
