### PR TITLE
Fix parsing for shows that have year in the title

### DIFF
--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -506,7 +506,7 @@ class FixTitlesThatExistOfYearNumbers(Rule):
                 if old_title:
                     to_remove.append(old_title)
                 continue
-            
+
             if fixed_year:
                 to_append.append(fixed_year)
 

--- a/medusa/name_parser/rules/rules.py
+++ b/medusa/name_parser/rules/rules.py
@@ -1852,7 +1852,7 @@ class AvoidMultipleValuesRule(Rule):
         :return:
         """
         to_remove = []
-        for name in ('episode_title', 'source', 'release_group', 'title', 'year'):
+        for name in ('episode_title', 'source', 'release_group', 'title'):
             values = matches.named(name)
             unique_values = {v.value for v in values}
             if len(unique_values) > 1:

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4586,7 +4586,29 @@
   source: 'Web'
   type: episode
 
+? 1923.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
 ? /1923 (2022)/Season 01/1923.2022.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+  
+  ? 1923.2022.S01E01.720p.WEB.h264-Group.mkv
 : title: "1923"
   season: 1
   episode: 1

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4575,16 +4575,6 @@
   video_profile: 'Advanced Video Codec High Definition'
   type: episode
 
-? /1923/Season 01/1923.S01E01.720p.WEB.h264-Group.mkv
-: title: "1923"
-  season: 1
-  episode: 1
-  screen_size: 720p
-  video_codec: H.264
-  release_group: Group
-  container: mkv
-  source: 'Web'
-  type: episode
 
 ? 1923.S01E01.720p.WEB.h264-Group.mkv
 : title: "1923"
@@ -4597,12 +4587,46 @@
   source: 'Web'
   type: episode
 
-? /1923 (2022)/Season 01/1923.2022.S01E01.720p.WEB.h264-Group.mkv
+? 1923.2022.S01E01.720p.WEB.h264-Group.mkv
 : title: "1923"
   season: 1
   episode: 1
   year: 2022
-  alias: '1923 2022'
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
+? /1923/Season 01/1923.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
+? /1923 (2022)/Season 01/1923.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
+? /1923 (2022)/Season 01/1923.(2022).S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  alias: "1923 2022"
+  season: 1
+  episode: 1
+  year: 2022
   screen_size: 720p
   video_codec: H.264
   release_group: Group

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4601,6 +4601,8 @@
 : title: "1923"
   season: 1
   episode: 1
+  alias: '1923 2022'
+  year: 2022
   screen_size: 720p
   video_codec: H.264
   release_group: Group
@@ -4608,10 +4610,12 @@
   source: 'Web'
   type: episode
   
-  ? 1923.2022.S01E01.720p.WEB.h264-Group.mkv
+? 1923.2022.S01E01.720p.WEB.h264-Group.mkv
 : title: "1923"
   season: 1
   episode: 1
+  alias: '1923 2022"'
+  year: 2022
   screen_size: 720p
   video_codec: H.264
   release_group: Group

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4575,6 +4575,28 @@
   video_profile: 'Advanced Video Codec High Definition'
   type: episode
 
+? /1923/Season 01/1923.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
+? /1923 (2022)/Season 01/1923.2022.S01E01.720p.WEB.h264-Group.mkv
+: title: "1923"
+  season: 1
+  episode: 1
+  screen_size: 720p
+  video_codec: H.264
+  release_group: Group
+  container: mkv
+  source: 'Web'
+  type: episode
+
 ? /series/9-1-1 (2018)/Season 05/9-1-1 (2018) (S05E06) (2021-11-01) (1080p-h264 BluRay AAC-2ch) Brawl in Cell Block 9-1-1.mkv
 : title: '9-1-1'
   alias: '9-1-1 2018'

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4601,8 +4601,8 @@
 : title: "1923"
   season: 1
   episode: 1
-  alias: '1923 2022'
   year: 2022
+  alias: '1923 2022'
   screen_size: 720p
   video_codec: H.264
   release_group: Group
@@ -4614,7 +4614,6 @@
 : title: "1923"
   season: 1
   episode: 1
-  alias: '1923 2022'
   year: 2022
   screen_size: 720p
   video_codec: H.264

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4609,18 +4609,6 @@
   container: mkv
   source: 'Web'
   type: episode
-  
-? 1923.2022.S01E01.720p.WEB.h264-Group.mkv
-: title: "1923"
-  season: 1
-  episode: 1
-  year: 2022
-  screen_size: 720p
-  video_codec: H.264
-  release_group: Group
-  container: mkv
-  source: 'Web'
-  type: episode
 
 ? /series/9-1-1 (2018)/Season 05/9-1-1 (2018) (S05E06) (2021-11-01) (1080p-h264 BluRay AAC-2ch) Brawl in Cell Block 9-1-1.mkv
 : title: '9-1-1'

--- a/tests/test_guessit.yml
+++ b/tests/test_guessit.yml
@@ -4614,7 +4614,7 @@
 : title: "1923"
   season: 1
   episode: 1
-  alias: '1923 2022"'
+  alias: '1923 2022'
   year: 2022
   screen_size: 720p
   video_codec: H.264


### PR DESCRIPTION
Specific show 1923.

Added conditions to the rule wrongfully parse year in a multi part release string.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
