### PR TITLE
#10703 Fix NullReference on testRename page

### DIFF
--- a/themes-default/slim/src/components/test-rename.vue
+++ b/themes-default/slim/src/components/test-rename.vue
@@ -97,7 +97,7 @@ export default {
     computed: {
         ...mapState({
             postprocessing: state => state.config.postprocessing,
-            seedLocation: state => state.clients.torrents.seedLocation,
+            seedLocation: state => state.config.clients.torrents.seedLocation,
             layout: state => state.config.layout,
             client: state => state.auth.client
         }),


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This PR fixes #10703. The path to the `seedLocation` property was wrong.