### PR TITLE
Fix import existing show with no English in indexer

### DIFF
--- a/medusa/indexers/tvdbv2/api.py
+++ b/medusa/indexers/tvdbv2/api.py
@@ -549,15 +549,46 @@ class TVDBv2(BaseIndexer):
             )
             get_show_in_language = self.config['language']
 
-        # Parse show information
-        log.debug('Getting all series data for {0}', tvdb_id)
+        # Build fallback order: preferred first, then 'en' as common fallback, then rest
+        languages_to_try = [get_show_in_language]
+        if get_show_in_language != 'en':
+            languages_to_try.append('en')
+        languages_to_try += [
+            lang for lang in self.config['valid_languages']
+            if lang not in languages_to_try
+        ]
 
-        # Parse show information
-        series_info = self._get_show_by_id(tvdb_id, request_language=get_show_in_language)
+        # Try each language until one returns valid data
+        series_info = None
+        last_error = None
+        effective_language = None
+
+        log.debug('Getting all series data for {0}', tvdb_id)
+        for try_language in languages_to_try:
+            try:
+                series_info = self._get_show_by_id(tvdb_id, request_language=try_language)
+                if series_info:
+                    effective_language = try_language
+                    if try_language != get_show_in_language:
+                        log.info(
+                            'Show not available in {requested}, using {fallback}',
+                            {'requested': get_show_in_language, 'fallback': try_language}
+                        )
+                    break
+            except IndexerShowNotFoundInLanguage as error:
+                last_error = error
+                log.debug('Show not found in language {0}, trying next', try_language)
+                continue
 
         if not series_info:
+            if last_error:
+                raise last_error
             log.debug('Series result returned zero')
             raise IndexerError('Series result returned zero')
+
+        # Use effective language for subsequent fetches (episodes, images, actors)
+        if effective_language:
+            self.config['language'] = effective_language
 
         # get series data / add the base_url to the image urls
         for k, v in viewitems(series_info['series']):

--- a/medusa/indexers/tvdbv2/api.py
+++ b/medusa/indexers/tvdbv2/api.py
@@ -583,8 +583,19 @@ class TVDBv2(BaseIndexer):
         if not series_info:
             if last_error:
                 raise last_error
-            log.debug('Series result returned zero')
-            raise IndexerError('Series result returned zero')
+            if languages_to_try:
+                attempted_languages = ', '.join(languages_to_try)
+                log.debug(
+                    'Series result returned zero for all attempted languages: {0}',
+                    attempted_languages
+                )
+                raise IndexerError(
+                    'Series result returned zero for all attempted languages: {0}'.format(
+                        attempted_languages
+                    )
+                )
+            log.debug('Series result returned zero and no languages were attempted')
+            raise IndexerError('Series result returned zero and no languages were attempted')
 
         # Use effective language for subsequent fetches (episodes, images, actors)
         if effective_language:


### PR DESCRIPTION
**Description**
Fixes import of existing shows that have no English translation on TVDB. Previously, adding such shows failed with IndexerShowNotFoundInLanguage.

**Changes**
Add language fallback in the TVDB indexer _get_show_data method
Try languages in order: preferred → English → other valid languages
Use the successful language for episode, image, and actor fetches
Log when a fallback language is used

**Checklist**
[x] PR is based on the DEVELOP branch
[x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
[x] Read the contribution guide

**Related**
Fixes IndexerShowNotFoundInLanguage when adding shows without English metadata on TVDB
Related to: #11480, #10992, #10965 (different issue: language preference not applied vs. no translation available)

