### PR TITLE
Read correct process_methods from config on startup

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -687,8 +687,8 @@ class Application(object):
             app.PROCESS_METHOD = check_setting_str(app.CFG, 'General', 'process_method', 'copy' if app.KEEP_PROCESSED_DIR else 'move')
 
             app.USE_SPECIFIC_PROCESS_METHOD = bool(check_setting_int(app.CFG, 'General', 'use_specific_process_method', 0))
-            app.PROCESS_METHOD_TORRENT = check_setting_str(app.CFG, 'General', 'process_method', 'copy' if app.KEEP_PROCESSED_DIR else 'move')
-            app.PROCESS_METHOD_NZB = check_setting_str(app.CFG, 'General', 'process_method', 'copy' if app.KEEP_PROCESSED_DIR else 'move')
+            app.PROCESS_METHOD_TORRENT = check_setting_str(app.CFG, 'General', 'process_method_torrent', 'copy' if app.KEEP_PROCESSED_DIR else 'move')
+            app.PROCESS_METHOD_NZB = check_setting_str(app.CFG, 'General', 'process_method_nzb', 'copy' if app.KEEP_PROCESSED_DIR else 'move')
 
             app.DELRARCONTENTS = bool(check_setting_int(app.CFG, 'General', 'del_rar_contents', 0))
             app.MOVE_ASSOCIATED_FILES = bool(check_setting_int(app.CFG, 'General', 'move_associated_files', 0))


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

On startup, init will overwrite previous values set for `process_method_torrent` and `process_method_nzb` because it's actually reading `process_method` for each setting.

This change fixes that by setting `PROCESS_METHOD_NZB` and `PROCESS_METHOD_TORRENT` to read from the correct string within config.

For quick reference, the config names for the specific process methods:
https://github.com/pymedusa/Medusa/blob/49ad1f901a050c79b7e8cb583cb02ee1a6abeecf/medusa/__main__.py#L1714-L1715