### PR TITLE
Fix/custom search templates not saved

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -35,6 +35,7 @@ from medusa.helper.common import (
 )
 from medusa.helpers import (
     chmod_as_parent, download_file,
+    get_title_without_year,
 )
 from medusa.indexers.config import INDEXER_TVDBV2
 from medusa.logger.adapters.style import BraceAdapter
@@ -678,7 +679,9 @@ class GenericProvider(object):
                 if episode.scene_season is not None and template.season != -1 and episode.scene_season != template.season:
                     continue
 
-                search_string['Episode'].append(episode.formatted_search_string(template.template, title=template.title))
+                # Custom templates may have title with year from UI; strip for search queries
+                search_title = template.title if template.default else get_title_without_year(template.title, episode.series.start_year)
+                search_string['Episode'].append(episode.formatted_search_string(template.template, title=search_title))
             return [search_string]
 
         all_possible_show_names = episode.series.get_all_possible_names()
@@ -721,7 +724,9 @@ class GenericProvider(object):
                 if episode.scene_season and template.season != -1 and episode.scene_season != template.season:
                     continue
 
-                search_string['Season'].append(episode.formatted_search_string(template.template, title=template.title))
+                # Custom templates may have title with year from UI; strip for search queries
+                search_title = template.title if template.default else get_title_without_year(template.title, episode.series.start_year)
+                search_string['Season'].append(episode.formatted_search_string(template.template, title=search_title))
             return [search_string]
 
         for show_name in episode.series.get_all_possible_names(season=episode.scene_season):

--- a/medusa/search_templates.py
+++ b/medusa/search_templates.py
@@ -272,7 +272,7 @@ class SearchTemplates(object):
         self.remove_custom()
         for template in templates:
             # Custom templates are user-defined; always save them
-            is_custom = not template.get('default', True)
+            is_custom = not template.get('default', False)
             if not is_custom:
                 # For default templates only, verify scene exception exists
                 find_scene_exception = self.main_db_con.select(

--- a/medusa/search_templates.py
+++ b/medusa/search_templates.py
@@ -58,12 +58,12 @@ class SearchTemplates(object):
         return self.templates
 
     def _clean(self):
-        """Clean up templates when there is no scene exception for it anymore."""
-        # Get the default title search string for Episode and Season
+        """Clean up default templates when scene exception was removed. Preserve custom templates."""
         self.main_db_con.action("""
             DELETE from search_templates
             WHERE indexer = ?
             AND series_id = ?
+            AND `default` = 1
             AND title not in (select title from scene_exceptions where indexer = ? and series_id = ?)
             AND title != ?
         """, [
@@ -271,17 +271,19 @@ class SearchTemplates(object):
         self.templates = []
         self.remove_custom()
         for template in templates:
-            # TODO: add validation
-            # Check if the scene exception still exists in db
-            find_scene_exception = self.main_db_con.select(
-                'SELECT season, title '
-                'FROM scene_exceptions '
-                'WHERE indexer = ? AND series_id = ? '
-                'AND title = ? AND season = ?',
-                [self.show_obj.indexer, self.show_obj.series_id, template['title'], template['season']]
-            )
-            if not find_scene_exception and template['title'] != self.show_obj.name:
-                continue
+            # Custom templates are user-defined; always save them
+            is_custom = not template.get('default', True)
+            if not is_custom:
+                # For default templates only, verify scene exception exists
+                find_scene_exception = self.main_db_con.select(
+                    'SELECT season, title '
+                    'FROM scene_exceptions '
+                    'WHERE indexer = ? AND series_id = ? '
+                    'AND title = ? AND season = ?',
+                    [self.show_obj.indexer, self.show_obj.series_id, template['title'], template['season']]
+                )
+                if not find_scene_exception and template['title'] != self.show_obj.name:
+                    continue
 
             # Save to db
             self.save(template)

--- a/tests/providers/test_generic_provider.py
+++ b/tests/providers/test_generic_provider.py
@@ -472,7 +472,6 @@ def test_create_search_string_anime(p, create_tvshow, create_tvepisode, monkeypa
     },
 ])
 def test_create_search_string_with_templates_episode(p, create_tvshow, create_tvepisode, monkeypatch):
-    from collections import namedtuple
     from medusa.search_templates import SearchTemplate
 
     series_name = p['series_name']
@@ -587,7 +586,6 @@ def test_create_search_string_with_templates_episode(p, create_tvshow, create_tv
     },
 ])
 def test_create_search_string_with_templates_season(p, create_tvshow, create_tvepisode, monkeypatch):
-    from collections import namedtuple
     from medusa.search_templates import SearchTemplate
 
     series_name = p['series_name']

