### PR TITLE
Make the show/season/ep leading and not the release_name for the failedProcessor

### DIFF
--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -77,6 +77,7 @@ class FailedProcessor(object):
         segment = []
         if self.episodes:
             # If we have episodes, we dont need the release name to know we want to fail these episodes.
+            self.log(logger.INFO, u'Episodes where found for this failed processor, using those in stead of a release name')
             segment = self.episodes
         else:
             segment = self._process_release_name()

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -83,6 +83,7 @@ class FailedProcessor(object):
             segment = self._process_release_name()
 
         if segment:
+            # This will only work with single episodes or season packs.
             cur_failed_queue_item = FailedQueueItem(segment[0].series, segment)
             app.forced_search_queue_scheduler.action.add_item(cur_failed_queue_item)
 

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -19,16 +19,52 @@ log.logger.addHandler(logging.NullHandler())
 class FailedProcessor(object):
     """Take appropriate action when a download fails to complete."""
 
-    def __init__(self, dirName, nzbName):
+    def __init__(self, dirName, nzbName, episodes=[]):
         """Initialize the class.
 
         :param dirName: Full path to the folder of the failed download
         :param nzbName: Full name of the nzb file that failed
+        :param episodes: Optionally passed array of episode objects. When we know for which episodes
+            whe're trying to process the resource as failed, we don't need to parse the release name.
+            We can just straight away call the FailedQueueItem.
         """
         self.dir_name = dirName
         self.nzb_name = nzbName
+        self.episodes = episodes
 
         self._output = []
+
+    def _process_release_name(self):
+        """Parse the release name for a show title and episode(s)."""
+        release_name = naming.determine_release_name(self.dir_name, self.nzb_name)
+        if not release_name:
+            self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
+            raise FailedPostProcessingFailedException()
+
+        try:
+            parse_result = NameParser().parse(release_name)
+        except (InvalidNameException, InvalidShowException):
+            self.log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
+                     u'Consider adding scene exceptions or improve naming for: {release}'.format
+                     (release=release_name))
+            raise FailedPostProcessingFailedException()
+
+        self.log(logger.DEBUG, u'Parsed info: {result}'.format(result=parse_result))
+
+        segment = []
+        if not parse_result.episode_numbers:
+            # Get all episode objects from that season
+            self.log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=release_name))
+            segment.extend(parse_result.series.get_all_episodes(parse_result.season_number))
+        else:
+            self.log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=release_name))
+            for episode in parse_result.episode_numbers:
+                segment.append(parse_result.series.get_episode(parse_result.season_number, episode))
+
+        if segment:
+            self.log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=release_name))
+
+        return segment
 
     def process(self):
         """
@@ -38,34 +74,15 @@ class FailedProcessor(object):
         """
         self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
 
-        releaseName = naming.determine_release_name(self.dir_name, self.nzb_name)
-        if not releaseName:
-            self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
-            raise FailedPostProcessingFailedException()
-
-        try:
-            parse_result = NameParser().parse(releaseName)
-        except (InvalidNameException, InvalidShowException):
-            self.log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
-                     u'Consider adding scene exceptions or improve naming for: {release}'.format
-                     (release=releaseName))
-            raise FailedPostProcessingFailedException()
-
-        self.log(logger.DEBUG, u'Parsed info: {result}'.format(result=parse_result))
-
         segment = []
-        if not parse_result.episode_numbers:
-            # Get all episode objects from that season
-            self.log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=releaseName))
-            segment.extend(parse_result.series.get_all_episodes(parse_result.season_number))
+        if self.episodes:
+            # If we have episodes, we dont need the release name to know we want to fail these episodes.
+            segment = self.episodes
         else:
-            self.log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=releaseName))
-            for episode in parse_result.episode_numbers:
-                segment.append(parse_result.series.get_episode(parse_result.season_number, episode))
+            segment = self._process_release_name()
 
         if segment:
-            self.log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=releaseName))
-            cur_failed_queue_item = FailedQueueItem(parse_result.series, segment)
+            cur_failed_queue_item = FailedQueueItem(segment[0].series, segment)
             app.forced_search_queue_scheduler.action.add_item(cur_failed_queue_item)
 
         return True

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -38,18 +38,18 @@ class FailedProcessor(object):
         """Parse the release name for a show title and episode(s)."""
         release_name = naming.determine_release_name(self.dir_name, self.resource)
         if not release_name:
