### PR TITLE
Update __init__.py

### DIFF
--- a/medusa/clients/rss/__init__.py
+++ b/medusa/clients/rss/__init__.py
@@ -167,7 +167,7 @@ def _write_xml(root_element, file_path):
     """
     try:
         xml_string = ElemTree.tostring(root_element, encoding='unicode')
-        xml_string = xml_string.replace('\n', '')
+        xml_string = xml_string.replace('\n', '').encode('asii', 'ignore')
         with open(file_path, 'w') as f:
             f.write(xml_string)
         return True


### PR DESCRIPTION
Ignore non-ascii characters in rss xml. Some descriptions put a non-breaking space at the end and that isn't valid ascii.