### PR TITLE
Fix qbittorrent 5.2.0 compatability, pkgutil error in python 3.14

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -101,21 +101,27 @@ class QBittorrentAPI(GenericClient):
                         {'name': self.name, 'error': error}, exc_info=1)
             return None
 
-        if not self.response:
+        if self.response is None:
             log.warning('{name}: Could not connect, check your config',
                         {'name': self.name})
             return None
 
-        if self.response.status_code == 200:
+        if self.response.status_code in (200, 204):
             if self.response.text == 'Fails.':
                 log.warning('{name}: Invalid Username or Password, check your config',
                             {'name': self.name})
                 return None
 
-            # Successful log in
-            self.auth = self.response.text
+            # Successful log in. qBittorrent WebAPI 2.14.0 no longer returns
+            # "Ok."; preserve the legacy auth value when it exists.
+            self.auth = self.response.text or True
 
             return self.auth
+
+        if self.response.status_code == 401:
+            log.warning('{name}: Invalid Username or Password, check your config',
+                        {'name': self.name})
+            return None
 
         if self.response.status_code == 404:
             # API v2 is not available

--- a/medusa/server/api/v2/config.py
+++ b/medusa/server/api/v2/config.py
@@ -3,9 +3,9 @@
 from __future__ import unicode_literals
 
 import datetime
+import importlib.util
 import inspect
 import logging
-import pkgutil
 import platform
 import sys
 from random import choice
@@ -1262,7 +1262,7 @@ class DataGenerator(object):
         section_data['specificProcessMethod'] = bool(app.USE_SPECIFIC_PROCESS_METHOD)
         section_data['processMethodTorrent'] = app.PROCESS_METHOD_TORRENT
         section_data['processMethodNzb'] = app.PROCESS_METHOD_NZB
-        section_data['reflinkAvailable'] = bool(pkgutil.find_loader('reflink'))
+        section_data['reflinkAvailable'] = importlib.util.find_spec('reflink') is not None
         section_data['autoPostprocessorFrequency'] = int(app.AUTOPOSTPROCESSOR_FREQUENCY)
         section_data['syncFiles'] = app.SYNC_FILES
         section_data['fileTimestampTimezone'] = app.FILE_TIMESTAMP_TIMEZONE

--- a/tests/apiv2/test_config.py
+++ b/tests/apiv2/test_config.py
@@ -3,8 +3,8 @@
 from __future__ import unicode_literals
 
 import datetime
+import importlib.util
 import json
-import pkgutil
 import platform
 import sys
 
@@ -442,7 +442,7 @@ def config_postprocessing():
     section_data['specificProcessMethod'] = bool(app.USE_SPECIFIC_PROCESS_METHOD)
     section_data['processMethodTorrent'] = app.PROCESS_METHOD_TORRENT
     section_data['processMethodNzb'] = app.PROCESS_METHOD_NZB
-    section_data['reflinkAvailable'] = bool(pkgutil.find_loader('reflink'))
+    section_data['reflinkAvailable'] = importlib.util.find_spec('reflink') is not None
     section_data['autoPostprocessorFrequency'] = int(app.AUTOPOSTPROCESSOR_FREQUENCY)
     section_data['syncFiles'] = app.SYNC_FILES
     section_data['fileTimestampTimezone'] = app.FILE_TIMESTAMP_TIMEZONE

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -8,6 +8,114 @@ from medusa.clients.torrent.qbittorrent import QBittorrentAPI
 import pytest
 
 
