### PR TITLE
Feature/rule for anime season ep

### DIFF
--- a/tests/test_guessit.py
+++ b/tests/test_guessit.py
@@ -49,6 +49,7 @@ def show_list(create_tvshow):
         create_tvshow(indexerid=17, name='Show! Name 2', anime=1),
         create_tvshow(indexerid=18, name='24'),  # expected titles shouldn't contain numbers
         create_tvshow(indexerid=18, name='9-1-1'),  # The dash in the title makes it an expected title
+        create_tvshow(indexerid=18, name='Tate no Yuusha no Nariagari Season 2'),  # The dash in the title makes it an expected title
     ]
 
 

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4589,3 +4589,13 @@
   release_group: "Brawl in Cell Block 9-1-1"
   container: mkv
   type: episode
+
+? "[Tsundere-Raws] Tate no Yuusha no Nariagari Season 2 - 09.mkv"
+: options: {show_type: anime}
+  title: Tate no Yuusha no Nariagari Season 2
+  absolute_episode: 9
+  episode: 9
+  release_group: Tsundere-Raws
+  container: mkv
+  mimetype: "video/x-matroska"
+  type: episode


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Utilizes the release title `My Show title Season 2` added to expected titles, because there is a numer in the title.
Potentially could interfere with release like: `My Show title Season 2 - 3`, where the release should specify seasons 2 to 3. But i'm only allowing the rule for anime shows. And we don't have any of those titles in our tests. I think chances are small for false positives.