### PR TITLE
fix: use configured indexer language when adding existing or new shows

### DIFF
--- a/themes-default/slim/src/components/new-show-search.vue
+++ b/themes-default/slim/src/components/new-show-search.vue
@@ -14,6 +14,14 @@
             <span v-else>
                 <b>{{ providedInfo.showName }}</b>
             </span>
+            <div class="show-add-option" style="margin-top: 10px;">
+                <language-select @update-language="providedInfo.indexerLanguage = $event"
+                                 :language="providedInfo.indexerLanguage || general.indexerDefaultLanguage || 'en'"
+                                 :available="indexers.main.validLanguages.join(',')"
+                                 class="form-control form-control-inline input-sm"
+                />
+                <label> Info language</label>
+            </div>
         </div>
         <div v-else>
             <div class="row">

--- a/themes-default/slim/src/components/new-show-search.vue
+++ b/themes-default/slim/src/components/new-show-search.vue
@@ -15,7 +15,7 @@
                 <b>{{ providedInfo.showName }}</b>
             </span>
             <div class="show-add-option" style="margin-top: 10px;">
-                <language-select @update-language="providedInfo.indexerLanguage = $event"
+                <language-select @update-language="$emit('update-provided-info-language', $event)"
                                  :language="providedInfo.indexerLanguage || general.indexerDefaultLanguage || 'en'"
                                  :available="indexers.main.validLanguages.join(',')"
                                  class="form-control form-control-inline input-sm"

--- a/themes-default/slim/src/components/new-show.vue
+++ b/themes-default/slim/src/components/new-show.vue
@@ -279,7 +279,6 @@ export default {
             // Collect all the needed form data.
             const {
                 indexerIdToName,
-                indexerLanguage,
                 presetShowOptions,
                 providedInfo,
                 selectedRootDir,
@@ -294,7 +293,9 @@ export default {
                 options.language = providedInfo.indexerLanguage;
                 showId[indexerIdToName(providedInfo.indexerId)] = providedInfo.showId;
             } else {
-                options.language = indexerLanguage;
+                // Use language selected in search component (Add New Show flow)
+                const searchComponent = this.$refs.newShowSearch;
+                options.language = searchComponent?.indexerLanguage ?? this.general?.indexerDefaultLanguage ?? 'en';
                 showId[indexerIdToName(selectedShow.indexerId)] = selectedShow.showId;
             }
 

--- a/themes-default/slim/src/components/new-shows-existing.vue
+++ b/themes-default/slim/src/components/new-shows-existing.vue
@@ -161,6 +161,7 @@ export default {
     computed: {
         ...mapState({
             indexers: state => state.config.indexers,
+            general: state => state.config.general,
             indexerDefault: state => state.config.general.indexerDefault,
             queueitems: state => state.shows.queueitems,
             client: state => state.auth.client
@@ -354,7 +355,7 @@ export default {
                 showName: '',
                 showDir: curDir.path,
                 indexerId: 0,
-                indexerLanguage: 'en',
+                indexerLanguage: this.general?.indexerDefaultLanguage ?? undefined,
                 curDirIndex, // Add so we can return it with the matching queueitem. This allows us to keep track.
                 // If promptForSettings is enabled, negate out the unattended flag if enabled.
                 unattended: unattended && !promptForSettings // Passed as a flag, to auto add the show if enabled.


### PR DESCRIPTION
This pull request introduces improvements to the language selection flow when adding new shows, ensuring that the user's chosen language is consistently used across components and defaults are respected. The changes primarily focus on propagating the selected language from the search component to the main show addition logic and updating defaults for existing shows.

**Language selection improvements:**

* Added a `language-select` dropdown to the `new-show-search.vue` component, allowing users to choose the info language when searching for shows.
* Updated the logic in `new-show.vue` so that the selected language from the search component is used when adding a new show, falling back to the general default language or 'en' if not set.
* Removed the `indexerLanguage` variable from the form data collection in `new-show.vue` to streamline language handling.

**Default language handling:**

* Modified `new-shows-existing.vue` to set the default `indexerLanguage` for new shows to the general default language if available, instead of always defaulting to 'en'.
* Added `general` state mapping in `new-shows-existing.vue` to access the general configuration and support the new default language logic.When adding an existing show, Medusa was always using English ('en') instead of the Default Indexer Language from General settings. When adding a new show, the language selected in the form was ignored and the default was used.

Changes:
- new-shows-existing.vue: Use general.indexerDefaultLanguage instead of hardcoded 'en'; fallback to undefined so backend uses its config
- new-show-search.vue: Add language selector for Add Existing Show flow so users can choose/override the info language before adding
- new-show.vue: Get language from search component for Add New Show flow instead of undefined indexerLanguage from parent scope

Fixes: #10992, #11480

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
