### PR TITLE
remove copy fallback when hardlink failed

### DIFF
--- a/medusa/helpers/__init__.py
+++ b/medusa/helpers/__init__.py
@@ -353,26 +353,14 @@ def hardlink_file(src_file, dest_file):
         link(src_file, dest_file)
         fix_set_group_id(dest_file)
     except OSError as msg:
-        if msg.errno == errno.EEXIST:
-            # File exists. Don't fallback to copy
-            log.warning(
-                u'Failed to create hardlink of {source} at {destination}.'
-                u' Error: {error!r}', {
-                    'source': src_file,
-                    'destination': dest_file,
-                    'error': msg
-                }
-            )
-        else:
-            log.warning(
-                u'Failed to create hardlink of {source} at {destination}.'
-                u' Error: {error!r}. Copying instead', {
-                    'source': src_file,
-                    'destination': dest_file,
-                    'error': msg,
-                }
-            )
-            copy_file(src_file, dest_file)
+        log.warning(
+            u'Failed to create hardlink of {source} at {destination}.'
+            u' Error: {error!r}.', {
+                'source': src_file,
+                'destination': dest_file,
+                'error': msg,
+            }
+        )
 
 
 def symlink(src, dst):


### PR DESCRIPTION
Currently, when hardlink failed, the fallback behavior will be copying file. This could fill up disks space and make unnecessary disks read/write if Medusa is run unattended. This PR remove this behavior and only raised the errors.
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
