### PR TITLE
Fix Plex .plexmatch episode paths to be relative

### DIFF
--- a/medusa/metadata/plex.py
+++ b/medusa/metadata/plex.py
@@ -170,7 +170,7 @@ class PlexMetadata(generic.GenericMetadata):
 
         # Add the location for the new episode.
         if ep_obj.series.location in ep_obj.location and ep_obj.location.replace(ep_obj.series.location, ''):
-            location = ep_obj.location.replace(ep_obj.series.location, '')
+            location = os.path.relpath(ep_obj.location, ep_obj.series.location).replace(os.path.sep, '/')
             if location:
                 if ep_obj.season == 0:
                     episodes.append(f'sp: {ep_obj.episode:02d}: {location}')


### PR DESCRIPTION
Plex expects paths in a series-level .plexmatch file to be relative to the show folder. (Ref: https://support.plex.tv/articles/plexmatch/)

Before this change, Medusa generated entries like:

ep: s01e01: /Season 1/file.mkv

That leading slash prevents Plex from matching the file correctly in some cases.

This changes the generated path to use os.path.relpath(), then normalizes separators to forward slashes for Plex compatibility.

Example output after this fix:

ep: s01e01: Season 1/file.mkv