### PR TITLE
Add python 3.13+ compatability

### DIFF
--- a/ext/guessit/rules/properties/website.py
+++ b/ext/guessit/rules/properties/website.py
@@ -4,9 +4,9 @@
 Website property.
 """
 try:
-    from importlib.resources import files  # @UnresolvedImport
+    from importlib.resources import files, read_text # @UnresolvedImport
 except ImportError:
-    from importlib_resources import files  # @UnresolvedImport
+    from importlib_resources import files, read_text # @UnresolvedImport
 
 from rebulk.remodule import re
 
@@ -16,7 +16,6 @@ from ..common.formatters import cleanup
 from ..common.pattern import is_disabled
 from ..common.validators import seps_surround
 from ...reutils import build_or_pattern
-
 
 def website(config):
     """
@@ -31,8 +30,21 @@ def website(config):
     rebulk = rebulk.regex_defaults(flags=re.IGNORECASE).string_defaults(ignore_case=True)
     rebulk.defaults(name="website")
 
-    with files('guessit.data') as data_files:
-        tld_file = data_files.joinpath('tlds-alpha-by-domain.txt').read_text(encoding='utf-8')
+
+    #python 3.13+
+    try:
+        tld_file = read_text('guessit', 'data', 'tlds-alpha-by-domain.txt', encoding='utf-8')
+    except (TypeError, NameError):
+        pass
+
+    #python 3.12 and below
+    try:
+        with files('guessit.data') as data_files:
+            tld_file = data_files.joinpath('tlds-alpha-by-domain.txt').read_text(encoding='utf-8')
+    except (TypeError, NameError):
+        pass
+
+    finally:
         tlds = [
             tld.strip()
             for tld in tld_file.split('\n')

--- a/lib/boto/ecs/item.py
+++ b/lib/boto/ecs/item.py
@@ -21,7 +21,7 @@
 
 
 import xml.sax
-import cgi
+import html
 from boto.compat import six, StringIO
 
 class ResponseGroup(xml.sax.ContentHandler):
@@ -67,7 +67,7 @@ class ResponseGroup(xml.sax.ContentHandler):
         return None
 
     def endElement(self, name, value, connection):
-        self._xml.write("%s</%s>" % (cgi.escape(value).replace("&amp;amp;", "&amp;"), name))
+        self._xml.write("%s</%s>" % (html.escape(value).replace("&amp;amp;", "&amp;"), name))
         if len(self._nodepath) == 0:
             return
         obj = None

--- a/medusa/helpers/__init__.py
+++ b/medusa/helpers/__init__.py
@@ -8,7 +8,6 @@ import ctypes
 import datetime
 import errno
 import hashlib
-import imghdr
 import io
 import logging
 import os
@@ -48,6 +47,8 @@ from medusa.indexers.exceptions import IndexerException
 from medusa.logger.adapters.style import BraceAdapter, BraceMessage
 from medusa.session.core import MedusaSafeSession
 from medusa.show.show import Show
+
+import puremagic
 
 import requests
 from requests.compat import urlparse
@@ -1493,14 +1494,14 @@ def get_image_size(image_path):
         head = f.read(24)
         if len(head) != 24:
             return
-        if imghdr.what(image_path) == 'png':
+        if puremagic.from_file(image_path).strip('.') == 'png':
             check = struct.unpack('>i', head[4:8])[0]
             if check != 0x0d0a1a0a:
                 return
             return struct.unpack('>ii', head[16:24])
-        elif imghdr.what(image_path) == 'gif':
+        elif puremagic.from_file(image_path).strip('.') == 'gif':
             return struct.unpack('<HH', head[6:10])
-        elif imghdr.what(image_path) == 'jpeg' or img_ext in ('jpg', 'jpeg'):
+        elif puremagic.from_file(image_path).strip('.') == 'jpeg' or img_ext in ('jpg', 'jpeg'):
             f.seek(0)  # Read 0xff next
             size = 2
             ftype = 0

--- a/medusa/notifiers/libnotify.py
+++ b/medusa/notifiers/libnotify.py
@@ -2,7 +2,7 @@
 
 from __future__ import unicode_literals
 
-import cgi
+import html
 import logging
 import os
 from builtins import object
@@ -38,13 +38,13 @@ def diagnose():
             bus = dbus.SessionBus()
         except dbus.DBusException as e:
             return (u'<p>Error: unable to connect to D-Bus session bus: <code>%s</code>.'
-                    u'<p>Are you running Medusa in a desktop session?') % (cgi.escape(e),)
+                    u'<p>Are you running Medusa in a desktop session?') % (html.escape(e),)
         try:
             bus.get_object('org.freedesktop.Notifications',
                            '/org/freedesktop/Notifications')
         except dbus.DBusException as e:
             return (u"<p>Error: there doesn't seem to be a notification daemon available: <code>%s</code> "
-                    u'<p>Try installing notification-daemon or notify-osd.') % (cgi.escape(e),)
+                    u'<p>Try installing notification-daemon or notify-osd.') % (html.escape(e),)
     return u'<p>Error: Unable to send notification.'
 
 

--- a/medusa/notifiers/nmj.py
+++ b/medusa/notifiers/nmj.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 import logging
 import re
-import telnetlib
 from builtins import object
 
 from medusa import app
@@ -14,6 +13,8 @@ from medusa.logger.adapters.style import BraceAdapter
 from requests.compat import urlencode
 
 from six.moves.urllib.request import Request, urlopen
+
+import telnetlib3
 
 try:
     import xml.etree.cElementTree as etree
@@ -35,7 +36,7 @@ class Notifier(object):
         """
         # establish a terminal session to the PC
         try:
-            terminal = telnetlib.Telnet(host)
+            terminal = telnetlib3.Telnet(host)
         except Exception:
             log.warning(u'Warning: unable to get a telnet session to {0}', host)
             return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Mako==1.2.4
 markdown2==2.4.13
 packaging==24.2
 profilehooks==1.12.0
+puremagic==1.28
 PyGithub==1.45
 PyJWT==2.7.0
 pymediainfo==7.0.1
@@ -37,6 +38,7 @@ requests-toolbelt==1.0.0
 six==1.16.0
 subliminal==2.2.1
 tmdbsimple==2.9.1
+telnetlib3==2.0.4
 tornado==6.1
 tornroutes==0.5.1
 trans==2.1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -7,6 +7,7 @@ flake8-import-order==0.18.2
 flake8-quotes==3.3.2
 packaging==24.2
 pep8-naming==0.13.2
+puremagic==1.28
 pytest>=6.2.5
 pytest-cov==4.1.0
 pytest-flake8==1.1.1
@@ -16,6 +17,7 @@ setuptools==68.0.0
 six==1.16.0
 tox
 tox-gh-actions
+telnetlib3==2.0.4
 tornado==6.1
 urllib3<2.0.0
 vcrpy


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

Addressing deprecated modules: imghdr, cgi, telnetlib in python 3.13

imghdr has been replaced with puremagic
cgi has been replaced with http
telnetlib has been replaced with telnetlib3

a traversal package problem has been attempted replaced in `ext/guessit/rules/properties/website.py`
importlib.resources.files is now tested, as well as importlib.resources.read_text, as read_text operates differently in 3.13, and the code which works for 3.12 and below does not work for 3.13

changes have been tested to work with python 3.12.x