-            self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
+            self.log(logger.WARNING, 'Warning: unable to find a valid release name.')
             raise FailedPostProcessingFailedException()
 
         try:
             parse_result = NameParser().parse(release_name)
         except (InvalidNameException, InvalidShowException):
-            self.log(logger.WARNING, u'Not enough information to parse release name into a valid show. '
-                     u'Consider adding scene exceptions or improve naming for: {release}'.format
+            self.log(logger.WARNING, 'Not enough information to parse release name into a valid show. '
+                     'Consider adding scene exceptions or improve naming for: {release}'.format
                      (release=release_name))
             raise FailedPostProcessingFailedException()
 
-        self.log(logger.DEBUG, u'Parsed info: {result}'.format(result=parse_result))
+        self.log(logger.DEBUG, 'Parsed info: {result}'.format(result=parse_result))
 
         segment = []
         if not parse_result.episode_numbers:
@@ -57,12 +57,12 @@ class FailedProcessor(object):
             self.log(logger.DEBUG, 'Detected as season pack: {release}'.format(release=release_name))
             segment.extend(parse_result.series.get_all_episodes(parse_result.season_number))
         else:
-            self.log(logger.DEBUG, u'Detected as single/multi episode: {release}'.format(release=release_name))
+            self.log(logger.DEBUG, 'Detected as single/multi episode: {release}'.format(release=release_name))
             for episode in parse_result.episode_numbers:
                 segment.append(parse_result.series.get_episode(parse_result.season_number, episode))
 
         if segment:
-            self.log(logger.DEBUG, u'Adding this release to failed queue: {release}'.format(release=release_name))
+            self.log(logger.DEBUG, 'Adding this release to failed queue: {release}'.format(release=release_name))
 
         return segment
 
@@ -72,12 +72,12 @@ class FailedProcessor(object):
 
         :return: True
         """
-        self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.resource, dir=self.dir_name))
+        self.log(logger.INFO, 'Failed download detected: (resource: {nzb}, dir: {dir})'.format(nzb=self.resource, dir=self.dir_name))
 
         segment = []
         if self.episodes:
             # If we have episodes, we dont need the release name to know we want to fail these episodes.
-            self.log(logger.INFO, u'Episodes where found for this failed processor, using those in stead of a release name')
+            self.log(logger.INFO, 'Episodes where found for this failed processor, using those instead of a release name')
             segment = self.episodes
         else:
             segment = self._process_release_name()

--- a/medusa/failed_processor.py
+++ b/medusa/failed_processor.py
@@ -19,24 +19,24 @@ log.logger.addHandler(logging.NullHandler())
 class FailedProcessor(object):
     """Take appropriate action when a download fails to complete."""
 
-    def __init__(self, dirName, nzbName, episodes=[]):
+    def __init__(self, dir_name, resource, episodes=[]):
         """Initialize the class.
 
-        :param dirName: Full path to the folder of the failed download
-        :param nzbName: Full name of the nzb file that failed
+        :param dir_name: Full path to the folder of the failed download
+        :param resource: Full name of the file/subfolder that failed
         :param episodes: Optionally passed array of episode objects. When we know for which episodes
             whe're trying to process the resource as failed, we don't need to parse the release name.
             We can just straight away call the FailedQueueItem.
         """
-        self.dir_name = dirName
-        self.nzb_name = nzbName
+        self.dir_name = dir_name
+        self.resource = resource
         self.episodes = episodes
 
         self._output = []
 
     def _process_release_name(self):
         """Parse the release name for a show title and episode(s)."""
-        release_name = naming.determine_release_name(self.dir_name, self.nzb_name)
+        release_name = naming.determine_release_name(self.dir_name, self.resource)
         if not release_name:
             self.log(logger.WARNING, u'Warning: unable to find a valid release name.')
             raise FailedPostProcessingFailedException()
@@ -72,7 +72,7 @@ class FailedProcessor(object):
 
         :return: True
         """
-        self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.nzb_name, dir=self.dir_name))
+        self.log(logger.INFO, u'Failed download detected: ({nzb}, {dir})'.format(nzb=self.resource, dir=self.dir_name))
 
         segment = []
         if self.episodes:

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -895,7 +895,7 @@ class ProcessResult(object):
     def process_failed(self, path):
         """Process a download that did not complete correctly."""
         try:
-            processor = failed_processor.FailedProcessor(path, self.resource_name)
+            processor = failed_processor.FailedProcessor(path, self.resource_name, self.episodes)
             self.result = processor.process()
             process_fail_message = ''
         except FailedPostProcessingFailedException as error:

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -116,7 +116,7 @@ class PostProcessQueueItem(generic_queue.QueueItem):
         """Process for when we have a valid path."""
         process_method = self.process_method or app.PROCESS_METHOD
 