--- a/tests/providers/test_generic_provider.py
+++ b/tests/providers/test_generic_provider.py
@@ -398,3 +398,233 @@ def test_create_search_string_anime(p, create_tvshow, create_tvepisode, monkeypa
     actual = search_string['Episode']
 
     assert expected == actual
+
+
+@pytest.mark.parametrize('p', [
+    {  # p0: Episode search with default template (year should be preserved)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Default template - year should NOT be stripped
+            {'id': 1, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 1, 'season_search': 0},
+        ],
+        'expected': ['My Series (2020) S01E05']
+    },
+    {  # p1: Episode search with custom template (year should be stripped)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Custom template - year SHOULD be stripped
+            {'id': 2, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 0},
+        ],
+        'expected': ['My Series S01E05']
+    },
+    {  # p2: Episode search with mixed templates (default and custom)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Default template - year should NOT be stripped
+            {'id': 1, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 1, 'season_search': 0},
+            # Custom template - year SHOULD be stripped
+            {'id': 2, 'template': '{title}.{season:02d}x{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 0},
+        ],
+        'expected': ['My Series (2020) S01E05', 'My Series.01x05']
+    },
+    {  # p3: Episode search with custom template without year
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Custom template without year - title should remain unchanged
+            {'id': 3, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 0},
+        ],
+        'expected': ['My Series S01E05']
+    },
+    {  # p4: Episode search filtering by season
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Season 1 template - should be included
+            {'id': 1, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': 1, 'enabled': 1, 'default': 0, 'season_search': 0},
+            # Season 2 template - should be excluded
+            {'id': 2, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'Other Title',
+             'series': 1, 'season': 2, 'enabled': 1, 'default': 0, 'season_search': 0},
+        ],
+        'expected': ['My Series S01E05']
+    },
+    {  # p5: Episode search with disabled templates excluded
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Enabled template
+            {'id': 1, 'template': '{title} S{season:02d}E{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 0},
+            # Disabled template - should be excluded
+            {'id': 2, 'template': '{title}.{season:02d}x{episode:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 0, 'default': 0, 'season_search': 0},
+        ],
+        'expected': ['My Series S01E05']
+    },
+])
+def test_create_search_string_with_templates_episode(p, create_tvshow, create_tvepisode, monkeypatch):
+    from collections import namedtuple
+    from medusa.search_templates import SearchTemplate
+
+    series_name = p['series_name']
+    start_year = p['start_year']
+    templates_data = p['templates']
+    expected = p['expected']
+
+    # Create mock series
+    mock_series = create_tvshow(indexer=1, name=series_name, start_year=start_year)
+    
+    # Create SearchTemplate namedtuples
+    templates = [SearchTemplate(**t) for t in templates_data]
+    
+    # Mock search_templates object with a templates list
+    mock_search_templates = type('obj', (object,), {'templates': templates})()
+    
+    # Mock the search_templates property getter instead of setting it
+    monkeypatch.setattr(type(mock_series), 'search_templates', 
+                        property(lambda self: mock_search_templates), raising=False)
+    mock_series.templates = True  # Enable use_templates
+    
+    # Create provider and episode
+    provider = GenericProvider('mock_provider')
+    provider.series = mock_series
+    
+    episode = create_tvepisode(mock_series, 1, 5)
+    episode.scene_season = 1
+    episode.scene_episode = 5
+    
+    # Mock formatted_search_string to return predictable output
+    def mock_formatted_search_string(template, title=None):
+        return template.format(title=title or series_name, season=1, episode=5)
+    
+    monkeypatch.setattr(episode, 'formatted_search_string', mock_formatted_search_string)
+    
+    # Call _get_episode_search_strings
+    result = provider._get_episode_search_strings(episode)
+    actual = result[0]['Episode']
+    
+    assert expected == actual
+
+
+@pytest.mark.parametrize('p', [
+    {  # p0: Season search with default template (year should be preserved)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Default template - year should NOT be stripped
+            {'id': 1, 'template': '{title} S{season:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 1, 'season_search': 1},
+        ],
+        'expected': ['My Series (2020) S01']
+    },
+    {  # p1: Season search with custom template (year should be stripped)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Custom template - year SHOULD be stripped
+            {'id': 2, 'template': '{title} S{season:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 1},
+        ],
+        'expected': ['My Series S01']
+    },
+    {  # p2: Season search with mixed templates (default and custom)
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Default template - year should NOT be stripped
+            {'id': 1, 'template': '{title} S{season:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 1, 'season_search': 1},
+            # Custom template - year SHOULD be stripped
+            {'id': 2, 'template': '{title} Season {season}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 1},
+        ],
+        'expected': ['My Series (2020) S01', 'My Series Season 1']
+    },
+    {  # p3: Season search with custom template without year
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Custom template without year - title should remain unchanged
+            {'id': 3, 'template': '{title} S{season:02d}', 'title': 'My Series',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 1},
+        ],
+        'expected': ['My Series S01']
+    },
+    {  # p4: Season search filtering by season
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Season 1 template - should be included
+            {'id': 1, 'template': '{title} S{season:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': 1, 'enabled': 1, 'default': 0, 'season_search': 1},
+            # Season 2 template - should be excluded
+            {'id': 2, 'template': '{title} S{season:02d}', 'title': 'Other Title',
+             'series': 1, 'season': 2, 'enabled': 1, 'default': 0, 'season_search': 1},
+        ],
+        'expected': ['My Series S01']
+    },
+    {  # p5: Season search with disabled templates excluded
+        'series_name': 'My Series',
+        'start_year': 2020,
+        'templates': [
+            # Enabled template
+            {'id': 1, 'template': '{title} S{season:02d}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 1, 'default': 0, 'season_search': 1},
+            # Disabled template - should be excluded
+            {'id': 2, 'template': '{title} Season {season}', 'title': 'My Series (2020)',
+             'series': 1, 'season': -1, 'enabled': 0, 'default': 0, 'season_search': 1},
+        ],
+        'expected': ['My Series S01']
+    },
+])
+def test_create_search_string_with_templates_season(p, create_tvshow, create_tvepisode, monkeypatch):
+    from collections import namedtuple
+    from medusa.search_templates import SearchTemplate
+
+    series_name = p['series_name']
+    start_year = p['start_year']
+    templates_data = p['templates']
+    expected = p['expected']
+
+    # Create mock series
+    mock_series = create_tvshow(indexer=1, name=series_name, start_year=start_year)
+    
+    # Create SearchTemplate namedtuples
+    templates = [SearchTemplate(**t) for t in templates_data]
+    
+    # Mock search_templates object with a templates list
+    mock_search_templates = type('obj', (object,), {'templates': templates})()
+    
+    # Mock the search_templates property getter instead of setting it
+    monkeypatch.setattr(type(mock_series), 'search_templates', 
+                        property(lambda self: mock_search_templates), raising=False)
+    mock_series.templates = True  # Enable use_templates
+    
+    # Create provider and episode
+    provider = GenericProvider('mock_provider')
+    provider.series = mock_series
+    
+    episode = create_tvepisode(mock_series, 1, 5)
+    episode.scene_season = 1
+    episode.scene_episode = 5
+    
+    # Mock formatted_search_string to return predictable output
+    def mock_formatted_search_string(template, title=None):
+        return template.format(title=title or series_name, season=1)
+    
+    monkeypatch.setattr(episode, 'formatted_search_string', mock_formatted_search_string)
+    
+    # Call _get_season_search_strings
+    result = provider._get_season_search_strings(episode)
+    actual = result[0]['Season']
+    
+    assert expected == actual

