### PR TITLE
Fix git subprocess call for Windows paths with spaces

### DIFF
--- a/medusa/updater/github_updater.py
+++ b/medusa/updater/github_updater.py
@@ -135,8 +135,8 @@ class GitUpdateManager(UpdateManager):
 
         try:
             log.debug(u'Executing {cmd} with your shell in {dir}', {'cmd': cmd, 'dir': app.PROG_DIR})
-            p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-                                 shell=True, cwd=app.PROG_DIR)
+            p = subprocess.Popen([git_path, args], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                 stderr=subprocess.STDOUT, cwd=app.PROG_DIR)
             output, err = p.communicate()
             exit_status = p.returncode
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
