### PR TITLE
Apply FDH for downloads where the PP fails.

### DIFF
--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -137,7 +137,8 @@ class PostProcessQueueItem(generic_queue.QueueItem):
             )
 
             # A user might want to use advanced post-processing, but opt-out of failed download handling.
-            if process_results.failed and app.USE_FAILED_DOWNLOADS:
+            if app.USE_FAILED_DOWNLOADS \
+               and (process_results.failed or (not process_results.succeeded and self.resource_name)):
                 process_results.process_failed(path)
 
             # In case we have an info_hash or (nzbid), update the history table with the pp results.


### PR DESCRIPTION
* Like for example where guessit can't parse a decent show from the proc_dir.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

I'm checking if resource_name is passed.
Because if it's not postprocessing a specific resource. And we can only `RETRY` a specific resource. Not a folder with x downloads.