### PR TITLE
Fix the runs_in_docker flag.

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -520,8 +520,16 @@ class Application(object):
             # set current commit branch from environment variable, if needed
             # use this to inject the branch information on immutable installations (e.g. Docker containers)
             commit_branch_env = os.environ.get('MEDUSA_COMMIT_BRANCH')
+
             if commit_branch_env and app.CUR_COMMIT_BRANCH != commit_branch_env:
                 app.CUR_COMMIT_BRANCH = commit_branch_env
+
+            if not app.BRANCH and app.CUR_COMMIT_BRANCH:
+                # Overwrite the current branch for non-git installations like docker.
+                app.BRANCH = app.CUR_COMMIT_BRANCH
+
+            # Asume we only have these environ variables when building a docker container.
+            app.RUNS_IN_DOCKER = os.environ.get('MEDUSA_COMMIT_HASH') and os.environ.get('MEDUSA_COMMIT_BRANCH')
 
             app.ACTUAL_CACHE_DIR = check_setting_str(app.CFG, 'General', 'cache_dir', 'cache')
 

--- a/medusa/updater/version_checker.py
+++ b/medusa/updater/version_checker.py
@@ -347,19 +347,4 @@ class CheckVersion(object):
         if app.RUNS_IN_DOCKER is not None:
             return app.RUNS_IN_DOCKER
 
-        path = '/proc/{pid}/cgroup'.format(pid=os.getpid())
-        try:
-            if not os.path.isfile(path):
-                return False
-
-            with open(path) as f:
-                for line in f:
-                    if re.match(r'\d+:[\w=]+:/docker(-[ce]e)?/\w+', line):
-                        log.debug(u'Running in a docker container')
-                        app.RUNS_IN_DOCKER = True
-                        return True
-                return False
-        except (EnvironmentError, OSError) as error:
-            log.info(u'Tried to check the path {path} if we are running in a docker container, '
-                     u'but an error occurred: {error}', {'path': path, 'error': error})
-            return False
+        return os.environ.get('MEDUSA_COMMIT_HASH') and os.environ.get('MEDUSA_COMMIT_BRANCH')


### PR DESCRIPTION
* Pass in the branch and commit through env variables. Medusa didn't pick up the branch name.
* Fix setting the RUNS_IN_DOCKER flag. So we prevent from updating from within container.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
