### PR TITLE
Added "back" exception handling for the download clients.

### DIFF
--- a/medusa/clients/nzb/nzbget.py
+++ b/medusa/clients/nzb/nzbget.py
@@ -12,6 +12,7 @@ from xmlrpc.client import Error, ProtocolError, ServerProxy
 from medusa import app
 from medusa.common import Quality
 from medusa.helper.common import try_int
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 
 import ttl_cache
@@ -56,7 +57,7 @@ def nzb_connection(url):
         return False
 
 
-def test_authentication(host, username, password, use_https):
+def test_authentication(host=None, username=None, password=None, use_https=False):
     """
     Test NZBget client connection.
 
@@ -197,10 +198,13 @@ def _get_nzb_queue():
     )
 
     if not nzb_connection(url):
-        return False
+        raise DownloadClientConnectionException('Error while fetching nzbget queue')
 
     nzb_get_rpc = ServerProxy(url)
-    nzb_groups = nzb_get_rpc.listgroups()
+    try:
+        nzb_groups = nzb_get_rpc.listgroups()
+    except ConnectionRefusedError as error:
+        raise DownloadClientConnectionException(f'Error while fetching nzbget history. Error: {error}')
 
     return nzb_groups
 
@@ -216,10 +220,13 @@ def _get_nzb_history():
     )
 
     if not nzb_connection(url):
-        return False
+        raise DownloadClientConnectionException('Error while fetching nzbget history')
 
     nzb_get_rpc = ServerProxy(url)
-    nzb_groups = nzb_get_rpc.history()
+    try:
+        nzb_groups = nzb_get_rpc.history()
+    except ConnectionRefusedError as error:
+        raise DownloadClientConnectionException(f'Error while fetching nzbget history. Error: {error}')
 
     return nzb_groups
 

--- a/medusa/clients/nzb/sab.py
+++ b/medusa/clients/nzb/sab.py
@@ -16,17 +16,19 @@ from os.path import basename, dirname
 
 from medusa import app
 from medusa.helper.common import sanitize_filename
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
-from medusa.session.core import ClientSession
+from medusa.session.core import MedusaSession
 
 from requests.compat import urljoin
+from requests.exceptions import ConnectionError
 
 import ttl_cache
 
 log = BraceAdapter(logging.getLogger(__name__))
 log.logger.addHandler(logging.NullHandler())
 
-session = ClientSession()
+session = MedusaSession()
 
 
 def send_nzb(nzb):
@@ -209,7 +211,11 @@ def _get_nzb_queue(host=None):
         'limit': 100
     }
 
-    data = session.get_json(url, params=params, verify=False)
+    try:
+        data = session.get_json(url, params=params, verify=False)
+    except ConnectionError as error:
+        raise DownloadClientConnectionException(f'Error while fetching sabnzbd queue. Error: {error}')
+
     if not data:
         log.info('Error connecting to sab, no data returned')
     else:
@@ -234,7 +240,11 @@ def _get_nzb_history(host=None):
         'limit': 100
     }
 
-    data = session.get_json(url, params=params, verify=False)
+    try:
+        data = session.get_json(url, params=params, verify=False)
+    except ConnectionError as error:
+        raise DownloadClientConnectionException(f'Error while fetching sabnzbd history. Error: {error}')
+
     if not data:
         log.info('Error connecting to sab, no data returned')
     else:

--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -68,7 +68,9 @@ class GenericClient(object):
         except requests.exceptions.RequestException as error:
             log.warning('{name}: Error occurred during request: {error}',
                         {'name': self.name, 'error': error})
-            raise # We want to raise connection errors for the download_handler.
+            # We want to raise connection errors for the download_handler. As we need to know
+            # explicitely if there was a connection error when untracking tracked torrents/nzb.
+            raise
         except Exception as error:
             log.error('{name}: Unknown exception raised when sending torrent to'
                       ' {name}: {error}', {'name': self.name, 'error': error})

--- a/medusa/clients/torrent/generic.py
+++ b/medusa/clients/torrent/generic.py
@@ -15,8 +15,11 @@ from bencodepy import BencodeDecodeError, DEFAULT as BENCODE
 import certifi
 
 from medusa import app, db
+from medusa.helper.common import http_code_description
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.session.core import ClientSession
+
+import requests
 
 
 log = BraceAdapter(logging.getLogger(__name__))
@@ -54,27 +57,41 @@ class GenericClient(object):
 
     def _request(self, method='get', params=None, data=None, files=None, cookies=None):
 
-        self.response = self.session.request(
-            method, self.url, params=params, data=data, files=files, timeout=60, cookies=cookies,
-            verify=self.verify if app.TORRENT_VERIFY_CERT else False
-        )
-        if not self.response:
-            log.warning('{name} {method} call to {url} failed!', {
-                'name': self.name, 'method': method.upper(), 'url': self.url
-            })
-            self.message = f'Connect to {self.name} on "{self.host}" failed!'
+        try:
+            self.response = self.session.request(
+                method, self.url, params=params, data=data, files=files, timeout=60, cookies=cookies,
+                verify=self.verify if app.TORRENT_VERIFY_CERT else False
+            )
+        except (requests.exceptions.MissingSchema, requests.exceptions.InvalidURL) as error:
+            log.warning('{name}: Invalid Host: {error}', {'name': self.name, 'error': error})
             return False
-        if self.response.status_code >= 400:
-            log.warning('{name}: Unable to reach torrent client. Reason: {reason}', {
-                'name': self.name, 'reason': self.response.reason
-            })
-            self.message = f'Failed to connect to {self.name} reason: {self.response.reason}'
+        except requests.exceptions.RequestException as error:
+            log.warning('{name}: Error occurred during request: {error}',
+                        {'name': self.name, 'error': error})
+            raise # We want to raise connection errors for the download_handler.
+        except Exception as error:
+            log.error('{name}: Unknown exception raised when sending torrent to'
+                      ' {name}: {error}', {'name': self.name, 'error': error})
             return False
+
+        if self.response.status_code == 401:
+            log.error('{name}: Invalid Username or Password,'
+                      ' check your config', {'name': self.name})
+            return False
+
+        code_description = http_code_description(self.response.status_code)
+
+        if code_description is not None:
+            log.info('{name}: {code}',
+                     {'name': self.name, 'code': code_description})
+            return False
+
         log.debug('{name}: Response to {method} request is {response}', {
             'name': self.name,
             'method': method.upper(),
             'response': self.response.text[0:1024] + '...' if len(self.response.text) > 1027 else self.response.text
         })
+
         return True
 
     def _get_auth(self):

--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -7,8 +7,6 @@ from __future__ import unicode_literals
 import logging
 import os
 
-from requests.exceptions import RequestException
-
 from medusa import app
 from medusa.clients.torrent.generic import GenericClient
 from medusa.helper.exceptions import DownloadClientConnectionException
@@ -17,6 +15,7 @@ from medusa.schedulers.download_handler import ClientStatus
 
 from requests.auth import HTTPDigestAuth
 from requests.compat import urljoin
+from requests.exceptions import RequestException
 
 import ttl_cache
 

--- a/medusa/clients/torrent/rtorrent.py
+++ b/medusa/clients/torrent/rtorrent.py
@@ -8,6 +8,7 @@ import logging
 
 from medusa import app
 from medusa.clients.torrent.generic import GenericClient
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.schedulers.download_handler import ClientStatus
 
@@ -51,10 +52,13 @@ class RTorrentAPI(GenericClient):
             if app.SSL_CA_BUNDLE:
                 tp_kwargs['check_ssl_cert'] = app.SSL_CA_BUNDLE
 
-        if self.username and self.password:
-            self.auth = RTorrent(self.host, self.username, self.password, True, tp_kwargs=tp_kwargs)
-        else:
-            self.auth = RTorrent(self.host, None, None, True)
+        try:
+            if self.username and self.password:
+                self.auth = RTorrent(self.host, self.username, self.password, True, tp_kwargs=tp_kwargs)
+            else:
+                self.auth = RTorrent(self.host, None, None, True)
+        except Exception as error:  # No request/connection specific exception thrown.
+            raise DownloadClientConnectionException(f'Unable to authenticate with rtorrent client: {error}')
 
         return self.auth
 
@@ -82,7 +86,11 @@ class RTorrentAPI(GenericClient):
         try:
             params = self._get_params(result)
             # Send magnet to rTorrent and start it
-            torrent = self.auth.load_magnet(result.url, result.hash, start=True, params=params)
+            try:
+                torrent = self.auth.load_magnet(result.url, result.hash, start=True, params=params)
+            except DownloadClientConnectionException:
+                return False
+
             if not torrent:
                 return False
 
@@ -101,7 +109,11 @@ class RTorrentAPI(GenericClient):
         try:
             params = self._get_params(result)
             # Send torrent to rTorrent and start it
-            torrent = self.auth.load_torrent(result.content, start=True, params=params)
+            try:
+                torrent = self.auth.load_torrent(result.content, start=True, params=params)
+            except DownloadClientConnectionException:
+                return False
+
             if not torrent:
                 return False
 
@@ -132,7 +144,10 @@ class RTorrentAPI(GenericClient):
     def pause_torrent(self, info_hash):
         """Get torrent and pause."""
         log.info('Pausing {client} torrent {hash} status.', {'client': self.name, 'hash': info_hash})
-        torrent = self.auth.find_torrent(info_hash.upper())
+        try:
+            torrent = self.auth.find_torrent(info_hash.upper())
+        except DownloadClientConnectionException:
+            return False
 
         if not torrent:
             log.debug('Could not locate torrent with {hash} status.', {'hash': info_hash})
@@ -143,7 +158,10 @@ class RTorrentAPI(GenericClient):
     def remove_torrent(self, info_hash):
         """Get torrent and remove."""
         log.info('Removing {client} torrent {hash} status.', {'client': self.name, 'hash': info_hash})
-        torrent = self.auth.find_torrent(info_hash.upper())
+        try:
+            torrent = self.auth.find_torrent(info_hash.upper())
+        except DownloadClientConnectionException:
+            return False
 
         if not torrent:
             log.debug('Could not locate torrent with {hash} status.', {'hash': info_hash})

--- a/medusa/clients/torrent/transmission.py
+++ b/medusa/clients/torrent/transmission.py
@@ -12,9 +12,9 @@ from base64 import b64encode
 
 from medusa import app
 from medusa.clients.torrent.generic import GenericClient
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.schedulers.download_handler import ClientStatus
-from medusa.helper.exceptions import DownloadClientConnectionException
 
 import requests.exceptions
 from requests.compat import urljoin

--- a/medusa/clients/torrent/transmission.py
+++ b/medusa/clients/torrent/transmission.py
@@ -14,6 +14,7 @@ from medusa import app
 from medusa.clients.torrent.generic import GenericClient
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.schedulers.download_handler import ClientStatus
+from medusa.helper.exceptions import DownloadClientConnectionException
 
 import requests.exceptions
 from requests.compat import urljoin
@@ -308,8 +309,7 @@ class TransmissionAPI(GenericClient):
         post_data = json.dumps({'arguments': return_params, 'method': 'torrent-get'})
 
         if not self._request(method='post', data=post_data) or not self.check_response():
-            log.warning('Error while fetching torrent {hash} status.', {'hash': info_hash})
-            return
+            raise DownloadClientConnectionException(f'Error while fetching torrent {info_hash} status.')
 
         torrent = self.response.json()['arguments']['torrents']
         if not torrent:

--- a/medusa/clients/torrent/utorrent.py
+++ b/medusa/clients/torrent/utorrent.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 
 from medusa import app
 from medusa.clients.torrent.generic import GenericClient
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.schedulers.download_handler import ClientStatus
 
@@ -251,11 +252,13 @@ class UTorrentAPI(GenericClient):
         info_hash, it will get all torrents for each info_hash. We might want to cache this one.
         """
         params = {'list': 1}
