### PR TITLE
Actually use the language filter for TMDB image searches

### DIFF
--- a/medusa/indexers/tmdb/api.py
+++ b/medusa/indexers/tmdb/api.py
@@ -363,10 +363,8 @@ class Tmdb(BaseIndexer):
         _images = {}
 
         # Let's get the different type of images available for this series
-        image_language = '{search_language},null'.format(search_language=self.config['language'])
-
         try:
-            images = self.tmdb.TV(tmdb_id).images(include_image_language=image_language)
+            images = self.tmdb.TV(tmdb_id).images()
         except (AttributeError, RequestException) as error:
             raise IndexerUnavailable('Error trying to get images. Cause: {cause}'.format(cause=error))
 
@@ -375,6 +373,14 @@ class Tmdb(BaseIndexer):
             try:
                 if images and image_type not in _images:
                     _images[image_type] = {}
+
+                # Filter posters by language, backdrops don't have languages
+                if image_type == "poster":
+                    search_language=self.config['language']
+                    images_for_language = [image for image in images if image['iso_639_1'] == search_language]
+                    # Use the language-limited list if anything was found, otherwise use all images
+                    if images_for_language:
+                        images = images_for_language
 
                 for image in images:
                     bid += 1

--- a/medusa/indexers/tmdb/api.py
+++ b/medusa/indexers/tmdb/api.py
@@ -375,8 +375,8 @@ class Tmdb(BaseIndexer):
                     _images[image_type] = {}
 
                 # Filter posters by language, backdrops don't have languages
-                if image_type == "poster":
-                    search_language=self.config['language']
+                if image_type == 'poster':
+                    search_language = self.config['language']
                     images_for_language = [image for image in images if image['iso_639_1'] == search_language]
                     # Use the language-limited list if anything was found, otherwise use all images
                     if images_for_language:

--- a/medusa/indexers/tmdb/api.py
+++ b/medusa/indexers/tmdb/api.py
@@ -363,10 +363,10 @@ class Tmdb(BaseIndexer):
         _images = {}
 
         # Let's get the different type of images available for this series
-        params = {'include_image_language': '{search_language}'.format(search_language=self.config['language'])}
+        image_language = '{search_language},null'.format(search_language=self.config['language'])
 
         try:
-            images = self.tmdb.TV(tmdb_id).images(params=params)
+            images = self.tmdb.TV(tmdb_id).images(include_image_language=image_language)
         except (AttributeError, RequestException) as error:
             raise IndexerUnavailable('Error trying to get images. Cause: {cause}'.format(cause=error))
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Fixes #10750

The old query param had no effect. If it actually worked, lots of foreign series would have no posters.

Instead, the new code tries to select an English one. If there's none, any language is used.