### PR TITLE
fix color of show-header in light-theme

### DIFF
--- a/themes-default/slim/static/css/light.css
+++ b/themes-default/slim/static/css/light.css
@@ -45,6 +45,9 @@ home.mako
 /* =======================================================================
 displayShow.mako
 ========================================================================== */
+.snatchTitle {
+    color: rgb(0, 0, 0) !important;
+}
 
 .displayShowTable th.row-seasonheader {
     border: none !important;


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

works for me

problem is that in light theme there is a "hidden" link to the Show . Hidden because white on white.
dark theme is OK.