-        if not self._request(params=params):
-            log.warning('Error while fetching torrents.')
-            return []
 
-        json_response = self.response.json()
+        try:
+            self._request(params=params)
+            json_response = self.response.json()
+        except RequestException as error:
+            raise DownloadClientConnectionException(f'Error while fetching torrent. Error: {error}')
+
         if json_response.get('torrents'):
             return json_response['torrents']
         return []

--- a/medusa/helper/exceptions.py
+++ b/medusa/helper/exceptions.py
@@ -134,3 +134,7 @@ class AnidbAdbaConnectionException(Exception):
 
     More info on the api: https://wiki.anidb.net/w/API.
     """
+
+
+class DownloadClientConnectionException(Exception):
+    """Connection exception raised while trying to communicate with the client api."""

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -918,7 +918,7 @@ class PostProcessor(object):
         self.log(u'Snatch in history: {0}'.format(self.in_history), level)
         self.log(u'Manually snatched: {0}'.format(self.manually_searched), level)
         self.log(u'Info hash: {0}'.format(self.info_hash), level)
-        self.log(u'NZB: {0}'.format(bool(self.nzb_name)), level)
+        self.log(u'Resource name: {0}'.format(bool(self.nzb_name)), level)
         self.log(u'Current quality: {0}'.format(Quality.qualityStrings[old_ep_quality]), level)
         self.log(u'New quality: {0}'.format(Quality.qualityStrings[new_ep_quality]), level)
         self.log(u'Proper: {0}'.format(self.is_proper), level)

--- a/medusa/post_processor.py
+++ b/medusa/post_processor.py
@@ -918,7 +918,7 @@ class PostProcessor(object):
         self.log(u'Snatch in history: {0}'.format(self.in_history), level)
         self.log(u'Manually snatched: {0}'.format(self.manually_searched), level)
         self.log(u'Info hash: {0}'.format(self.info_hash), level)
-        self.log(u'Resource name: {0}'.format(bool(self.nzb_name)), level)
+        self.log(u'Resource name: {0}'.format(self.nzb_name), level)
         self.log(u'Current quality: {0}'.format(Quality.qualityStrings[old_ep_quality]), level)
         self.log(u'New quality: {0}'.format(Quality.qualityStrings[new_ep_quality]), level)
         self.log(u'Proper: {0}'.format(self.is_proper), level)

--- a/medusa/schedulers/download_handler.py
+++ b/medusa/schedulers/download_handler.py
@@ -22,7 +22,6 @@ import datetime
 import logging
 from builtins import object
 from enum import Enum
-from medusa.helper.exceptions import DownloadClientConnectionException
 from uuid import uuid4
 
 from medusa import app, db, ws
@@ -30,6 +29,7 @@ from medusa.clients import torrent
 from medusa.clients.nzb import nzbget, sab
 from medusa.clients.torrent.generic import GenericClient
 from medusa.helper.common import ConstsBitwize
+from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.process_tv import PostProcessQueueItem
 

--- a/medusa/session/core.py
+++ b/medusa/session/core.py
@@ -221,7 +221,7 @@ class IndexerSession(MedusaSafeSession):
         super(IndexerSession, self).__init__(**kwargs)
 
 
-class ClientSession(MedusaSafeSession):
+class ClientSession(MedusaSession):
     """Requests session for clients."""
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
* This is needed because we want to raise exceptions when a connection error occurs.
The downloadhandler will remove tracked info_hashes when it doesn't get them back from the client. We don't want to untrack info_hash because it doesn't get them back, due to a connection error.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
