### PR TITLE
fix: match non-standard manual search releases by episode title

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -15,6 +15,8 @@ from os.path import join
 
 from dateutil import parser, tz
 
+import guessit
+
 from medusa import (
     app,
     config,
@@ -44,6 +46,11 @@ from medusa.name_parser.parser import (
     NameParser,
 )
 from medusa.search import FORCED_SEARCH, PROPER_SEARCH
+from medusa.search.release_matcher import (
+    ReleaseMatcher,
+    extract_strong_numbering,
+    has_explicit_non_video_extension,
+)
 from medusa.session.core import ProviderSession
 from medusa.show.show import Show
 
@@ -245,6 +252,103 @@ class GenericProvider(object):
         """
         return self.cache.find_episodes(episodes)
 
+    @staticmethod
+    def _use_contextual_matching(manual_search, episodes, search_mode, manual_search_type):
+        return (
+            manual_search
+            and len(episodes) == 1
+            and search_mode == 'eponly'
+            and manual_search_type == 'episode'
+        )
+
+    @staticmethod
+    def _apply_parsed_result_to_search_result(search_result, parsed_result):
+        search_result.parsed_result = parsed_result
+        search_result.series = parsed_result.series
+        search_result.quality = parsed_result.quality
+        search_result.release_group = parsed_result.release_group
+        search_result.version = parsed_result.version
+        search_result.actual_season = parsed_result.season_number
+        search_result.actual_episodes = parsed_result.episode_numbers
+
+    @staticmethod
+    def _build_minimal_parse_result(release_name, series):
+        guess = guessit.guessit(
+            release_name,
+            dict(show_type='anime' if series.is_anime else 'normal')
+        )
+        parser = NameParser(series=series)
+        result = parser.to_parse_result(release_name, guess)
+        result.series = series
+        return result
+
+    def _apply_contextual_manual_parse(self, search_result, series, target_episode):
+        """Parse and match a release for a single-episode manual search."""
+        parse_method = ('normal', 'anime')[series.is_anime]
+        release_name = search_result.name
+
+        if has_explicit_non_video_extension(release_name):
+            log.debug(
+                'Rejected release because the filename extension is not a supported video type: {release_name}',
+                {'release_name': release_name}
+            )
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        parsed_result = None
+        strict_succeeded = False
+        try:
+            parsed_result = NameParser(parse_method=parse_method).parse(release_name)
+            strict_succeeded = True
+        except (InvalidNameException, InvalidShowException) as error:
+            log.debug(
+                'Strict release parsing failed: {release_name}, with error: {error}',
+                {'release_name': release_name, 'error': error}
+            )
+
+        reliable = extract_strong_numbering(release_name)
+        if strict_succeeded and reliable:
+            strong_season, strong_episodes = reliable
+            if strong_season == target_episode.season and target_episode.episode in strong_episodes:
+                self._apply_parsed_result_to_search_result(search_result, parsed_result)
+                return True
+
+            log.debug(
+                'Rejected release because explicit numbering conflicts with the requested episode: {release_name}',
+                {'release_name': release_name}
+            )
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        advisory_parsed = None
+        try:
+            advisory_parsed = NameParser(
+                series=series,
+                parse_method=parse_method,
+            ).parse(
+                release_name,
+                cache_result=False,
+                use_cache=False,
+            )
+        except (InvalidNameException, InvalidShowException):
+            advisory_parsed = self._build_minimal_parse_result(release_name, series)
+
+        matcher = ReleaseMatcher(series, [target_episode])
+        match = matcher.match(release_name, advisory_parsed)
+
+        if not match.matched:
+            search_result.add_cache_entry = False
+            search_result.result_wanted = False
+            return False
+
+        advisory_parsed.series = series
+        advisory_parsed.season_number = match.season
+        advisory_parsed.episode_numbers = match.episodes
+        self._apply_parsed_result_to_search_result(search_result, advisory_parsed)
+        return True
+
     def find_search_results(self, series, episodes, search_mode, forced_search=False, download_current_quality=False,
                             manual_search=False, manual_search_type='episode'):
         """
@@ -293,6 +397,10 @@ class GenericProvider(object):
         # sort qualities in descending order
         results.sort(key=operator.attrgetter('quality'), reverse=True)
 
+        use_contextual_matching = self._use_contextual_matching(
+            manual_search, episodes, search_mode, manual_search_type
+        )
+
         # Move through each item and parse with NameParser()
         for search_result in results:
 
@@ -301,25 +409,25 @@ class GenericProvider(object):
             search_result.download_current_quality = download_current_quality
             search_result.result_wanted = True
 
-            try:
-                search_result.parsed_result = NameParser(
-                    parse_method=('normal', 'anime')[series.is_anime]).parse(
-                        search_result.name)
-            except (InvalidNameException, InvalidShowException) as error:
-                log.debug('Error during parsing of release name: {release_name}, with error: {error}',
-                          {'release_name': search_result.name, 'error': error})
-                search_result.add_cache_entry = False
-                search_result.result_wanted = False
-                continue
+            if use_contextual_matching:
+                if not self._apply_contextual_manual_parse(
+                        search_result, series, episodes[0]):
+                    continue
+            else:
+                try:
+                    search_result.parsed_result = NameParser(
+                        parse_method=('normal', 'anime')[series.is_anime]
+                    ).parse(search_result.name)
+                except (InvalidNameException, InvalidShowException) as error:
+                    log.debug(
+                        'Error during parsing of release name: {release_name}, with error: {error}',
+                        {'release_name': search_result.name, 'error': error}
+                    )
+                    search_result.add_cache_entry = False
+                    search_result.result_wanted = False
+                    continue
 
-            # I don't know why i'm doing this. Maybe remove it later on all together, now i've added the parsed_result
-            # to the search_result.
-            search_result.series = search_result.parsed_result.series
-            search_result.quality = search_result.parsed_result.quality
-            search_result.release_group = search_result.parsed_result.release_group
-            search_result.version = search_result.parsed_result.version
-            search_result.actual_season = search_result.parsed_result.season_number
-            search_result.actual_episodes = search_result.parsed_result.episode_numbers
+                self._apply_parsed_result_to_search_result(search_result, search_result.parsed_result)
 
             if not manual_search:
                 if not (search_result.series.air_by_date or search_result.series.sports):

--- a/medusa/search/release_matcher.py
+++ b/medusa/search/release_matcher.py
@@ -1,0 +1,311 @@
+# coding=utf-8
+"""Contextual release matching for manual episode search."""
+
+from __future__ import unicode_literals
+
+import logging
+import os
+import re
+import unicodedata
+
+from medusa import scene_exceptions
+from medusa.logger.adapters.style import BraceAdapter
+
+from six import text_type
+
+log = BraceAdapter(logging.getLogger(__name__))
+log.logger.addHandler(logging.NullHandler())
+
+MIN_EPISODE_TITLE_LENGTH = 3
+
+STRONG_EPISODE_PATTERNS = [
+    re.compile(
+        r'\bS(?P<season>\d{1,2})[ ._-]*E(?P<episode>\d{1,3})\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\b(?P<season>\d{1,2})x(?P<episode>\d{1,3})\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\bseason[ ._-]*(?P<season>\d+).*?episode[ ._-]*(?P<episode>\d+)\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\bsaison[ ._-]*(?P<season>\d+).*?episode[ ._-]*(?P<episode>\d+)\b',
+        re.IGNORECASE,
+    ),
+]
+
+SEASON_PACK_PATTERNS = [
+    re.compile(r'\bs(?P<season>\d{1,2})[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bseason[ ._-]*(?P<season>\d+)[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bsaison[ ._-]*(?P<season>\d+)[ ._-]*complete\b', re.IGNORECASE),
+    re.compile(r'\bseason[ ._-]*pack\b', re.IGNORECASE),
+]
+
+VIDEO_EXTENSIONS = {
+    '.mkv', '.mp4', '.avi', '.mpg', '.mpeg', '.m4v',
+    '.mov', '.wmv', '.ts', '.m2ts', '.webm',
+}
+
+NON_VIDEO_EXTENSIONS = {
+    '.jpg', '.jpeg', '.png', '.gif', '.bmp', '.webp',
+    '.nfo', '.sfv', '.txt', '.url', '.exe', '.com', '.bat',
+    '.srt', '.sub', '.idx', '.rar', '.zip', '.7z',
+}
+
+
+class ReleaseMatch(object):
+    """Result of contextual release matching."""
+
+    __slots__ = ('matched', 'season', 'episodes', 'method', 'reason')
+
+    def __init__(self, matched=False, season=None, episodes=None, method=None, reason=None):
+        self.matched = matched
+        self.season = season
+        self.episodes = episodes or []
+        self.method = method
+        self.reason = reason
+
+
+def normalize_release_text(text):
+    """Normalize text for token-sequence comparison."""
+    if not text:
+        return ''
+
+    text = unicodedata.normalize('NFKD', text_type(text))
+    text = ''.join(ch for ch in text if not unicodedata.combining(ch))
+    text = text.replace("'", ' ').replace('\u2019', ' ').replace('`', ' ')
+    text = text.casefold()
+    text = re.sub(r'[\[\](){}]+', ' ', text)
+    text = re.sub(r'[._\-]+', ' ', text)
+    text = re.sub(r'\s+', ' ', text).strip()
+    return text
+
+
+def normalize_to_tokens(text):
+    """Return normalized whitespace-delimited tokens."""
+    normalized = normalize_release_text(text)
+    if not normalized:
+        return []
+    return normalized.split(' ')
+
+
+def tokens_contain_sequence(haystack_tokens, needle_tokens):
+    """Return True when needle_tokens appear as a contiguous token subsequence."""
+    if not needle_tokens:
+        return False
+
+    if len(needle_tokens) > len(haystack_tokens):
+        return False
+
+    width = len(needle_tokens)
+    for index in range(len(haystack_tokens) - width + 1):
+        if haystack_tokens[index:index + width] == needle_tokens:
+            return True
+    return False
+
+
+def extract_strong_numbering(release_name):
+    """Extract season and episode from reliable TV numbering patterns."""
+    for pattern in STRONG_EPISODE_PATTERNS:
+        match = pattern.search(release_name)
+        if match:
+            return int(match.group('season')), [int(match.group('episode'))]
+    return None
+
+
+def is_explicit_season_pack(release_name):
+    """Return True when the release name explicitly indicates a season pack."""
+    return any(pattern.search(release_name) for pattern in SEASON_PACK_PATTERNS)
+
+
+def has_explicit_non_video_extension(release_name):
+    """Return True when the release name ends with a known non-video extension."""
+    _, extension = os.path.splitext(release_name.lower().strip())
+    return extension in NON_VIDEO_EXTENSIONS
+
+
+def has_video_extension(release_name):
+    """Return True when the release name ends with a known video extension."""
+    _, extension = os.path.splitext(release_name.lower().strip())
+    return extension in VIDEO_EXTENSIONS
+
+
+def guessit_episode_numbers(parsed_result):
+    if not parsed_result:
+        return []
+
+    episodes = parsed_result.episode_numbers or []
+    if episodes:
+        return list(episodes)
+
+    guess = getattr(parsed_result, 'guess', None) or {}
+    return list(guess.get('episode') or [])
+
+
+def _series_candidate_names(series, target_episode):
+    names = {series.name}
+    try:
+        for exception_set in scene_exceptions.get_all_scene_exceptions(series).values():
+            for title_exception in exception_set:
+                names.add(title_exception.title)
+        for title_exception in scene_exceptions.get_season_scene_exceptions(series, target_episode.season):
+            names.add(title_exception.title)
+    except (AttributeError, TypeError):
+        pass
+    return names
+
+
+def _duplicate_episode_titles(series, normalized_title, target_episode):
+    """Return episodes sharing the same normalized title as the target."""
+    duplicates = []
+    try:
+        all_episodes = series.get_all_episodes()
+    except (AttributeError, TypeError):
+        return duplicates
+
+    for episode in all_episodes:
+        if normalize_release_text(episode.name) != normalized_title:
+            continue
+        if episode.season == target_episode.season and episode.episode == target_episode.episode:
+            continue
+        duplicates.append(episode)
+    return duplicates
+
+
+class ReleaseMatcher(object):
+    """Match a provider release to a manually requested episode."""
+
+    def __init__(self, series, requested_episodes):
+        self.series = series
+        self.requested_episodes = requested_episodes or []
+        self.target_episode = self.requested_episodes[0] if len(self.requested_episodes) == 1 else None
+        self._series_token_candidates = []
+        if self.target_episode is not None:
+            for name in _series_candidate_names(series, self.target_episode):
+                tokens = normalize_to_tokens(name)
+                if tokens:
+                    self._series_token_candidates.append(tokens)
+
+    def matches_series(self, release_name):
+        """Return True when a known series alias appears as a token subsequence."""
+        release_tokens = normalize_to_tokens(release_name)
+        if not release_tokens:
+            return False
+
+        for candidate_tokens in self._series_token_candidates:
+            if tokens_contain_sequence(release_tokens, candidate_tokens):
+                return True
+        return False
+
+    def match(self, release_name, parsed_result=None):
+        """Decide whether the release matches the requested episode."""
+        if self.target_episode is None:
+            return ReleaseMatch(matched=False, reason='implicit_season_pack')
+
+        if has_explicit_non_video_extension(release_name):
+            log.debug(
+                'Rejected release because the filename extension is not a supported video type: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='episode_title_not_found')
+
+        if is_explicit_season_pack(release_name):
+            log.debug(
+                'Rejected unnumbered release instead of treating it as a season pack: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='implicit_season_pack')
+
+        if not self.matches_series(release_name):
+            log.debug(
+                'Rejected release because the series name was not found: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='series_not_found')
+
+        target = self.target_episode
+        strong = extract_strong_numbering(release_name)
+        guess_episodes = guessit_episode_numbers(parsed_result)
+        normalized_title = normalize_release_text(target.name)
+        title_tokens = normalize_to_tokens(target.name)
+        release_tokens = normalize_to_tokens(release_name)
+        title_present = (
+            len(normalized_title) >= MIN_EPISODE_TITLE_LENGTH
+            and tokens_contain_sequence(release_tokens, title_tokens)
+        )
+
+        if strong:
+            strong_season, strong_episodes = strong
+            strong_episode = strong_episodes[0]
+            if strong_season == target.season and strong_episode == target.episode:
+                log.info(
+                    'Matched release using explicit season and episode numbering: {release_name}',
+                    {'release_name': release_name}
+                )
+                return ReleaseMatch(
+                    matched=True,
+                    season=target.season,
+                    episodes=[target.episode],
+                    method='explicit_numbering',
+                    reason='explicit_numbering',
+                )
+
+            if title_present:
+                log.debug(
+                    'Rejected release because explicit numbering conflicts with the requested episode: {release_name}',
+                    {'release_name': release_name}
+                )
+                return ReleaseMatch(matched=False, reason='explicit_number_conflict')
+
+            log.debug(
+                'Rejected release because explicit numbering conflicts with the requested episode: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='explicit_number_conflict')
+
+        if not title_present:
+            if guess_episodes:
+                log.debug(
+                    'Rejected release because weak numbering was found without a title match: {release_name}',
+                    {'release_name': release_name}
+                )
+            else:
+                log.debug(
+                    'Rejected release because no unique episode-title match was found: {release_name}',
+                    {'release_name': release_name}
+                )
+            return ReleaseMatch(matched=False, reason='episode_title_not_found')
+
+        if len(normalized_title) < MIN_EPISODE_TITLE_LENGTH:
+            return ReleaseMatch(matched=False, reason='episode_title_not_found')
+
+        if _duplicate_episode_titles(self.series, normalized_title, target):
+            log.debug(
+                'Rejected release because the episode title is ambiguous: {release_name}',
+                {'release_name': release_name}
+            )
+            return ReleaseMatch(matched=False, reason='ambiguous_episode_title')
+
+        if guess_episodes:
+            log.debug(
+                'Ignored weak episode number extracted from release suffix: {release_name}',
+                {'release_name': release_name}
+            )
+            method = 'weak_number_ignored'
+        else:
+            method = 'episode_title'
+
+        log.info(
+            'Matched release using the requested episode title: {release_name}',
+            {'release_name': release_name}
+        )
+        return ReleaseMatch(
+            matched=True,
+            season=target.season,
+            episodes=[target.episode],
+            method=method,
+            reason=method,
+        )

--- a/tests/search/__init__.py
+++ b/tests/search/__init__.py
@@ -1,0 +1,1 @@
+# coding=utf-8

--- a/tests/search/test_release_matcher.py
+++ b/tests/search/test_release_matcher.py
@@ -1,0 +1,229 @@
+# coding=utf-8
+"""Tests for contextual release matching."""
+
+from __future__ import unicode_literals
+
+from mock.mock import Mock, patch
+
+import pytest
+
+from medusa.providers.generic_provider import GenericProvider
+from medusa.search.release_matcher import (
+    ReleaseMatcher,
+    extract_strong_numbering,
+    is_explicit_season_pack,
+    normalize_release_text,
+    normalize_to_tokens,
+    tokens_contain_sequence,
+)
+
+
+SHOW_NAME = 'Alpha Chronicle'
+OTHER_SHOW = 'Beta Chronicle'
+EPISODE_TITLE = 'First Contact'
+OTHER_EPISODE_TITLE = 'Second Wave'
+
+
+def _episode(season, episode, name):
+    ep = Mock()
+    ep.season = season
+    ep.episode = episode
+    ep.name = name
+    return ep
+
+
+def _series(name, episodes):
+    series = Mock()
+    series.name = name
+    series.is_anime = False
+    series.get_all_episodes.return_value = episodes
+    return series
+
+
+def _matcher(series, episodes):
+    return ReleaseMatcher(series, episodes)
+
+
+@pytest.fixture
+def alpha_series():
+    return _series(SHOW_NAME, [
+        _episode(1, 1, EPISODE_TITLE),
+        _episode(1, 2, OTHER_EPISODE_TITLE),
+    ])
+
+
+@pytest.fixture
+def alpha_matcher(alpha_series):
+    return _matcher(alpha_series, [_episode(1, 1, EPISODE_TITLE)])
+
+
+def test_normalize_and_token_sequence():
+    assert normalize_release_text("Alpha Chronicle") == 'alpha chronicle'
+    assert normalize_to_tokens('[Uploader] Alpha.Chronicle') == ['uploader', 'alpha', 'chronicle']
+    assert tokens_contain_sequence(['alpha', 'chronicle', 'first', 'contact'], ['alpha', 'chronicle']) is True
+    assert tokens_contain_sequence(['beta', 'chronicle'], ['alpha', 'chronicle']) is False
+
+
+def test_extract_strong_numbering():
+    assert extract_strong_numbering('Alpha.Chronicle.S01E02.Title') == (1, [2])
+    assert extract_strong_numbering('Alpha.Chronicle.1x02.Title') == (1, [2])
+    assert extract_strong_numbering('Alpha.Chronicle.site-1--group') is None
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_explicit_numbering_match(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.S01E01.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'explicit_numbering'
+    assert match.episodes == [1]
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_explicit_numbering_without_title(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.S01E01.1080p.WEB.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'explicit_numbering'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_explicit_numbering_conflict(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.S01E02.First.Contact.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'explicit_number_conflict'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_title_match_without_numbering(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.-.Segment.-.First.Contact.-.suffix.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'episode_title'
+    assert match.season == 1
+    assert match.episodes == [1]
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_prefix_before_series_title(_season_exc, _all_exc, alpha_matcher):
+    release = '[Uploader] Alpha.Chronicle.-.First.Contact.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is True
+    assert match.method == 'episode_title'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_suffix_after_episode_title(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.-.First.Contact.-.website-1--group.mkv'
+    parsed = Mock()
+    parsed.episode_numbers = [1]
+    parsed.guess = {'episode': [1]}
+    match = alpha_matcher.match(release, parsed_result=parsed)
+    assert match.matched is True
+    assert match.method == 'weak_number_ignored'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_weak_number_without_title_rejected(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.-.website-1--group.mkv'
+    parsed = Mock()
+    parsed.episode_numbers = [1]
+    parsed.guess = {'episode': [1]}
+    match = alpha_matcher.match(release, parsed_result=parsed)
+    assert match.matched is False
+    assert match.reason == 'episode_title_not_found'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_other_series_rejected(_season_exc, _all_exc):
+    series = _series(OTHER_SHOW, [_episode(1, 1, EPISODE_TITLE)])
+    matcher = _matcher(series, [_episode(1, 1, EPISODE_TITLE)])
+    release = 'Beta.Chronicle.-.First.Contact.mkv'
+    assert matcher.matches_series(release) is True
+    matcher = _matcher(_series(SHOW_NAME, [_episode(1, 1, EPISODE_TITLE)]), [_episode(1, 1, EPISODE_TITLE)])
+    match = matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'series_not_found'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_duplicate_episode_titles_rejected(_season_exc, _all_exc):
+    episodes = [
+        _episode(1, 1, 'Shared Title'),
+        _episode(2, 1, 'Shared Title'),
+    ]
+    series = _series(SHOW_NAME, episodes)
+    matcher = _matcher(series, [episodes[0]])
+    release = 'Alpha.Chronicle.-.Shared.Title.mkv'
+    match = matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'ambiguous_episode_title'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_short_series_title_not_matched_inside_unrelated_word(_season_exc, _all_exc):
+    series = _series('Go', [_episode(1, 1, EPISODE_TITLE)])
+    matcher = _matcher(series, [_episode(1, 1, EPISODE_TITLE)])
+    release = 'Dragon.-.First.Contact.mkv'
+    assert matcher.matches_series(release) is False
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_unresolved_release_not_season_pack(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.-.Unrelated.Segment.mkv'
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'episode_title_not_found'
+
+
+@patch('medusa.search.release_matcher.scene_exceptions.get_all_scene_exceptions', return_value={})
+@patch('medusa.search.release_matcher.scene_exceptions.get_season_scene_exceptions', return_value=[])
+def test_explicit_season_pack_marker_rejected_for_single_episode(_season_exc, _all_exc, alpha_matcher):
+    release = 'Alpha.Chronicle.Season.1.Complete.mkv'
+    assert is_explicit_season_pack(release) is True
+    match = alpha_matcher.match(release)
+    assert match.matched is False
+    assert match.reason == 'implicit_season_pack'
+
+
+def test_contextual_matching_gate():
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'eponly', 'episode') is True
+    assert GenericProvider._use_contextual_matching(True, [Mock(), Mock()], 'eponly', 'episode') is False
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'sponly', 'episode') is False
+    assert GenericProvider._use_contextual_matching(True, [Mock()], 'eponly', 'season') is False
+    assert GenericProvider._use_contextual_matching(False, [Mock()], 'eponly', 'episode') is False
+
+
+def test_non_manual_path_uses_strict_parser_only():
+    search_result = Mock()
+    search_result.name = 'Alpha.Chronicle.S01E01.mkv'
+    search_result.add_cache_entry = True
+    search_result.result_wanted = True
+
+    series = Mock()
+    series.is_anime = False
+
+    parsed = Mock()
+    parsed.series = series
+    parsed.quality = 1
+    parsed.release_group = 'GROUP'
+    parsed.version = -1
+    parsed.season_number = 1
+    parsed.episode_numbers = [1]
+
+    provider = GenericProvider('TestProvider')
+    with patch('medusa.providers.generic_provider.NameParser') as parser_cls:
+        parser_cls.return_value.parse.return_value = parsed
+        assert provider._use_contextual_matching(False, [Mock()], 'eponly', 'episode') is False


### PR DESCRIPTION
## Summary

Add contextual release matching for single-episode manual searches when provider results use non-standard release names.

Some valid results contain the series and episode titles but do not include reliable SxxExx or 1x01 numbering. They may also contain prefixes, suffixes, or unrelated numeric tokens that GuessIt interprets as episode numbers.

Previously, these results were rejected during strict release parsing and never appeared in the manual search results.

## Changes

- Add a contextual `ReleaseMatcher` for manual single-episode searches.
- Keep the existing strict `NameParser` path as the primary matching method.
- Fall back to normalized series and episode-title matching when strict parsing fails or only weak numbering is detected.
- Distinguish explicit TV numbering from unrelated numeric suffixes.
- Reject releases when explicit numbering conflicts with the requested episode.
- Prevent unresolved individual releases from being treated as implicit season packs.
- Keep automatic, backlog, daily, proper, season, post-processing, and library-scan behavior unchanged.
- Add focused tests for normalization, explicit and weak numbering, title matching, conflicts, ambiguity, media validation, and contextual-matching gates.

## Matching rules

The contextual fallback is limited to:

- manual searches;
- one requested episode;
- episode search mode;
- manual search type episode.

Reliable explicit numbering remains authoritative.

When reliable numbering is absent, a result may be associated with the requested episode only when:

- the current series name or a known scene alias is identified;
- the requested episode title has a unique normalized match;
- no reliable explicit numbering contradicts the requested episode.

## Tests

51 passed

Executed:

```
python -m pytest \
  tests/search/test_release_matcher.py \
  tests/providers/test_generic_provider.py \
  tests/name_parser/test_parse_series.py \
  -q
```

Additional validation:

```
python -m compileall \
  medusa/search/release_matcher.py \
  medusa/providers/generic_provider.py
```

```
git diff --check
```

Manual runtime validation confirmed that:

- non-standard provider results are displayed in manual search;
- weak numeric suffixes are ignored when the episode-title match is unique;
- the selected result is associated only with the requested episode;
- explicit conflicting numbering is rejected.

## Scope

This PR intentionally does not change:

- global `NameParser._parse_series()` behavior;
- automatic or backlog matching;
- parser cache keys;
- torrent file-content inspection;
- the secondary `update_cache_manual_search` logging behavior.

Fixes #12219