### PR TITLE
Feature/docker python 310

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,25 @@
-FROM python:3.7-alpine3.9
+# Need this image for the /bin/start-build script.
+# Build unrar.  It has been moved to non-free since Alpine 3.15.
+# https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.15.0#unrar_moved_to_non-free
+FROM jlesage/alpine-abuild:3.15 AS unrar
+WORKDIR /tmp
+RUN \
+    mkdir /tmp/aport && \
+    cd /tmp/aport && \
+    git init && \
+    git remote add origin https://git.alpinelinux.org/aports && \
+    git config core.sparsecheckout true && \
+    echo "non-free/unrar/*" >> .git/info/sparse-checkout && \
+    git pull origin 3.15-stable && \
+    PKG_SRC_DIR=/tmp/aport/non-free/unrar && \
+    PKG_DST_DIR=/tmp/unrar-pkg && \
+    mkdir "$PKG_DST_DIR" && \
+    /bin/start-build -r && \
+    rm /tmp/unrar-pkg/*-doc-* && \
+    mkdir /tmp/unrar-install && \
+    tar xf /tmp/unrar-pkg/unrar-*.apk -C /tmp/unrar-install
+
+FROM python:3.10.4-alpine3.15
 LABEL maintainer="pymedusa"
 
 ARG GIT_BRANCH
@@ -18,7 +39,7 @@ RUN \
 	apk add --no-cache \
 		mediainfo \
 		tzdata \
-		unrar \
+		p7zip \
 	&& \
 	# Cleanup
 	rm -rf \
@@ -26,6 +47,9 @@ RUN \
 
 # Install app
 COPY . /app/medusa/
+
+# Copy unrar bin
+COPY --from=unrar /tmp/unrar-install/usr/bin/unrar /usr/bin/
 
 # Ports and Volumes
 EXPOSE 8081

--- a/runscripts/init.docker
+++ b/runscripts/init.docker
@@ -2,21 +2,40 @@
 
 PUID=${PUID:-0}
 PGID=${PGID:-0}
+DEFAULT_GROUP="abc"
+DEFAULT_USER="abc"
 
 if [[ $PUID != "0" ]] && [[ $PGID != "0" ]]
 then
-  addgroup -g "$PGID" abc
-  adduser -u "$PUID" --ingroup abc --disabled-password abc
+  EXISTING_GROUP=$(getent group $PGID | awk -F ":" '{ print $1 }')
+  if [[ -z $EXISTING_GROUP ]]
+  then
+    echo "Group does not exist, adding $DEFAULT_GROUP"
+    addgroup -g "$PGID" $DEFAULT_GROUP
+  else
+    echo "Group already exists, re-using group $EXISTING_GROUP"
+    DEFAULT_GROUP=$EXISTING_GROUP
+  fi
+
+  EXISTING_USER=$(getent passwd $PUID | awk -F ":" '{ print $1 }')
+  if [[ -z $EXISTING_USER ]]
+  then
+    echo "User does not exist, adding $EXISTING_USER"
+    adduser -u "$PUID" --ingroup $DEFAULT_GROUP --disabled-password $DEFAULT_USER
+  else
+    echo "User already exists, re-using user $EXISTING_USER"
+    DEFAULT_USER=$EXISTING_USER
+  fi
 
   echo "
-  User uid:    $(id -u abc)
-  User gid:    $(id -g abc)
+  User uid:    $(id -u $DEFAULT_USER)
+  User gid:    $(id -g $DEFAULT_USER)
   -------------------------------------
   "
-  chown -R abc:abc /app
-  chown -R abc:abc /config
+  chown -R $DEFAULT_USER:$DEFAULT_GROUP /app
+  chown -R $DEFAULT_USER:$DEFAULT_GROUP /config
 
-  exec su abc -s /bin/sh -c "python start.py --nolaunch --datadir /config"
+  exec su $DEFAULT_USER -s /bin/sh -c "python start.py --nolaunch --datadir /config"
 else
   echo "Starting medusa as root"
   python start.py --nolaunch --datadir /config


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR will have the docker image start using python3.10.
Because the python docker image has alpine 3.15 bundled with newer python versions, I had to create a workaround for bundling unrar. As unrar is not available for alpine 3.15 (non-free) anymore.

In the future we'll start using 7zip/p7 for extracting archives. So i've already bundled that.

Also added a fix for users that want to use a PGID/PUID that already exist in the image.

@medariox FYA