### PR TITLE
Upversion the ext version of wrapt since the old version was not compatible with python 3.11.0

### DIFF
--- a/ext/readme.md
+++ b/ext/readme.md
@@ -68,7 +68,7 @@ ext | `typing-extensions` | [4.1.1](https://pypi.org/project/typing-extensions/4
 ext | **`urllib3`** | [1.24.1](https://pypi.org/project/urllib3/1.24.1/) | `requests` | -
 ext | **`validators`** | [0.18.2](https://pypi.org/project/validators/0.18.2/) | **`medusa`** | -
 ext | **`webencodings`** | [0.5.1](https://pypi.org/project/webencodings/0.5.1/) | `html5lib` | -
-ext | **`wrapt`** | [1.10.11](https://pypi.org/project/wrapt/1.10.11/) | `deprecated` | -
+ext | **`wrapt`** | [1.14.1](https://pypi.org/project/wrapt/1.14.1/) | `deprecated` | -
 ext | `zipp` | [3.6.0](https://pypi.org/project/zipp/3.6.0/) | `importlib_resources` | File: `zipp.py`
 
 #### Notes:

--- a/ext/wrapt/__init__.py
+++ b/ext/wrapt/__init__.py
@@ -1,10 +1,10 @@
-__version_info__ = ('1', '10', '11')
+__version_info__ = ('1', '14', '1')
 __version__ = '.'.join(__version_info__)
 
 from .wrappers import (ObjectProxy, CallableObjectProxy, FunctionWrapper,
-        BoundFunctionWrapper, WeakFunctionProxy, resolve_path, apply_patch,
-        wrap_object, wrap_object_attribute, function_wrapper,
-        wrap_function_wrapper, patch_function_wrapper,
+        BoundFunctionWrapper, WeakFunctionProxy, PartialCallableObjectProxy,
+        resolve_path, apply_patch, wrap_object, wrap_object_attribute,
+        function_wrapper, wrap_function_wrapper, patch_function_wrapper,
         transient_function_wrapper)
 
 from .decorators import (adapter_factory, AdapterFactory, decorator,
@@ -13,7 +13,15 @@ from .decorators import (adapter_factory, AdapterFactory, decorator,
 from .importer import (register_post_import_hook, when_imported,
         notify_module_loaded, discover_post_import_hooks)
 
-try:
-    from inspect import getcallargs
-except ImportError:
-    from .arguments import getcallargs
+# Import of inspect.getcallargs() included for backward compatibility. An
+# implementation of this was previously bundled and made available here for
+# Python <2.7. Avoid using this in future.
+
+from inspect import getcallargs
+
+# Variant of inspect.formatargspec() included here for forward compatibility.
+# This is being done because Python 3.11 dropped inspect.formatargspec() but
+# code for handling signature changing decorators relied on it. Exposing the
+# bundled implementation here in case any user of wrapt was also needing it.
+
+from .arguments import formatargspec

--- a/ext/wrapt/arguments.py
+++ b/ext/wrapt/arguments.py
@@ -1,96 +1,38 @@
-# This is a copy of the inspect.getcallargs() function from Python 2.7
-# so we can provide it for use under Python 2.6. As the code in this
-# file derives from the Python distribution, it falls under the version
-# of the PSF license used for Python 2.7.
+# The inspect.formatargspec() function was dropped in Python 3.11 but we need
+# need it for when constructing signature changing decorators based on result of
+# inspect.getargspec() or inspect.getfullargspec(). The code here implements
+# inspect.formatargspec() base on Parameter and Signature from inspect module,
+# which were added in Python 3.6. Thanks to Cyril Jouve for the implementation.
 
-from inspect import getargspec, ismethod
-import sys
-
-def getcallargs(func, *positional, **named):
-    """Get the mapping of arguments to values.
-
-    A dict is returned, with keys the function argument names (including the
-    names of the * and ** arguments, if any), and values the respective bound
-    values from 'positional' and 'named'."""
-    args, varargs, varkw, defaults = getargspec(func)
-    f_name = func.__name__
-    arg2value = {}
-
-    # The following closures are basically because of tuple parameter unpacking.
-    assigned_tuple_params = []
-    def assign(arg, value):
-        if isinstance(arg, str):
-            arg2value[arg] = value
-        else:
-            assigned_tuple_params.append(arg)
-            value = iter(value)
-            for i, subarg in enumerate(arg):
-                try:
-                    subvalue = next(value)
-                except StopIteration:
-                    raise ValueError('need more than %d %s to unpack' %
-                                     (i, 'values' if i > 1 else 'value'))
-                assign(subarg, subvalue)
-            try:
-                next(value)
-            except StopIteration:
-                pass
-            else:
-                raise ValueError('too many values to unpack')
-    def is_assigned(arg):
-        if isinstance(arg, str):
-            return arg in arg2value
-        return arg in assigned_tuple_params
-    if ismethod(func) and func.im_self is not None:
-        # implicit 'self' (or 'cls' for classmethods) argument
-        positional = (func.im_self,) + positional
-    num_pos = len(positional)
-    num_total = num_pos + len(named)
-    num_args = len(args)
-    num_defaults = len(defaults) if defaults else 0
-    for arg, value in zip(args, positional):
-        assign(arg, value)
-    if varargs:
-        if num_pos > num_args:
-            assign(varargs, positional[-(num_pos-num_args):])
-        else:
-            assign(varargs, ())
-    elif 0 < num_args < num_pos:
-        raise TypeError('%s() takes %s %d %s (%d given)' % (
-            f_name, 'at most' if defaults else 'exactly', num_args,
-            'arguments' if num_args > 1 else 'argument', num_total))
-    elif num_args == 0 and num_total:
+try:
+    from inspect import Parameter, Signature
+except ImportError:
+    from inspect import formatargspec
+else:
+    def formatargspec(args, varargs=None, varkw=None, defaults=None,
+                      kwonlyargs=(), kwonlydefaults={}, annotations={}):
+        if kwonlydefaults is None:
+            kwonlydefaults = {}
+        ndefaults = len(defaults) if defaults else 0
+        parameters = [
+            Parameter(
+                arg,
+                Parameter.POSITIONAL_OR_KEYWORD,
+                default=defaults[i] if i >= 0 else Parameter.empty,
+                annotation=annotations.get(arg, Parameter.empty),
+            ) for i, arg in enumerate(args, ndefaults - len(args))
+        ]
+        if varargs:
+            parameters.append(Parameter(varargs, Parameter.VAR_POSITIONAL))
+        parameters.extend(
+            Parameter(
+                kwonlyarg,
+                Parameter.KEYWORD_ONLY,
+                default=kwonlydefaults.get(kwonlyarg, Parameter.empty),
+                annotation=annotations.get(kwonlyarg, Parameter.empty),
+            ) for kwonlyarg in kwonlyargs
+        )
         if varkw:
-            if num_pos:
-                # XXX: We should use num_pos, but Python also uses num_total:
-                raise TypeError('%s() takes exactly 0 arguments '
-                                '(%d given)' % (f_name, num_total))
-        else:
-            raise TypeError('%s() takes no arguments (%d given)' %
-                            (f_name, num_total))
-    for arg in args:
-        if isinstance(arg, str) and arg in named:
-            if is_assigned(arg):
-                raise TypeError("%s() got multiple values for keyword "
-                                "argument '%s'" % (f_name, arg))
-            else:
-                assign(arg, named.pop(arg))
-    if defaults:    # fill in any missing values with the defaults
-        for arg, value in zip(args[-num_defaults:], defaults):
-            if not is_assigned(arg):
-                assign(arg, value)
-    if varkw:
-        assign(varkw, named)
-    elif named:
-        unexpected = next(iter(named))
-        if isinstance(unexpected, unicode):
-            unexpected = unexpected.encode(sys.getdefaultencoding(), 'replace')
-        raise TypeError("%s() got an unexpected keyword argument '%s'" %
-                        (f_name, unexpected))
-    unassigned = num_args - len([arg for arg in args if is_assigned(arg)])
-    if unassigned:
-        num_required = num_args - num_defaults
-        raise TypeError('%s() takes %s %d %s (%d given)' % (
-            f_name, 'at least' if defaults else 'exactly', num_required,
-            'arguments' if num_required > 1 else 'argument', num_total))
-    return arg2value
+            parameters.append(Parameter(varkw, Parameter.VAR_KEYWORD))
+        return_annotation = annotations.get('return', Signature.empty)
+        return str(Signature(parameters, return_annotation=return_annotation))

--- a/ext/wrapt/importer.py
+++ b/ext/wrapt/importer.py
@@ -7,20 +7,20 @@ import sys
 import threading
 
 PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
-if PY3:
-    import importlib
-    string_types = str,
-else:
+if PY2:
     string_types = basestring,
+    find_spec = None
+else:
+    string_types = str,
+    from importlib.util import find_spec
 
 from .decorators import synchronized
 
 # The dictionary registering any post import hooks to be triggered once
 # the target module has been imported. Once a module has been imported
 # and the hooks fired, the list of hooks recorded against the target
-# module will be truncacted but the list left in the dictionary. This
+# module will be truncated but the list left in the dictionary. This
 # acts as a flag to indicate that the module had already been imported.
 
 _post_import_hooks = {}
@@ -153,11 +153,28 @@ class _ImportHookChainedLoader:
     def __init__(self, loader):
         self.loader = loader
 
-    def load_module(self, fullname):
+        if hasattr(loader, "load_module"):
+          self.load_module = self._load_module
+        if hasattr(loader, "create_module"):
+          self.create_module = self._create_module
+        if hasattr(loader, "exec_module"):
+          self.exec_module = self._exec_module
+
+    def _load_module(self, fullname):
         module = self.loader.load_module(fullname)
         notify_module_loaded(module)
 
         return module
+
+    # Python 3.4 introduced create_module() and exec_module() instead of
+    # load_module() alone. Splitting the two steps.
+
+    def _create_module(self, spec):
+        return self.loader.create_module(spec)
+
+    def _exec_module(self, module):
+        self.loader.exec_module(module)
+        notify_module_loaded(module)
 
 class ImportHookFinder:
 
@@ -188,21 +205,7 @@ class ImportHookFinder:
         # Now call back into the import system again.
 
         try:
-            if PY3:
-                # For Python 3 we need to use find_loader() from
-                # the importlib module. It doesn't actually
-                # import the target module and only finds the
-                # loader. If a loader is found, we need to return
-                # our own loader which will then in turn call the
-                # real loader to import the module and invoke the
-                # post import hooks.
-
-                loader = importlib.find_loader(fullname, path)
-
-                if loader:
-                    return _ImportHookChainedLoader(loader)
-
-            else:
+            if not find_spec:
                 # For Python 2 we don't have much choice but to
                 # call back in to __import__(). This will
                 # actually cause the module to be imported. If no
@@ -214,6 +217,61 @@ class ImportHookFinder:
                 __import__(fullname)
 
                 return _ImportHookLoader()
+
+            else:
+                # For Python 3 we need to use find_spec().loader
+                # from the importlib.util module. It doesn't actually
+                # import the target module and only finds the
+                # loader. If a loader is found, we need to return
+                # our own loader which will then in turn call the
+                # real loader to import the module and invoke the
+                # post import hooks.
+
+                loader = getattr(find_spec(fullname), "loader", None)
+
+                if loader and not isinstance(loader, _ImportHookChainedLoader):
+                    return _ImportHookChainedLoader(loader)
+
+        finally:
+            del self.in_progress[fullname]
+
+    def find_spec(self, fullname, path=None, target=None):
+        # Since Python 3.4, you are meant to implement find_spec() method
+        # instead of find_module() and since Python 3.10 you get deprecation
+        # warnings if you don't define find_spec().
+
+        # If the module being imported is not one we have registered
+        # post import hooks for, we can return immediately. We will
+        # take no further part in the importing of this module.
+
+        if not fullname in _post_import_hooks:
+            return None
+
+        # When we are interested in a specific module, we will call back
+        # into the import system a second time to defer to the import
+        # finder that is supposed to handle the importing of the module.
+        # We set an in progress flag for the target module so that on
+        # the second time through we don't trigger another call back
+        # into the import system and cause a infinite loop.
+
+        if fullname in self.in_progress:
+            return None
+
+        self.in_progress[fullname] = True
+
+        # Now call back into the import system again.
+
+        try:
+            # This should only be Python 3 so find_spec() should always
+            # exist so don't need to check.
+
+            spec = find_spec(fullname)
+            loader = getattr(spec, "loader", None)
+
+            if loader and not isinstance(loader, _ImportHookChainedLoader):
+                spec.loader = _ImportHookChainedLoader(loader)
+
+            return spec
 
         finally:
             del self.in_progress[fullname]


### PR DESCRIPTION
The new version should work with 3.5 and greater

This fixes #11007 and allows medusa to open on my system with python 3.11.0. I added a new show to make sure it worked. No issues.

Side note: At some point we should remove the python 2 vs 3 stuff. I see elsewhere we dropped support for Python 2 a while ago, but the code still seems to act like both are supported in some places.

The new wrapt is the python files copy/pasted from the release here: https://pypi.org/project/wrapt/1.14.1

- [x ] PR is based on the DEVELOP branch
- [x ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x ] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
