### PR TITLE
Utilize the prev_airdate property in stead of prev_episode()

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -2224,8 +2224,10 @@ class Application(object):
         for sql_show in sql_results:
             try:
                 cur_show = Series(sql_show['indexer'], sql_show['indexer_id'])
-                cur_show.prev_episode()
-                cur_show.next_episode()
+                # update previous and next episode cache
+                cur_show.prev_airdate
+                cur_show.next_airdate
+
                 app.showList.append(cur_show)
             except Exception as error:
                 exception_handler.handle(error, 'There was an error creating the show in {location}',


### PR DESCRIPTION
prev_episode() is not cached.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This fixes an issue where the user starts up medusa and directly after tries to open the home page.
It will be in the process of getting all the prev / next airdates from the startup, and then will again get the prev / next airdates through the api call. Running both can results in db lockups. Which will result in api call timeouts.