--- a/tests/test_search_templates.py
+++ b/tests/test_search_templates.py
@@ -1,0 +1,331 @@
+# coding=utf-8
+"""Tests for medusa.search_templates module."""
+
+from medusa.search_templates import SearchTemplates
+
+
+def test_clean_preserves_custom_templates(monkeypatch, create_tvshow, monkeypatch_function_return):
+    """Test that _clean() preserves custom templates (default=0) even when titles don't match scene exceptions."""
+    # Create a test show
+    series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
+    
+    # Mock the database to return scene exceptions (only one exception exists)
+    scene_exceptions = [
+        {
+            'indexer': 1,
+            'series_id': 1,
+            'season': 1,
+            'title': 'Valid Exception'
+        }
+    ]
+    
+    # Mock the initial templates in the database
+    # Include both default and custom templates
+    initial_templates = [
+        {
+            'search_template_id': 1,
+            'template': '%SN S%0SE%0E',
+            'title': 'Test Show',
+            'indexer': 1,
+            'series_id': 1,
+            'season': -1,
+            'enabled': 1,
+            'default': 1,  # Default template with show name (should be preserved)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 2,
+            'template': '%SN S%0SE%0E',
+            'title': 'Valid Exception',
+            'indexer': 1,
+            'series_id': 1,
+            'season': 1,
+            'enabled': 1,
+            'default': 1,  # Default template with valid scene exception (should be preserved)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 3,
+            'template': '%SN S%0SE%0E',
+            'title': 'Old Exception',
+            'indexer': 1,
+            'series_id': 1,
+            'season': 2,
+            'enabled': 1,
+            'default': 1,  # Default template without scene exception (should be removed)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 4,
+            'template': '%SN custom template',
+            'title': 'Custom Title',
+            'indexer': 1,
+            'series_id': 1,
+            'season': 1,
+            'enabled': 1,
+            'default': 0,  # Custom template (should NEVER be removed)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 5,
+            'template': '%SN another custom',
+            'title': 'Orphaned Custom',
+            'indexer': 1,
+            'series_id': 1,
+            'season': 3,
+            'enabled': 1,
+            'default': 0,  # Custom template without scene exception (should still be preserved)
+            'season_search': 0
+        }
+    ]
+    
+    deleted_ids = []
+    
+    def mock_action(query, params):
+        """Mock the database action method to track deletions."""
+        # Parse the DELETE query to understand what would be deleted
+        if 'DELETE from search_templates' in query:
+            # Simulate the deletion by tracking which templates would be deleted
+            for template in initial_templates:
+                if (template['indexer'] == params[0] and
+                    template['series_id'] == params[1] and
+                    template['default'] == 1 and  # Only default templates
+                    template['title'] not in [e['title'] for e in scene_exceptions] and
+                    template['title'] != series.name):
+                    deleted_ids.append(template['search_template_id'])
+    
+    def mock_select(query, params):
+        """Mock the database select method."""
+        if 'FROM search_templates' in query:
+            # Return templates that weren't deleted
+            return [t for t in initial_templates if t['search_template_id'] not in deleted_ids]
+        elif 'FROM scene_exceptions' in query:
+            # Return scene exceptions
+            return scene_exceptions
+        return []
+    
+    # Apply mocks
+    search_templates = SearchTemplates(series)
+    monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
+    monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
+    
+    # Execute read_from_db which calls _clean()
+    search_templates.read_from_db()
+    
+    # Verify results
+    # Should have deleted template ID 3 (Old Exception - default template without scene exception)
+    assert 3 in deleted_ids, "Default template 'Old Exception' should be removed"
+    
+    # Should NOT have deleted template IDs 1, 2 (show name and valid exception)
+    assert 1 not in deleted_ids, "Default template with show name should be preserved"
+    assert 2 not in deleted_ids, "Default template with valid scene exception should be preserved"
+    
+    # Should NOT have deleted template IDs 4, 5 (custom templates)
+    assert 4 not in deleted_ids, "Custom template should be preserved"
+    assert 5 not in deleted_ids, "Custom template without scene exception should still be preserved"
+    
+    # Verify the templates list
+    template_ids = [t.id for t in search_templates.templates]
+    assert 1 in template_ids, "Show name template should be in results"
+    assert 2 in template_ids, "Valid exception template should be in results"
+    assert 3 not in template_ids, "Old exception template should not be in results"
+    assert 4 in template_ids, "Custom template should be in results"
+    assert 5 in template_ids, "Orphaned custom template should be in results"
+
+
+def test_clean_removes_default_templates_without_exceptions(monkeypatch, create_tvshow):
+    """Test that _clean() removes default templates when their scene exceptions are removed."""
+    # Create a test show
+    series = create_tvshow(indexer=1, indexerid=2, name='Another Show')
+    
+    # Mock the database with NO scene exceptions
+    scene_exceptions = []
+    
+    # Mock the initial templates in the database
+    initial_templates = [
+        {
+            'search_template_id': 10,
+            'template': '%SN S%0SE%0E',
+            'title': 'Another Show',
+            'indexer': 1,
+            'series_id': 2,
+            'season': -1,
+            'enabled': 1,
+            'default': 1,  # Default template with show name (should be preserved)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 11,
+            'template': '%SN S%0SE%0E',
+            'title': 'Removed Exception 1',
+            'indexer': 1,
+            'series_id': 2,
+            'season': 1,
+            'enabled': 1,
+            'default': 1,  # Default template without scene exception (should be removed)
+            'season_search': 0
+        },
+        {
+            'search_template_id': 12,
+            'template': '%SN S%0SE%0E',
+            'title': 'Removed Exception 2',
+            'indexer': 1,
+            'series_id': 2,
+            'season': 2,
+            'enabled': 1,
+            'default': 1,  # Default template without scene exception (should be removed)
+            'season_search': 0
+        }
+    ]
+    
+    deleted_ids = []
+    
+    def mock_action(query, params):
+        """Mock the database action method to track deletions."""
+        if 'DELETE from search_templates' in query:
+            for template in initial_templates:
+                if (template['indexer'] == params[0] and
+                    template['series_id'] == params[1] and
+                    template['default'] == 1 and
+                    template['title'] not in [e['title'] for e in scene_exceptions] and
+                    template['title'] != series.name):
+                    deleted_ids.append(template['search_template_id'])
+    
+    def mock_select(query, params):
+        """Mock the database select method."""
+        if 'FROM search_templates' in query:
+            return [t for t in initial_templates if t['search_template_id'] not in deleted_ids]
+        elif 'FROM scene_exceptions' in query:
+            return scene_exceptions
+        return []
+    
+    # Apply mocks
+    search_templates = SearchTemplates(series)
+    monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
+    monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
+    
+    # Execute read_from_db which calls _clean()
+    search_templates.read_from_db()
+    
+    # Verify results
+    # Should have deleted template IDs 11 and 12 (removed exceptions)
+    assert 11 in deleted_ids, "Default template 'Removed Exception 1' should be removed"
+    assert 12 in deleted_ids, "Default template 'Removed Exception 2' should be removed"
+    
+    # Should NOT have deleted template ID 10 (show name)
+    assert 10 not in deleted_ids, "Default template with show name should be preserved"
+    
+    # Verify the templates list
+    template_ids = [t.id for t in search_templates.templates]
+    assert 10 in template_ids, "Show name template should be in results"
+    assert 11 not in template_ids, "Removed exception 1 template should not be in results"
+    assert 12 not in template_ids, "Removed exception 2 template should not be in results"
+
+
+def test_clean_with_multiple_shows(monkeypatch, create_tvshow):
+    """Test that _clean() only affects templates for the specific show."""
+    # Create two test shows
+    series1 = create_tvshow(indexer=1, indexerid=100, name='Show One')
+    series2 = create_tvshow(indexer=1, indexerid=200, name='Show Two')
+    
+    # Mock the database with scene exceptions for both shows
+    scene_exceptions_map = {
+        100: [{'indexer': 1, 'series_id': 100, 'season': 1, 'title': 'Exception One'}],
+        200: [{'indexer': 1, 'series_id': 200, 'season': 1, 'title': 'Exception Two'}]
+    }
+    
+    # Mock templates for both shows
+    all_templates = [
+        # Show 1 templates
+        {
+            'search_template_id': 101,
+            'template': '%SN S%0SE%0E',
+            'title': 'Show One',
+            'indexer': 1,
+            'series_id': 100,
+            'season': -1,
+            'enabled': 1,
+            'default': 1,
+            'season_search': 0
+        },
+        {
+            'search_template_id': 102,
+            'template': '%SN S%0SE%0E',
+            'title': 'Old Exception One',
+            'indexer': 1,
+            'series_id': 100,
+            'season': 2,
+            'enabled': 1,
+            'default': 1,  # Should be removed for show 1
+            'season_search': 0
+        },
+        # Show 2 templates
+        {
+            'search_template_id': 201,
+            'template': '%SN S%0SE%0E',
+            'title': 'Show Two',
+            'indexer': 1,
+            'series_id': 200,
+            'season': -1,
+            'enabled': 1,
+            'default': 1,
+            'season_search': 0
+        },
+        {
+            'search_template_id': 202,
+            'template': '%SN S%0SE%0E',
+            'title': 'Old Exception Two',
+            'indexer': 1,
+            'series_id': 200,
+            'season': 2,
+            'enabled': 1,
+            'default': 1,  # Should NOT be affected when cleaning show 1
+            'season_search': 0
+        }
+    ]
+    
+    deleted_ids = []
+    
+    def create_mock_action(series):
+        def mock_action(query, params):
+            """Mock the database action method to track deletions."""
+            if 'DELETE from search_templates' in query:
+                exceptions = scene_exceptions_map.get(series.series_id, [])
+                for template in all_templates:
+                    if (template['indexer'] == params[0] and
+                        template['series_id'] == params[1] and
+                        template['default'] == 1 and
+                        template['title'] not in [e['title'] for e in exceptions] and
+                        template['title'] != series.name):
+                        deleted_ids.append(template['search_template_id'])
+        return mock_action
+    
+    def create_mock_select(series):
+        def mock_select(query, params):
+            """Mock the database select method."""
+            if 'FROM search_templates' in query:
+                return [t for t in all_templates 
+                        if t['series_id'] == series.series_id and 
+                        t['search_template_id'] not in deleted_ids]
+            elif 'FROM scene_exceptions' in query:
+                return scene_exceptions_map.get(series.series_id, [])
+            return []
+        return mock_select
+    
+    # Test cleaning for series1
+    search_templates1 = SearchTemplates(series1)
+    monkeypatch.setattr(search_templates1.main_db_con, 'action', create_mock_action(series1))
+    monkeypatch.setattr(search_templates1.main_db_con, 'select', create_mock_select(series1))
+    
+    search_templates1.read_from_db()
+    
+    # Verify only show 1's orphaned template was deleted
+    assert 102 in deleted_ids, "Show 1's orphaned template should be removed"
+    assert 202 not in deleted_ids, "Show 2's template should not be affected"
+    
+    # Verify show 1's templates
+    template_ids1 = [t.id for t in search_templates1.templates]
+    assert 101 in template_ids1, "Show 1's name template should be in results"
+    assert 102 not in template_ids1, "Show 1's orphaned template should not be in results"
+    assert 201 not in template_ids1, "Show 2's templates should not appear for show 1"
+    assert 202 not in template_ids1, "Show 2's templates should not appear for show 1"

