### PR TITLE
Add the original info URL to the release object stored for Newznab/Torznab search results

### DIFF
--- a/medusa/classes.py
+++ b/medusa/classes.py
@@ -59,6 +59,8 @@ class SearchResult(object):
         self.episodes = None
         # URL to the NZB/torrent file
         self.url = ''
+        # URL to the release info page on the indexer (from Newznab/Torznab <comments>)
+        self.info_url = ''
         # used by some providers to store extra info associated with the result
         self.extra_info = []
         # quality of the release
@@ -273,6 +275,7 @@ class SearchResult(object):
         self._create_episode_objects()
 
         self.name, self.url = self.provider._get_title_and_url(self.item)
+        self.info_url = self.provider._get_info_url(self.item)
         self.seeders, self.leechers = self.provider._get_result_info(self.item)
         self.size = self.provider._get_size(self.item)
         self.pubdate = self.provider._get_pubdate(self.item)
@@ -311,6 +314,7 @@ class SearchResult(object):
         cached_result = self.cache
         self.episodes = self._episodes_from_cache()
         self.url = cached_result['url']
+        self.info_url = cached_result['info_url'] or ''
         self.quality = int(cached_result['quality'])
         self.name = cached_result['name']
         self.size = int(cached_result['size'])

--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -757,6 +757,12 @@ class GenericProvider(object):
         """
         return None
 
+    def _get_info_url(self, item):
+        """Return the per-release info page URL when the parser provides one."""
+        if not item:
+            return ''
+        return item.get('info_url', '') or ''
+
     def _get_title_and_url(self, item):
         """Return title and url from result."""
         if not item:

--- a/medusa/providers/nzb/newznab.py
+++ b/medusa/providers/nzb/newznab.py
@@ -249,11 +249,16 @@ class NewznabProvider(NZBProvider):
                     pubdate_raw = item.pubdate.get_text(strip=True)
                     pubdate = self.parse_pubdate(pubdate_raw)
 
+                    info_url = ''
+                    if item.comments:
+                        info_url = item.comments.get_text(strip=True)
+
                     item = {
                         'title': title,
                         'link': download_url,
                         'size': size,
                         'pubdate': pubdate,
+                        'info_url': info_url,
                     }
                     if mode != 'RSS':
                         log.debug('Found result: {0}', title)

--- a/medusa/providers/torrent/torznab/torznab.py
+++ b/medusa/providers/torrent/torznab/torznab.py
@@ -213,6 +213,10 @@ class TorznabProvider(TorrentProvider):
                     pubdate_raw = item.pubdate.get_text(strip=True)
                     pubdate = self.parse_pubdate(pubdate_raw)
 
+                    info_url = ''
+                    if item.comments:
+                        info_url = item.comments.get_text(strip=True)
+
                     item = {
                         'title': title,
                         'link': download_url,
@@ -220,6 +224,7 @@ class TorznabProvider(TorrentProvider):
                         'seeders': seeders,
                         'leechers': leechers,
                         'pubdate': pubdate,
+                        'info_url': info_url,
                     }
                     if mode != 'RSS':
                         log.debug('Found result: {0} with {1} seeders and {2} leechers',

--- a/medusa/server/api/v2/providers.py
+++ b/medusa/server/api/v2/providers.py
@@ -89,6 +89,7 @@ class ProvidersHandler(BaseRequestHandler):
                         'seriesId': item['indexerid'],
                         'showSlug': show_slug,
                         'url': item['url'],
+                        'infoUrl': item['info_url'] or None,
                         'time': datetime.fromtimestamp(item['time']),
                         'quality': item['quality'],
                         'releaseGroup': item['release_group'],

--- a/medusa/tv/cache.py
+++ b/medusa/tv/cache.py
@@ -56,6 +56,7 @@ class CacheDBConnection(db.DBConnection):
                     '    indexer NUMERIC,'
                     '    indexerid NUMERIC,'
                     '    url TEXT,'
+                    '    info_url TEXT,'
                     '    time NUMERIC,'
                     '    quality NUMERIC,'
                     '    release_group TEXT,'
@@ -96,6 +97,7 @@ class CacheDBConnection(db.DBConnection):
                 ('proper_tags', 'TEXT', None),
                 ('date_added', 'NUMERIC', 0),
                 ('indexer', 'NUMERIC', None),
+                ('info_url', 'TEXT', None),
             )
             for column, data_type, default in table:
                 # add columns to table if missing
@@ -436,6 +438,7 @@ class Cache(object):
 
             identifier = self._get_identifier(search_result)
             url = search_result.url
+            info_url = search_result.info_url
             seeders = search_result.seeders
             leechers = search_result.leechers
             size = search_result.size
@@ -445,13 +448,13 @@ class Cache(object):
                 log.debug('Added item: {0} to cache: {1} with url: {2}', name, self.provider_id, url)
                 return [
                     'INSERT INTO [{name}] '
-                    '   (identifier, name, season, episodes, indexerid, url, time, quality, '
+                    '   (identifier, name, season, episodes, indexerid, url, info_url, time, quality, '
                     '    release_group, version, seeders, leechers, size, pubdate, '
                     '    proper_tags, date_added, indexer ) '
-                    'VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)'.format(
+                    'VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)'.format(
                         name=self.provider_id
                     ),
-                    [identifier, name, season, episode_text, parsed_result.series.series_id, url,
+                    [identifier, name, season, episode_text, parsed_result.series.series_id, url, info_url,
                      cur_timestamp, quality, release_group, version,
                      seeders, leechers, size, pubdate, proper_tags, cur_timestamp, parsed_result.series.indexer]
                 ]
@@ -459,13 +462,13 @@ class Cache(object):
                 log.debug('Updating item: {0} to cache: {1}', name, self.provider_id)
                 return [
                     'UPDATE [{name}] '
-                    'SET name=?, url=?, season=?, episodes=?, indexer=?, indexerid=?, '
+                    'SET name=?, url=?, info_url=?, season=?, episodes=?, indexer=?, indexerid=?, '
                     '    time=?, quality=?, release_group=?, version=?, '
                     '    seeders=?, leechers=?, size=?, pubdate=?, proper_tags=? '
                     'WHERE identifier=?'.format(
                         name=self.provider_id
                     ),
-                    [name, url, season, episode_text, parsed_result.series.indexer, parsed_result.series.series_id,
+                    [name, url, info_url, season, episode_text, parsed_result.series.indexer, parsed_result.series.series_id,
                      cur_timestamp, quality, release_group, version,
                      seeders, leechers, size, pubdate, proper_tags, identifier]
                 ]


### PR DESCRIPTION
Hi team! I wanted to contribute this feature I have created while working on my alternative React-based client for Medusa.

## Motivation

When picking between candidates in a manual search, users often want to open a release on the indexer's site to check the file list or see bundled subtitles. Today Medusa exposes only the download URL on cached results, so a frontend can let you snatch a release but not preview it.

This information is already available to use: Newznab and Torznab XML responses include a `<comments>` element pointing to the release's info page.

I considered recovering the URL on the frontend by rewriting the download URL or querying the configured Prowlarr server at `/api/v1/search` but the solution would be sub-optimal and end up as a half-assed fix rather than a good feature. Plumbing `<comments>` through the API to the DB is the smallest change with the broadest reach: every Newznab/Torznab provider gets a real per-release info link with no extra requests.

## Changes

A new `info_url` follows the same path `url` does today:

- `SearchResult` (`medusa/classes.py`) gains an `info_url` attribute, populated from the parser on live results and from the cache row on reload.
- `GenericProvider._get_info_url` reads `item['info_url']` by default — any provider whose `parse()` adds that key gets piped through automatically.
- Newznab and Torznab parsers extract `<comments>` into the item dict.
- Provider cache table (`medusa/tv/cache.py`) gains an `info_url TEXT` column. New installs get it from `CREATE TABLE`; existing tables pick it up via the same auto-add-column loop
  already handling `release_group`, `proper_tags`, etc. — no DB migration version bump. INSERT/UPDATE persist it alongside `url`.
- `/api/v2/providers/<id>/results` exposes the field as `infoUrl`, returning `null` for rows written before the column existed so consumers fall back gracefully.

## Test plan

- Confirmed the column is added on new installs and via the auto-migration loop on existing ones.
- Manual searches against a Newznab and a Prowlarr-fronted indexer both populate `info_url`; the Prowlarr-fronted case points to the upstream tracker domain, not the Prowlarr host.
- Pre-migration cache rows return `infoUrl: null` without errors.

_No existing issue tracking this but happy to file one if the maintainers would prefer a reference_

- [x] PR is based on the DEVELOP branch
- [x] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [x] Read the [contribution guide](https://github.com/pymedusa/Medusa/blob/master/.github/CONTRIBUTING.md)
