### PR TITLE
fix(subliminal): set english language in requests header

### DIFF
--- a/medusa/subtitle_providers/addic7ed.py
+++ b/medusa/subtitle_providers/addic7ed.py
@@ -108,6 +108,7 @@ class Addic7edProvider(Provider):
         """Initialize Addic7edProvider provider."""
         self.session = Session()
         self.session.headers['User-Agent'] = self.user_agent
+        self.session.headers['Accept-Language'] = 'en-US,en;q=1.0'
 
         # login
         if self.username and self.password:


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)


Addic7ed force language based on IP location so if your medusa instance is located in a country where english is not the first language. Subliminal will failed to download subtitle because it match only on  `Completed` results. if the request is made from france the word will be "Terminé". 

set `en-US,en;q=1.0` as Accept-Language in requests header solve this issue

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Language

Cheers