--- a/tests/test_search_templates.py
+++ b/tests/test_search_templates.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 """Tests for medusa.search_templates module."""
+from __future__ import unicode_literals
 
 from medusa.search_templates import SearchTemplates
 
@@ -310,3 +311,123 @@ def test_clean_with_multiple_shows(monkeypatch, create_tvshow):
     assert 102 not in template_ids1, "Show 1's orphaned template should not be in results"
     assert 201 not in template_ids1, "Show 2's templates should not appear for show 1"
     assert 202 not in template_ids1, "Show 2's templates should not appear for show 1"
+
+
+def test_update_saves_custom_template_without_scene_exception(monkeypatch, create_tvshow):
+    """Test that update() saves custom templates even when no matching scene exception exists."""
+    # Create a test show
+    series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
+    
+    # Mock the database to return NO scene exceptions
+    scene_exceptions = []
+    
+    # Track what gets saved via upsert
+    saved_templates = []
+    
+    def mock_upsert(table, new_values, control_values):
+        """Mock the database upsert method to track what gets saved."""
+        if table == 'search_templates':
+            saved_templates.append({
+                'title': new_values['title'],
+                'template': new_values['template'],
+                'default': new_values['`default`'],
+                'season': new_values['season'],
+                'enabled': new_values['enabled']
+            })
+    
+    def mock_action(query, params):
+        """Mock the database action method."""
+        pass  # Don't actually delete anything
+    
+    def mock_select(query, params):
+        """Mock the database select method."""
+        if 'FROM scene_exceptions' in query:
+            return scene_exceptions
+        return []
+    
+    # Create SearchTemplates instance and apply mocks
+    search_templates = SearchTemplates(series)
+    monkeypatch.setattr(search_templates.main_db_con, 'upsert', mock_upsert)
+    monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
+    monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
+    
+    # Create a custom template with a title that doesn't match any scene exception
+    custom_template = {
+        'id': None,
+        'template': '%SN S%0SE%0E custom',
+        'title': 'My Custom Title',  # This doesn't match any scene exception
+        'season': 1,
+        'enabled': True,
+        'default': 0,  # Custom template (default=0)
+        'seasonSearch': False
+    }
+    
+    # Call update with the custom template
+    result = search_templates.update([custom_template])
+    
+    # Verify the custom template was saved
+    assert len(saved_templates) == 1, "Custom template should be saved"
+    assert saved_templates[0]['title'] == 'My Custom Title', "Custom template title should match"
+    assert saved_templates[0]['default'] == 0, "Template should be marked as custom (default=0)"
+    
+    # Verify the template appears in self.templates
+    assert len(result) == 1, "Custom template should be in results"
+    assert result[0].title == 'My Custom Title', "Result template title should match"
+    assert not result[0].default, "Result template should be custom (default=False)"
+
+
+def test_update_skips_default_template_without_scene_exception(monkeypatch, create_tvshow):
+    """Test that update() skips default templates when no matching scene exception exists."""
+    # Create a test show
+    series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
+    
+    # Mock the database to return NO scene exceptions
+    scene_exceptions = []
+    
+    # Track what gets saved via upsert
+    saved_templates = []
+    
+    def mock_upsert(table, new_values, control_values):
+        """Mock the database upsert method to track what gets saved."""
+        if table == 'search_templates':
+            saved_templates.append({
+                'title': new_values['title'],
+                'template': new_values['template'],
+                'default': new_values['`default`'],
+            })
+    
+    def mock_action(query, params):
+        """Mock the database action method."""
+        pass  # Don't actually delete anything
+    
+    def mock_select(query, params):
+        """Mock the database select method."""
+        if 'FROM scene_exceptions' in query:
+            return scene_exceptions
+        return []
+    
+    # Create SearchTemplates instance and apply mocks
+    search_templates = SearchTemplates(series)
+    monkeypatch.setattr(search_templates.main_db_con, 'upsert', mock_upsert)
+    monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
+    monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
+    
+    # Create a default template with a title that doesn't match any scene exception or show name
+    default_template = {
+        'id': None,
+        'template': '%SN S%0SE%0E',
+        'title': 'Some Exception',  # This doesn't match any scene exception or show name
+        'season': 1,
+        'enabled': True,
+        'default': 1,  # Default template (default=1)
+        'seasonSearch': False
+    }
+    
+    # Call update with the default template
+    result = search_templates.update([default_template])
+    
+    # Verify the default template was NOT saved (because it has no matching scene exception)
+    assert len(saved_templates) == 0, "Default template without scene exception should not be saved"
+    
+    # Verify the template does NOT appear in self.templates
+    assert len(result) == 0, "Default template without scene exception should not be in results"

