### PR TITLE
Remove deprecated distutils for python 3.12 compatability

### DIFF
--- a/.github/workflows/api-tests.yml
+++ b/.github/workflows/api-tests.yml
@@ -25,6 +25,7 @@ jobs:
         pip install dredd_hooks
         pip install 'PyYAML>=5.1'
         pip install 'six>=1.13.0'
+        pip install packaging
     - name: Install Node.js dependencies
       run: yarn install --ignore-scripts
     - name: Test with Dredd

--- a/ext/pint/testsuite/helpers.py
+++ b/ext/pint/testsuite/helpers.py
@@ -4,7 +4,7 @@ from __future__ import division, unicode_literals, print_function, absolute_impo
 
 
 import doctest
-from distutils.version import StrictVersion
+from packaging.utils import canonical_version
 import re
 import unittest
 
@@ -14,13 +14,13 @@ from pint.compat import HAS_NUMPY, HAS_PROPER_BABEL, HAS_UNCERTAINTIES, NUMPY_VE
 def requires_numpy18():
     if not HAS_NUMPY:
         return unittest.skip('Requires NumPy')
-    return unittest.skipUnless(StrictVersion(NUMPY_VER) >= StrictVersion('1.8'), 'Requires NumPy >= 1.8')
+    return unittest.skipUnless(canonical_version(NUMPY_VER) >= canonical_version('1.8'), 'Requires NumPy >= 1.8')
 
 
 def requires_numpy_previous_than(version):
     if not HAS_NUMPY:
         return unittest.skip('Requires NumPy')
-    return unittest.skipUnless(StrictVersion(NUMPY_VER) < StrictVersion(version), 'Requires NumPy < %s' % version)
+    return unittest.skipUnless(canonical_version(NUMPY_VER) < canonical_version(version), 'Requires NumPy < %s' % version)
 
 
 def requires_numpy():

--- a/lib/pkg_resources/tests/test_pkg_resources.py
+++ b/lib/pkg_resources/tests/test_pkg_resources.py
@@ -7,7 +7,7 @@ import time
 import subprocess
 import stat
 import distutils.dist
-import distutils.command.install_egg_info
+import setuptools.command.install_egg_info
 
 try:
     from unittest import mock
@@ -344,8 +344,8 @@ class TestDeepVersionLookupDistutils:
         """
         ld = "This package has unicode metadata! ❄"
         attrs = dict(name='foo', version=version, long_description=ld)
-        dist = distutils.dist.Distribution(attrs)
-        iei_cmd = distutils.command.install_egg_info.install_egg_info(dist)
+        dist = setuptools.dist.Distribution(attrs)
+        iei_cmd = setuptools.command.install_egg_info.install_egg_info(dist)
         iei_cmd.initialize_options()
         iei_cmd.install_dir = env.paths['lib']
         iei_cmd.finalize_options()

--- a/medusa/updater/update_manager.py
+++ b/medusa/updater/update_manager.py
@@ -3,12 +3,13 @@
 from __future__ import unicode_literals
 
 import logging
-from packaging.version import Version
 
 from github import GithubException
 
 from medusa import app
 from medusa.logger.adapters.style import BraceAdapter
+
+from packaging.version import Version
 
 from requests.exceptions import RequestException
 

--- a/medusa/updater/update_manager.py
+++ b/medusa/updater/update_manager.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 import logging
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 from github import GithubException
 
@@ -42,7 +42,7 @@ class UpdateManager(object):
     def is_latest_version(self):
         """Compare the current installed version with the remote version."""
         try:
-            if LooseVersion(self.newest_version) > LooseVersion(self.current_version):
+            if Version(self.newest_version) > Version(self.current_version):
                 return False
         except (GithubException, RequestException) as error:
             log.warning("Unable to contact GitHub, can't get latest version: {0!r}", error)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ jsonrpclib-pelix==0.4.3.2
 knowit==0.4.0
 Mako==1.2.4
 markdown2==2.4.13
+packaging==24.2
 profilehooks==1.12.0
 PyGithub==1.45
 PyJWT==2.7.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -6,6 +6,7 @@ pycodestyle==2.8.0
 flake8-docstrings==1.7.0
 flake8-import-order==0.18.2
 flake8-quotes==3.3.2
+packaging
 pep8-naming==0.13.2
 pytest>=6.2.5
 pytest-cov==4.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -18,11 +18,11 @@ deps =
     pytest
     -rtest_requirements.txt
 commands =
-    python setup.py test -a "{posargs:tests} --cov=medusa --cov-report=xml"
+    pytest {posargs:tests} --cov=medusa --cov-report=xml
 
 [testenv:lint]
 deps = 
     pytest
     -rtest_requirements.txt
 commands =
-    python setup.py test -a "medusa --flake8"
+    pytest medusa --flake8


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

As seen in the medusa discord, distutils causes crashes for end users because of lines 6 and 45 in medusa/updater/update_manager.py

due to references to distutils, which is deprecated in python 3.12

I've also attempted to update helper libraries which are not needed to address the crash itself.
