### PR TITLE
Switch from using `unrar` to `7z`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,3 @@
-# Need this image for the /bin/start-build script.
-# Build unrar.  It has been moved to non-free since Alpine 3.15.
-# https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.15.0#unrar_moved_to_non-free
-FROM jlesage/alpine-abuild:3.15 AS unrar
-WORKDIR /tmp
-RUN \
-    mkdir /tmp/aport && \
-    cd /tmp/aport && \
-    git init && \
-    git remote add origin https://github.com/alpinelinux/aports && \
-    git config core.sparsecheckout true && \
-    echo "non-free/unrar/*" >> .git/info/sparse-checkout && \
-    git pull origin 3.15-stable && \
-    PKG_SRC_DIR=/tmp/aport/non-free/unrar && \
-    PKG_DST_DIR=/tmp/unrar-pkg && \
-    mkdir "$PKG_DST_DIR" && \
-    /bin/start-build -r && \
-    rm /tmp/unrar-pkg/*-doc-* && \
-    mkdir /tmp/unrar-install && \
-    tar xf /tmp/unrar-pkg/unrar-*.apk -C /tmp/unrar-install
-
 FROM python:3.10.8-alpine3.15
 LABEL maintainer="pymedusa"
 
@@ -48,9 +27,6 @@ RUN \
 
 # Install app
 COPY . /app/medusa/
-
-# Copy unrar bin
-COPY --from=unrar /tmp/unrar-install/usr/bin/unrar /usr/bin/
 
 # Ports and Volumes
 EXPOSE 8081

--- a/ext/rarfile.py
+++ b/ext/rarfile.py
@@ -196,16 +196,16 @@ DEFAULT_CHARSET = "windows-1252"
 TRY_ENCODINGS = ('utf8', 'utf-16le')
 
 #: 'unrar', 'rar' or full path to either one
-UNRAR_TOOL = "unrar"
+UNRAR_TOOL = "7z"
 
 #: Command line args to use for opening file for reading.
-OPEN_ARGS = ('p', '-inul')
+OPEN_ARGS = ('e', '-so')
 
 #: Command line args to use for extracting file to disk.
-EXTRACT_ARGS = ('x', '-y', '-idq')
+EXTRACT_ARGS = ('x', '-y')
 
 #: args for testrar()
-TEST_ARGS = ('t', '-idq')
+TEST_ARGS = ('t')
 
 #
 # Allow use of tool that is not compatible with unrar.


### PR DESCRIPTION
- [X] PR is based on the DEVELOP branch
- [X] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [X] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

This little patch experimentally replaces use of `unrar` (problematic in e.g. #10777) with `7z`, which is actually pretty close to drop-in compatible, it seems.