--- a/tests/test_search_templates.py
+++ b/tests/test_search_templates.py
@@ -7,13 +7,13 @@ from medusa.search_templates import SearchTemplates
 
 def _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids):
     """Create mock database functions for testing _clean() behavior.
-    
+
     Args:
         series: The show object being tested
         scene_exceptions: List of scene exception dicts for this show
         initial_templates: List of template dicts in the database
         deleted_ids: List to track which template IDs are deleted
-    
+
     Returns:
         Tuple of (mock_action, mock_select) functions
     """
@@ -27,7 +27,7 @@ def _create_mock_functions(series, scene_exceptions, initial_templates, deleted_
                     template['title'] not in [e['title'] for e in scene_exceptions] and
                     template['title'] != series.name):
                     deleted_ids.append(template['search_template_id'])
-    
+
     def mock_select(query, params):
         """Mock the database select method."""
         if 'FROM search_templates' in query:
@@ -35,7 +35,7 @@ def _create_mock_functions(series, scene_exceptions, initial_templates, deleted_
         elif 'FROM scene_exceptions' in query:
             return scene_exceptions
         return []
-    
+
     return mock_action, mock_select
 
 
@@ -43,7 +43,7 @@ def test_clean_preserves_custom_templates(monkeypatch, create_tvshow):
     """Test that _clean() preserves custom templates (default=0) even when titles don't match scene exceptions."""
     # Create a test show
     series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
-    
+
     # Mock the database to return scene exceptions (only one exception exists)
     scene_exceptions = [
         {
@@ -53,7 +53,7 @@ def test_clean_preserves_custom_templates(monkeypatch, create_tvshow):
             'title': 'Valid Exception'
         }
     ]
-    
+
     # Mock the initial templates in the database
     # Include both default and custom templates
     initial_templates = [
@@ -113,30 +113,30 @@ def test_clean_preserves_custom_templates(monkeypatch, create_tvshow):
             'season_search': 0
         }
     ]
