### PR TITLE
Only run self.proper_path() when detailed info is requested

### DIFF
--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1122,7 +1122,6 @@ class Episode(TV):
         data['file'] = {}
         data['file']['location'] = self.location
         data['file']['name'] = os.path.basename(self.location)
-        data['file']['properPath'] = self.proper_path()
         if self.file_size:
             data['file']['size'] = self.file_size
 
@@ -1137,6 +1136,10 @@ class Episode(TV):
             data['statistics']['subtitleSearch']['count'] = self.subtitles_searchcount
             data['wantedQualities'] = self.wanted_quality
             data['related'] = self.related_episodes
+
+            if self.file_size:
+                # Used by the test-rename vue component.
+                data['file']['properPath'] = self.proper_path()
 
         return data
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Because of #9831 self.proper_path() was run on each episode requested through the apiv2. This method reads the file from disk, and runs Guessit on it. This is a massive performance hit. Therefor method moved to detailed=true.