### PR TITLE
Don't empty SID cookie when qbittorrent is not returning any cookies

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -110,7 +110,6 @@ class QBittorrentAPI(GenericClient):
                 return None
 
             # Successful log in
-            # self.session.cookies = self.response.cookies
             self.auth = self.response.text
 
             return self.auth

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -64,9 +64,7 @@ class QBittorrentAPI(GenericClient):
             self.url = urljoin(self.host, 'api/v2/app/webapiVersion')
             try:
                 response = self.session.get(self.url, verify=app.TORRENT_VERIFY_CERT)
-                if not response:
-                    raise ValueError('No response from qbittorrent client')
-                if not response.text:
+                if not response or not response.text:
                     raise ValueError('Response from client is empty. [Status: {0}]'.format(response.status_code))
                 # Make sure version is using the (major, minor, release) format
                 version = tuple(map(int, response.text.split('.')))

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -110,7 +110,7 @@ class QBittorrentAPI(GenericClient):
                 return None
 
             # Successful log in
-            self.session.cookies = self.response.cookies
+            # self.session.cookies = self.response.cookies
             self.auth = self.response.text
 
             return self.auth


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

The cookies where not handled as recommended. As we should let the requests session handle this.
But this is a workaround to this issue: https://github.com/qbittorrent/qBittorrent/issues/14497