### PR TITLE
Fix parsing number for shows, in multipart string

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -390,17 +390,18 @@ class FixTitlesThatExistOfNumbers(Rule):
         if not absolute_episodes:
             return
 
+        to_remove = []
+        to_append = []
+
         fileparts = matches.markers.named('path')
         for filepart in marker_sorted(fileparts, matches):
             old_title = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'title', index=0)
+            absolute_episode = matches.range(filepart.start, filepart.end, predicate=lambda match: match.name == 'absolute_episode', index=0)
 
-            if not filepart.value.startswith(str(absolute_episodes[0].value)):
+            if not absolute_episode or not filepart.value.startswith(str(absolute_episode.value)):
                 continue
 
-            to_remove = []
-            to_append = []
-
-            absolute_episode = absolute_episodes[0]
+            # absolute_episode = absolute_episodes[0]
             new_title = copy.copy(absolute_episode)
             new_title.name = 'title'
             new_title.value = str(absolute_episode.value)
@@ -409,7 +410,7 @@ class FixTitlesThatExistOfNumbers(Rule):
             to_remove.append(absolute_episode)
             to_remove.append(old_title)
 
-            return to_remove, to_append
+        return to_remove, to_append
 
 
 class CreateAliasWithCountryOrYear(Rule):

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -401,7 +401,6 @@ class FixTitlesThatExistOfNumbers(Rule):
             if not absolute_episode or not filepart.value.startswith(str(absolute_episode.value)):
                 continue
 
-            # absolute_episode = absolute_episodes[0]
             new_title = copy.copy(absolute_episode)
             new_title.name = 'title'
             new_title.value = str(absolute_episode.value)

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4558,3 +4558,19 @@
   proper_count: 1
   proper_tag: REPACK
   type: episode
+
+
+? /1883 (2021)/Season 01/1883 (2021) (S01E03) (2021-12-26) (1080p-AVC BluRay EAC3-6ch) River.mkv
+: title: "1883"
+  year: 2021
+  season: 1
+  episode: 3
+  date: 2021-12-26
+  screen_size: 1080p
+  video_codec: H.264
+  container: mkv
+  source: 'Blu-ray'
+  audio_codec: 'Dolby Digital Plus'
+  audio_channels: '5.1'
+  video_profile: 'Advanced Video Codec High Definition'
+  type: episode


### PR DESCRIPTION
Better rule for removing the wrongfully parsed absolute_episode in a multi part release string.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