+def test_auth_v2_empty_204_response_is_success(requests_mock):
+    # Given
+    requests_mock.post('http://localhost/api/v2/auth/login', text='', status_code=204)
+    requests_mock.get('http://localhost/api/v2/app/webapiVersion', text='2.14.0')
+
+    # When
+    client = QBittorrentAPI(host='http://localhost')
+
+    # Then
+    assert client.auth is True
+    assert client.api == (2, 14, 0)
+
+
+def test_auth_v2_legacy_ok_response_is_success(requests_mock):
+    # Given
+    requests_mock.post('http://localhost/api/v2/auth/login', text='Ok.', status_code=200)
+    requests_mock.get('http://localhost/api/v2/app/webapiVersion', text='2.13.1')
+
+    # When
+    client = QBittorrentAPI(host='http://localhost')
+
+    # Then
+    assert client.auth == 'Ok.'
+    assert client.api == (2, 13, 1)
+
+
+def test_auth_v2_legacy_fails_response_is_invalid_credentials(requests_mock):
+    # Given
+    requests_mock.post('http://localhost/api/v2/auth/login', text='Fails.', status_code=200)
+
+    # When
+    client = QBittorrentAPI(host='http://localhost')
+
+    # Then
+    assert client.auth is None
+    assert client.api is None
+
+
+def test_auth_v2_401_response_is_invalid_credentials(requests_mock):
+    # Given
+    requests_mock.post('http://localhost/api/v2/auth/login', text='', status_code=401)
+
+    # When
+    client = QBittorrentAPI(host='http://localhost')
+
+    # Then
+    assert client.auth is None
+    assert client.api is None
+
+
+def test_add_torrent_uri_accepts_async_response(requests_mock, monkeypatch):
+    # Given
+    class Series(object):
+        is_anime = False
+
+    class Result(object):
+        url = 'magnet:?xt=urn:btih:aabbcc'
+        series = Series()
+
+    monkeypatch.setattr('medusa.app.TORRENT_PATH', '')
+    monkeypatch.setattr('medusa.app.TORRENT_LABEL', '')
+
+    requests_mock.post('http://localhost/api/v2/auth/login', text='', status_code=200)
+    requests_mock.get('http://localhost/api/v2/app/webapiVersion', text='2.14.0')
+    client = QBittorrentAPI(host='http://localhost')
+    client.api = (2, 14, 0)
+    requests_mock.post(
+        'http://localhost/api/v2/torrents/add',
+        json={
+            'success_count': 0,
+            'failure_count': 0,
+            'pending_count': 1,
+            'added_torrent_ids': [],
+        },
+        status_code=202,
+    )
+
+    # When
+    actual = client._add_torrent_uri(Result())
+
+    # Then
+    assert actual is True
+
+
+def test_add_torrent_uri_accepts_legacy_ok_response(requests_mock, monkeypatch):
+    # Given
+    class Series(object):
+        is_anime = False
+
+    class Result(object):
+        url = 'magnet:?xt=urn:btih:aabbcc'
+        series = Series()
+
+    monkeypatch.setattr('medusa.app.TORRENT_PATH', '')
+    monkeypatch.setattr('medusa.app.TORRENT_LABEL', '')
+
+    requests_mock.post('http://localhost/api/v2/auth/login', text='Ok.', status_code=200)
+    requests_mock.get('http://localhost/api/v2/app/webapiVersion', text='2.13.1')
+    client = QBittorrentAPI(host='http://localhost')
+    requests_mock.post('http://localhost/api/v2/torrents/add', text='Ok.', status_code=200)
+
+    # When
+    actual = client._add_torrent_uri(Result())
+
+    # Then
+    assert actual is True
+
+
 @pytest.mark.parametrize('p', [
     {  # p0
         'method': 'properties',

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -57,6 +57,18 @@ def test_auth_v2_401_response_is_invalid_credentials(requests_mock):
     assert client.auth is None
     assert client.api is None
 
+def test_auth_v2_404_falls_back_to_legacy_api(requests_mock):
+    # Given
+    requests_mock.post('http://localhost/api/v2/auth/login', status_code=404)
+    requests_mock.post('http://localhost/login', status_code=200)
+    requests_mock.get('http://localhost/version/api', text='17')
+
+    # When
+    client = QBittorrentAPI(host='http://localhost')
+
+    # Then
+    assert client.auth is True
+    assert client.api == (1, 17, 0)
 
 def test_add_torrent_uri_accepts_async_response(requests_mock, monkeypatch):
     # Given

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -57,6 +57,7 @@ def test_auth_v2_401_response_is_invalid_credentials(requests_mock):
     assert client.auth is None
     assert client.api is None
 
+
 def test_auth_v2_404_falls_back_to_legacy_api(requests_mock):
     # Given
     requests_mock.post('http://localhost/api/v2/auth/login', status_code=404)
@@ -69,6 +70,7 @@ def test_auth_v2_404_falls_back_to_legacy_api(requests_mock):
     # Then
     assert client.auth is True
     assert client.api == (1, 17, 0)
+
 
 def test_add_torrent_uri_accepts_async_response(requests_mock, monkeypatch):
     # Given


### PR DESCRIPTION
- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)

adds compatability with newest qbittorrent 5.2.0, while also resolving in authentication success on 5.1.4

fixes error when launching pymedusa on python 3.14