-    
+
     deleted_ids = []
-    
+
     # Apply mocks
     search_templates = SearchTemplates(series)
     mock_action, mock_select = _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
-    
+
     # Execute read_from_db which calls _clean()
     search_templates.read_from_db()
-    
+
     # Verify results
     # Should have deleted template ID 3 (Old Exception - default template without scene exception)
     assert 3 in deleted_ids, "Default template 'Old Exception' should be removed"
-    
+
     # Should NOT have deleted template IDs 1, 2 (show name and valid exception)
     assert 1 not in deleted_ids, "Default template with show name should be preserved"
     assert 2 not in deleted_ids, "Default template with valid scene exception should be preserved"
-    
+
     # Should NOT have deleted template IDs 4, 5 (custom templates)
     assert 4 not in deleted_ids, "Custom template should be preserved"
     assert 5 not in deleted_ids, "Custom template without scene exception should still be preserved"
-    
+
     # Verify the templates list
     template_ids = [t.id for t in search_templates.templates]
     assert 1 in template_ids, "Show name template should be in results"
@@ -150,10 +150,10 @@ def test_clean_removes_default_templates_without_exceptions(monkeypatch, create_
     """Test that _clean() removes default templates when their scene exceptions are removed."""
     # Create a test show
     series = create_tvshow(indexer=1, indexerid=2, name='Another Show')
-    
+
     # Mock the database with NO scene exceptions
     scene_exceptions = []
-    
+
     # Mock the initial templates in the database
     initial_templates = [
         {
@@ -190,26 +190,26 @@ def test_clean_removes_default_templates_without_exceptions(monkeypatch, create_
             'season_search': 0
         }
     ]
-    
+
     deleted_ids = []
-    
+
     # Apply mocks
     search_templates = SearchTemplates(series)
     mock_action, mock_select = _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
-    
+
     # Execute read_from_db which calls _clean()
     search_templates.read_from_db()
-    
+
     # Verify results
     # Should have deleted template IDs 11 and 12 (removed exceptions)
     assert 11 in deleted_ids, "Default template 'Removed Exception 1' should be removed"
     assert 12 in deleted_ids, "Default template 'Removed Exception 2' should be removed"
-    
+
     # Should NOT have deleted template ID 10 (show name)
     assert 10 not in deleted_ids, "Default template with show name should be preserved"
-    
+
     # Verify the templates list
     template_ids = [t.id for t in search_templates.templates]
     assert 10 in template_ids, "Show name template should be in results"
@@ -222,13 +222,13 @@ def test_clean_with_multiple_shows(monkeypatch, create_tvshow):
     # Create two test shows
     series1 = create_tvshow(indexer=1, indexerid=100, name='Show One')
     series2 = create_tvshow(indexer=1, indexerid=200, name='Show Two')
-    
+
     # Mock the database with scene exceptions for both shows
     scene_exceptions_map = {
         100: [{'indexer': 1, 'series_id': 100, 'season': 1, 'title': 'Exception One'}],
         200: [{'indexer': 1, 'series_id': 200, 'season': 1, 'title': 'Exception Two'}]
     }
-    
+
     # Mock templates for both shows
     all_templates = [
         # Show 1 templates
@@ -278,33 +278,33 @@ def test_clean_with_multiple_shows(monkeypatch, create_tvshow):
             'season_search': 0
         }
     ]
-    
+
     deleted_ids = []
-    
+
     # Test cleaning for series1
     search_templates1 = SearchTemplates(series1)
     exceptions1 = scene_exceptions_map.get(series1.series_id, [])
     mock_action1, mock_select1 = _create_mock_functions(series1, exceptions1, all_templates, deleted_ids)
-    
+
     # Wrap mock_select to filter by series_id for multi-show scenario
     original_select = mock_select1
     def filtered_select(query, params):
         """Filter templates by series_id for multi-show tests."""
         if 'FROM search_templates' in query:
-            return [t for t in all_templates 
-                    if t['series_id'] == series1.series_id and 
+            return [t for t in all_templates
+                    if t['series_id'] == series1.series_id and
                     t['search_template_id'] not in deleted_ids]
         return original_select(query, params)
-    
+
     monkeypatch.setattr(search_templates1.main_db_con, 'action', mock_action1)
     monkeypatch.setattr(search_templates1.main_db_con, 'select', filtered_select)
-    
+
     search_templates1.read_from_db()
-    
+
     # Verify only show 1's orphaned template was deleted
     assert 102 in deleted_ids, "Show 1's orphaned template should be removed"
     assert 202 not in deleted_ids, "Show 2's template should not be affected"
-    
+
     # Verify show 1's templates
     template_ids1 = [t.id for t in search_templates1.templates]
     assert 101 in template_ids1, "Show 1's name template should be in results"
@@ -317,13 +317,13 @@ def test_update_saves_custom_template_without_scene_exception(monkeypatch, creat
     """Test that update() saves custom templates even when no matching scene exception exists."""
     # Create a test show
     series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
-    
+
     # Mock the database to return NO scene exceptions
     scene_exceptions = []
-    
+
     # Track what gets saved via upsert
     saved_templates = []
-    
+
     def mock_upsert(table, new_values, control_values):
         """Mock the database upsert method to track what gets saved."""
         if table == 'search_templates':
@@ -334,23 +334,23 @@ def test_update_saves_custom_template_without_scene_exception(monkeypatch, creat
                 'season': new_values['season'],
                 'enabled': new_values['enabled']
             })
-    
+
     def mock_action(query, params):
         """Mock the database action method."""
         pass  # Don't actually delete anything
-    
+
     def mock_select(query, params):
         """Mock the database select method."""
         if 'FROM scene_exceptions' in query:
             return scene_exceptions
         return []
-    
+
     # Create SearchTemplates instance and apply mocks
     search_templates = SearchTemplates(series)
     monkeypatch.setattr(search_templates.main_db_con, 'upsert', mock_upsert)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
-    
+
     # Create a custom template with a title that doesn't match any scene exception
     custom_template = {
         'id': None,
@@ -361,15 +361,15 @@ def test_update_saves_custom_template_without_scene_exception(monkeypatch, creat
         'default': 0,  # Custom template (default=0)
         'seasonSearch': False
     }
-    
+
     # Call update with the custom template
     result = search_templates.update([custom_template])
-    
+
     # Verify the custom template was saved
     assert len(saved_templates) == 1, "Custom template should be saved"
     assert saved_templates[0]['title'] == 'My Custom Title', "Custom template title should match"
     assert saved_templates[0]['default'] == 0, "Template should be marked as custom (default=0)"
-    
+
     # Verify the template appears in self.templates
     assert len(result) == 1, "Custom template should be in results"
     assert result[0].title == 'My Custom Title', "Result template title should match"
@@ -380,13 +380,13 @@ def test_update_skips_default_template_without_scene_exception(monkeypatch, crea
     """Test that update() skips default templates when no matching scene exception exists."""
     # Create a test show
     series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
-    
+
     # Mock the database to return NO scene exceptions
     scene_exceptions = []
-    
+
     # Track what gets saved via upsert
     saved_templates = []
-    
+
     def mock_upsert(table, new_values, control_values):
         """Mock the database upsert method to track what gets saved."""
         if table == 'search_templates':
@@ -395,23 +395,23 @@ def test_update_skips_default_template_without_scene_exception(monkeypatch, crea
                 'template': new_values['template'],
                 'default': new_values['`default`'],
             })
-    
+
     def mock_action(query, params):
         """Mock the database action method."""
         pass  # Don't actually delete anything
-    
+
     def mock_select(query, params):
         """Mock the database select method."""
         if 'FROM scene_exceptions' in query:
             return scene_exceptions
         return []
-    
+
     # Create SearchTemplates instance and apply mocks
     search_templates = SearchTemplates(series)
     monkeypatch.setattr(search_templates.main_db_con, 'upsert', mock_upsert)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
-    
+
     # Create a default template with a title that doesn't match any scene exception or show name
     default_template = {
         'id': None,
@@ -422,12 +422,12 @@ def test_update_skips_default_template_without_scene_exception(monkeypatch, crea
         'default': 1,  # Default template (default=1)
         'seasonSearch': False
     }
-    
+
     # Call update with the default template
     result = search_templates.update([default_template])
-    
+
     # Verify the default template was NOT saved (because it has no matching scene exception)
     assert len(saved_templates) == 0, "Default template without scene exception should not be saved"
-    
+
     # Verify the template does NOT appear in self.templates
     assert len(result) == 0, "Default template without scene exception should not be in results"

--- a/tests/test_search_templates.py
+++ b/tests/test_search_templates.py
@@ -4,7 +4,41 @@
 from medusa.search_templates import SearchTemplates
 
 
-def test_clean_preserves_custom_templates(monkeypatch, create_tvshow, monkeypatch_function_return):
+def _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids):
+    """Create mock database functions for testing _clean() behavior.
+    
+    Args:
+        series: The show object being tested
+        scene_exceptions: List of scene exception dicts for this show
+        initial_templates: List of template dicts in the database
+        deleted_ids: List to track which template IDs are deleted
+    
+    Returns:
+        Tuple of (mock_action, mock_select) functions
+    """
+    def mock_action(query, params):
+        """Mock the database action method to track deletions."""
+        if 'DELETE from search_templates' in query:
+            for template in initial_templates:
+                if (template['indexer'] == params[0] and
+                    template['series_id'] == params[1] and
+                    template['default'] == 1 and
+                    template['title'] not in [e['title'] for e in scene_exceptions] and
+                    template['title'] != series.name):
+                    deleted_ids.append(template['search_template_id'])
+    
+    def mock_select(query, params):
+        """Mock the database select method."""
+        if 'FROM search_templates' in query:
+            return [t for t in initial_templates if t['search_template_id'] not in deleted_ids]
+        elif 'FROM scene_exceptions' in query:
+            return scene_exceptions
+        return []
+    
+    return mock_action, mock_select
+
+
+def test_clean_preserves_custom_templates(monkeypatch, create_tvshow):
     """Test that _clean() preserves custom templates (default=0) even when titles don't match scene exceptions."""
     # Create a test show
     series = create_tvshow(indexer=1, indexerid=1, name='Test Show')
@@ -81,31 +115,9 @@ def test_clean_preserves_custom_templates(monkeypatch, create_tvshow, monkeypatc
     
     deleted_ids = []
     
-    def mock_action(query, params):
-        """Mock the database action method to track deletions."""
-        # Parse the DELETE query to understand what would be deleted
-        if 'DELETE from search_templates' in query:
-            # Simulate the deletion by tracking which templates would be deleted
-            for template in initial_templates:
-                if (template['indexer'] == params[0] and
-                    template['series_id'] == params[1] and
-                    template['default'] == 1 and  # Only default templates
-                    template['title'] not in [e['title'] for e in scene_exceptions] and
-                    template['title'] != series.name):
-                    deleted_ids.append(template['search_template_id'])
-    
-    def mock_select(query, params):
-        """Mock the database select method."""
-        if 'FROM search_templates' in query:
-            # Return templates that weren't deleted
-            return [t for t in initial_templates if t['search_template_id'] not in deleted_ids]
-        elif 'FROM scene_exceptions' in query:
-            # Return scene exceptions
-            return scene_exceptions
-        return []
-    
     # Apply mocks
     search_templates = SearchTemplates(series)
+    mock_action, mock_select = _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
     
@@ -180,27 +192,9 @@ def test_clean_removes_default_templates_without_exceptions(monkeypatch, create_
     
     deleted_ids = []
     
-    def mock_action(query, params):
-        """Mock the database action method to track deletions."""
-        if 'DELETE from search_templates' in query:
-            for template in initial_templates:
-                if (template['indexer'] == params[0] and
-                    template['series_id'] == params[1] and
-                    template['default'] == 1 and
-                    template['title'] not in [e['title'] for e in scene_exceptions] and
-                    template['title'] != series.name):
-                    deleted_ids.append(template['search_template_id'])
-    
-    def mock_select(query, params):
-        """Mock the database select method."""
-        if 'FROM search_templates' in query:
-            return [t for t in initial_templates if t['search_template_id'] not in deleted_ids]
-        elif 'FROM scene_exceptions' in query:
-            return scene_exceptions
-        return []
-    
     # Apply mocks
     search_templates = SearchTemplates(series)
+    mock_action, mock_select = _create_mock_functions(series, scene_exceptions, initial_templates, deleted_ids)
     monkeypatch.setattr(search_templates.main_db_con, 'action', mock_action)
     monkeypatch.setattr(search_templates.main_db_con, 'select', mock_select)
     
@@ -286,36 +280,23 @@ def test_clean_with_multiple_shows(monkeypatch, create_tvshow):
     
     deleted_ids = []
     
-    def create_mock_action(series):
-        def mock_action(query, params):
-            """Mock the database action method to track deletions."""
-            if 'DELETE from search_templates' in query:
-                exceptions = scene_exceptions_map.get(series.series_id, [])
-                for template in all_templates:
-                    if (template['indexer'] == params[0] and
-                        template['series_id'] == params[1] and
-                        template['default'] == 1 and
-                        template['title'] not in [e['title'] for e in exceptions] and
-                        template['title'] != series.name):
-                        deleted_ids.append(template['search_template_id'])
-        return mock_action
-    
-    def create_mock_select(series):
-        def mock_select(query, params):
-            """Mock the database select method."""
-            if 'FROM search_templates' in query:
-                return [t for t in all_templates 
-                        if t['series_id'] == series.series_id and 
-                        t['search_template_id'] not in deleted_ids]
-            elif 'FROM scene_exceptions' in query:
-                return scene_exceptions_map.get(series.series_id, [])
-            return []
-        return mock_select
-    
     # Test cleaning for series1
     search_templates1 = SearchTemplates(series1)
-    monkeypatch.setattr(search_templates1.main_db_con, 'action', create_mock_action(series1))
-    monkeypatch.setattr(search_templates1.main_db_con, 'select', create_mock_select(series1))
+    exceptions1 = scene_exceptions_map.get(series1.series_id, [])
+    mock_action1, mock_select1 = _create_mock_functions(series1, exceptions1, all_templates, deleted_ids)
+    
+    # Wrap mock_select to filter by series_id for multi-show scenario
+    original_select = mock_select1
+    def filtered_select(query, params):
+        """Filter templates by series_id for multi-show tests."""
+        if 'FROM search_templates' in query:
+            return [t for t in all_templates 
+                    if t['series_id'] == series1.series_id and 
+                    t['search_template_id'] not in deleted_ids]
+        return original_select(query, params)
+    
+    monkeypatch.setattr(search_templates1.main_db_con, 'action', mock_action1)
+    monkeypatch.setattr(search_templates1.main_db_con, 'select', filtered_select)
     
     search_templates1.read_from_db()
     


### PR DESCRIPTION
This pull request improves how search strings are generated for TV series episodes and seasons, especially when using custom search templates. The main change is that custom templates now strip the year from the series title in search queries, while default templates preserve it. The update also ensures that only default templates are cleaned up when scene exceptions are removed, and only default templates are validated against scene exceptions in the database. Comprehensive tests have been added to verify these behaviors.

Template handling improvements:

* Custom search templates now strip the year from the series title when generating search strings for episodes and seasons, while default templates retain the year. This is achieved by introducing the `get_title_without_year` helper and updating the logic in `GenericProvider._get_episode_search_strings` and `GenericProvider._get_season_search_strings`. [[1]](diffhunk://#diff-20bd3fcb964e966806e0e242d2576e8c13f2fbf58e0bffef2ff33d1aa0f53dbfR38) [[2]](diffhunk://#diff-20bd3fcb964e966806e0e242d2576e8c13f2fbf58e0bffef2ff33d1aa0f53dbfL681-R684) [[3]](diffhunk://#diff-20bd3fcb964e966806e0e242d2576e8c13f2fbf58e0bffef2ff33d1aa0f53dbfL724-R729)

* The cleanup logic in `SearchTemplates._clean` is updated to only remove default templates when their associated scene exception is no longer present, preserving custom templates.

* The update logic in `SearchTemplates.update` now always saves custom templates and only validates default templates against the database for the existence of a scene exception.

Testing enhancements:

* Extensive parameterized tests are added to `tests/providers/test_generic_provider.py` to verify episode and season search string generation with various combinations of default and custom templates, filtering by season, and template enable/disable states.Fix custom search templates not saved and year in search queries
Custom search templates not saved (fixes #11024, #11038)
Cause: Custom templates were filtered out by the scene exception check in update() and could be removed by _clean().
Changes in medusa/search_templates.py:
update(): Skip the scene exception check for custom templates (default=0). Only default templates are validated against scene_exceptions.
_clean(): Add AND \default\ = 1 so only default templates are deleted. Custom templates are left untouched.
Year in search queries (Append year to show title)
Cause: With "Append (year) to each show title" enabled, custom templates could get a title like "Show Name (2024)" from the UI. That value was used in provider search strings, but the year should only be used for folder creation and UI, not for search.
Changes in medusa/providers/generic_provider.py:
For custom search templates, use get_title_without_year() when building search strings.
Default templates still use the original title; their titles already come from series.name without a year.
Applied for both episode and season search templates.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
