### PR TITLE
Add ffmpeg to docker build for postprocessing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN \
 		mediainfo \
 		tzdata \
 		p7zip \
+		ffmpeg \
 	&& \
 	# Cleanup
 	rm -rf \


### PR DESCRIPTION
Add ffmpeg binaries to the docker container for use in Medusa postprocessing.
Without it the PostProcessing Settings page displays error:
"Ffmpeg binary not found. Add the ffmpeg bin location to your system's environment or configure a path manually below."

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
