### PR TITLE
Changing found_required_word filtering from OR to AND

### DIFF
--- a/medusa/search/core.py
+++ b/medusa/search/core.py
@@ -11,6 +11,7 @@ import operator
 import os
 import threading
 import time
+import re
 
 from medusa import (
     app,
@@ -317,7 +318,8 @@ def filter_results(results):
         ignored_words = series_obj.show_words().ignored_words
         required_words = series_obj.show_words().required_words
         found_ignored_word = naming.contains_at_least_one_word(cur_result.name, ignored_words)
-        found_required_word = naming.contains_at_least_one_word(cur_result.name, required_words)
+        name_lower = cur_result.name.lower()
+        found_required_word = all(re.search(rf'\b{re.escape(word.lower())}\b', name_lower) for word in required_words)
 
         if ignored_words and found_ignored_word:
             log.info(u'Ignoring {0} based on ignored words filter: {1}', cur_result.name, found_ignored_word)


### PR DESCRIPTION
Trying to download some specific multi-audio anime i run into incosistent results so i made this change to significantly improve the search precision by requiring all keywords to be present as distinct words, eliminating inconsistent matches.

Strict Matching: Replaced contains_at_least_one_word with an all() condition to ensure every required word is present in the result name before validation.

Word Boundaries: Implemented regex with \b anchors to ensure we match whole words only, preventing false positives from partial string matches (e.g. "cat" matching "category").

Normalization & Safety: Added case-insensitive matching via .lower() and used re.escape() to safely handle any special characters within the required words list.

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
