### PR TITLE
Feature/fix early wanted

### DIFF
--- a/medusa/indexers/tvmaze/api.py
+++ b/medusa/indexers/tvmaze/api.py
@@ -219,7 +219,7 @@ class TVmaze(BaseIndexer):
             return
 
         mapped_results = self._map_results(results, self.series_map)
-        
+
         # Sanitize the airs_time. As for some shows this might be missing.
         if not mapped_results.get('airs_time'):
             mapped_results['airs_time'] = '0:00AM'

--- a/medusa/indexers/tvmaze/api.py
+++ b/medusa/indexers/tvmaze/api.py
@@ -219,6 +219,11 @@ class TVmaze(BaseIndexer):
             return
 
         mapped_results = self._map_results(results, self.series_map)
+        
+        # Sanitize the airs_time. As for some shows this might be missing.
+        if not mapped_results.get('airs_time'):
+            mapped_results['airs_time'] = '0:00AM'
+
         return OrderedDict({'series': mapped_results})
 
     def _get_episodes(self, tvmaze_id, specials=False, *args, **kwargs):  # pylint: disable=unused-argument

--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1638,6 +1638,12 @@ class Series(TV):
         if getattr(indexed_show, 'airs_dayofweek', '') and getattr(indexed_show, 'airs_time', ''):
             self.airs = '{airs_day_of_week} {airs_time}'.format(airs_day_of_week=indexed_show['airs_dayofweek'],
                                                                 airs_time=indexed_show['airs_time'])
+        else:
+            log.info(
+                '{id}: We could not determin a specific `airs_dayofweek` or `airs_time` for the show: {show}'
+                '\n We might start searching early for episodes.',
+                {'id': self.series_id, 'show': self.name}
+            )
 
         self.status = self.normalize_status(getattr(indexed_show, 'status', None))
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Issue is specific for tvmaze shows, that don't provide an `airs time` value for the show.
Probably for streaming services.

Fix #10573 