-        process_results = ProcessResult(self.path, process_method, failed=self.failed)
+        process_results = ProcessResult(self.path, process_method, failed=self.failed, episodes=self.episodes)
         process_results.process(
             resource_name=self.resource_name,
             force=self.force,

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -228,6 +228,9 @@ class ProcessResult(object):
         :param path: The root path to start postprocessing from.
         :param process_method: Process method ('copy', 'move', 'hardlink', 'symlink', 'keeplink').
         :param failed: Start the ProcessResult with a failed download.
+        :param episodes: Array of episode objects.
+            Used to specify the episodes to `Retry` in case of a failed download.
+            Currently only used by the Download Handler.
         """
         self._output = []
         self.directory = path

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -36,7 +36,7 @@ class PostProcessQueueItem(generic_queue.QueueItem):
 
     def __init__(self, path=None, info_hash=None, resource_name=None, force=False,
                  is_priority=False, process_method=None, delete_on=False, failed=False,
-                 proc_type='auto', ignore_subs=False):
+                 proc_type='auto', ignore_subs=False, episodes=[]):
         """Initialize the class."""
         generic_queue.QueueItem.__init__(self, u'Post Process')
 
@@ -52,6 +52,7 @@ class PostProcessQueueItem(generic_queue.QueueItem):
         self.failed = failed
         self.proc_type = proc_type
         self.ignore_subs = ignore_subs
+        self.episodes = episodes
 
         self.to_json.update({
             'success': self.success,

--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -221,7 +221,7 @@ class ProcessResult(object):
 
     IGNORED_FOLDERS = ('@eaDir', '#recycle', '.@__thumb',)
 
-    def __init__(self, path, process_method=None, failed=False):
+    def __init__(self, path, process_method=None, failed=False, episodes=[]):
         """
         Initialize ProcessResult object.
 
@@ -242,6 +242,7 @@ class ProcessResult(object):
         self.process_file = False
         # When multiple media folders/files processed. Flag postpone_any of any them was postponed.
         self.postpone_any = False
+        self.episodes = episodes
 
     @property
     def directory(self):

--- a/medusa/schedulers/download_handler.py
+++ b/medusa/schedulers/download_handler.py
@@ -32,6 +32,7 @@ from medusa.helper.common import ConstsBitwize
 from medusa.helper.exceptions import DownloadClientConnectionException
 from medusa.logger.adapters.style import BraceAdapter
 from medusa.process_tv import PostProcessQueueItem
+from medusa.show.show import Show
 
 from requests import RequestException
 
@@ -328,9 +329,6 @@ class DownloadHandler(object):
 
     def _postprocess(self, path, info_hash, resource_name, failed=False):
         """Queue a postprocess action."""
-        # TODO: Add a check for if not already queued or run.
-        # queue a postprocess action
-
         # Use the info hash get a segment of episodes.
         history_items = self.main_db_con.select(
             'SELECT * FROM history WHERE info_hash = ?',
@@ -340,10 +338,9 @@ class DownloadHandler(object):
         episodes = []
         for history_item in history_items:
             # Search for show in library
-            from medusa.show.show import Show
             show = Show.find_by_id(app.showList, history_item['indexer_id'], history_item['showid'])
             if not show:
-                # Show is -no longer- available in library.
+                # Show is "no longer" available in library.
                 continue
             episodes.append(show.get_episode(history_item['season'], history_item['episode']))
 

--- a/medusa/schedulers/download_handler.py
+++ b/medusa/schedulers/download_handler.py
@@ -345,7 +345,7 @@ class DownloadHandler(object):
             if not show:
                 # Show is -no longer- available in library.
                 continue
-            episodes.push(show.get_episode(history_item['season'], history_item['episode']))
+            episodes.append(show.get_episode(history_item['season'], history_item['episode']))
 
         queue_item = PostProcessQueueItem(path, info_hash, resource_name=resource_name, failed=failed, episodes=episodes)
         app.post_processor_queue_scheduler.action.add_item(queue_item)


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This will fix an issue where the failed processor gets a release name to parse, for which it can't find a valid show/title. As at that time we already know we can't process the file, we just want to RETRY the specific episode/season pack.

Currently a bad release name, can fail in the postprocessor, but then it also can't retry a new ep. Because it doesn't know for which show/ep it needs to retry.

Using the download_handler we always know for which show/ep is being processed, so now we're using that information.