### PR TITLE
Set the WEB_PORT by enviroment variable if enviroment variable is set.

### DIFF
--- a/medusa/__main__.py
+++ b/medusa/__main__.py
@@ -559,6 +559,12 @@ class Application(object):
             except Exception:
                 app.WEB_PORT = 8081
 
+            # attempt override WEB_PORT if enviroment variable is set
+            try:
+                app.WEB_PORT = int(os.environ.get('MEDUSA_WEB_PORT'))
+            except Exception:
+                pass
+
             if not 21 < app.WEB_PORT < 65535:
                 app.WEB_PORT = 8081
 


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Provide means to set the web_port by environment variable, with "MEDUSA_WEB_PORT"