### PR TITLE
fix: coerce qBittorrent progress fields when API returns strings

### DIFF
--- a/medusa/clients/torrent/qbittorrent.py
+++ b/medusa/clients/torrent/qbittorrent.py
@@ -450,11 +450,16 @@ class QBittorrentAPI(GenericClient):
         # if torrent['ratio'] >= torrent['max_ratio']:
         #     client_status.set_status_string('Seeded')
 
-        # Store ratio
-        client_status.ratio = torrent['ratio'] * 1.0
+        # Store ratio (API may return numbers as strings depending on client/proxy)
+        client_status.ratio = float(torrent['ratio'])
 
-        # Store progress
-        client_status.progress = int(torrent['downloaded'] / torrent['size'] * 100) if torrent['size'] else 0
+        # Store progress. Prefer the API progress field (0.0-1.0); fall back to downloaded/size.
+        # Coerce to float: some qBittorrent setups return these fields as strings.
+        if torrent.get('progress') is not None:
+            client_status.progress = int(float(torrent['progress']) * 100)
+        else:
+            size = float(torrent['size'] or 0)
+            client_status.progress = int(float(torrent['downloaded']) / size * 100) if size else 0
 
         # Store destination
         client_status.destination = torrent['save_path']

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -294,6 +294,55 @@ def test_get_status_unknown_state_does_not_raise():
     assert status.progress == 0
 
 
+def test_get_status_coerces_string_numeric_fields():
+    # Given — some qBittorrent setups return numeric fields as strings
+    info_hash = 'aabbccdd'
+    torrent = {
+        'hash': info_hash,
+        'state': 'downloading',
+        'ratio': '1.5',
+        'downloaded': '250',
+        'size': '1000',
+        'save_path': '/downloads',
+        'content_path': '/downloads/show.mkv',
+    }
+
+    client = _make_qbittorrent_client()
+    client._get_torrents = lambda **kwargs: [torrent]
+
+    # When
+    status = client.get_status(info_hash)
+
+    # Then
+    assert str(status) == 'Downloading'
+    assert status.ratio == 1.5
+    assert status.progress == 25
+
+
+def test_get_status_uses_progress_field_when_present():
+    # Given
+    info_hash = 'aabbccdd'
+    torrent = {
+        'hash': info_hash,
+        'state': 'downloading',
+        'ratio': 0.5,
+        'progress': 0.42,
+        'downloaded': 'unused',
+        'size': 'unused',
+        'save_path': '/downloads',
+        'content_path': '/downloads/show.mkv',
+    }
+
+    client = _make_qbittorrent_client()
+    client._get_torrents = lambda **kwargs: [torrent]
+
+    # When
+    status = client.get_status(info_hash)
+
+    # Then
+    assert status.progress == 42
+
+
 def test_torrent_completed(requests_mock):
     # Given
     requests_mock.post(

--- a/tests/clients/qbittorrent.py
+++ b/tests/clients/qbittorrent.py
@@ -343,6 +343,30 @@ def test_get_status_uses_progress_field_when_present():
     assert status.progress == 42
 
 
+def test_get_status_coerces_string_progress():
+    # Given
+    info_hash = 'aabbccdd'
+    torrent = {
+        'hash': info_hash,
+        'state': 'downloading',
+        'ratio': '0.6',
+        'progress': '0.43',
+        'downloaded': 'unused',
+        'size': 'unused',
+        'save_path': '/downloads',
+        'content_path': '/downloads/show.mkv',
+    }
+
+    client = _make_qbittorrent_client()
+    client._get_torrents = lambda **kwargs: [torrent]
+
+    # When
+    status = client.get_status(info_hash)
+
+    # Then
+    assert status.progress == 43
+
+
 def test_torrent_completed(requests_mock):
     # Given
     requests_mock.post(


### PR DESCRIPTION
## Summary
- Coerce `ratio`, `downloaded`, `size`, and `progress` to float in the qBittorrent client `get_status()` path.
- Prefer the API `progress` field (0.0–1.0) when present; fall back to `downloaded / size`.
- Fixes `TypeError: unsupported operand type(s) for /: 'str' and 'str'` when talking to qBittorrent-compatible proxies such as aMuTorrent, which return numeric fields as strings.

## Scope
- `medusa/clients/torrent/qbittorrent.py`
- `tests/clients/qbittorrent.py`

## Validation
- `pytest tests/clients/qbittorrent.py` — 26 passed
- Live check against aMuTorrent: DOWNLOADHANDLER updates torrent status without TypeError

## Risk
- Low: defensive numeric coercion only in status reporting; real qBittorrent still returns numbers and behaves the same.

## Rollback
- Revert this commit.