### PR TITLE
Avoid division by zero error

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -402,7 +402,7 @@ class QBittorrentAPI(GenericClient):
         client_status.ratio = torrent['ratio'] * 1.0
 
         # Store progress
-        client_status.progress = int(torrent['downloaded'] / torrent['size'] * 100)
+        client_status.progress = int(torrent['downloaded'] / torrent['size'] * 100) if torrent['size'] else 0
 
         # Store destination
         client_status.destination = torrent['save_path']


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This takes care of cases where torrent sizes may be zero. Which may be when a magnet is queued, and metadata and size has not yet been fetched.

Closes #9608.