### PR TITLE
fix: avoid double spaces, trailing NBSP, and glued apostrophes in naming

### DIFF
--- a/medusa/helper/common.py
+++ b/medusa/helper/common.py
@@ -300,9 +300,18 @@ def sanitize_filename(filename):
     :return: The cleaned ``filename``
     """
     if isinstance(filename, (str, text_type)):
+        # Treat non-breaking spaces like regular spaces so strip/collapse work.
+        filename = filename.replace(u'\u00a0', ' ')
+
+        # Smart colon replacement (Sonarr-style): avoid "Title  Subtitle" when
+        # removing "Title : Subtitle". See pymedusa/Medusa#12244.
+        filename = filename.replace(': ', ' - ')
+        filename = filename.replace(':', '-')
+
         # https://stackoverflow.com/a/31976060/7597273
+        # Colon is handled above; keep the remaining Windows-forbidden set here.
         remove = r''.join((
-            r':"<>|?',
+            r'"<>|?',
             r'™',  # Trade Mark Sign [unicode: \u2122]
             r'\t',  # Tab
             r'\x00-\x1f',  # Null & Control characters
@@ -311,6 +320,8 @@ def sanitize_filename(filename):
 
         filename = re.sub(r'[\\/\*]', '-', filename)
         filename = re.sub(remove, '', filename)
+        # Collapse spaces left behind by removed punctuation (e.g. trailing '?').
+        filename = re.sub(r' +', ' ', filename)
         # Filenames cannot end in a space or dot on Windows systems
         filename = filename.strip(' .')
 

--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1503,6 +1503,11 @@ class Episode(TV):
         ep_name = self.__ep_name()
 
         def dot(name):
+            # Replace apostrophes with a separator before scene sanitization so
+            # French elisions stay readable (L'émission -> L.émission) without
+            # changing sanitize_scene_name used by search/name cache (#12244).
+            if name:
+                name = name.replace("'", '.').replace(u'\u2019', '.')
             return helpers.sanitize_scene_name(name)
 
         def us(name):

--- a/tests/helper/test_common.py
+++ b/tests/helper/test_common.py
@@ -221,11 +221,18 @@ def test_replace_extension(p):
     ('', ''),
     ('filename', 'filename'),
     ('fi\\le/na*me', 'fi-le-na-me'),
-    ('fi:le"na<me', 'filename'),
+    ('fi:le"na<me', 'fi-lename'),
     ('fi>le|na?me', 'filename'),
     (' . file\u2122name. .', 'filename'),
     (' . file\tname. .', 'filename'),
     (' . file\x00as\x08df\x1fname. .', 'fileasdfname'),
+    # smart colon / whitespace (#12244)
+    ('Alien theory : Les preuves ultimes', 'Alien theory - Les preuves ultimes'),
+    ('Star Trek:Voyager', 'Star Trek-Voyager'),
+    ('dictature du futur\u00a0?', 'dictature du futur'),
+    ('Au bout de l\'enquete, la fin du crime parfait ?',
+     'Au bout de l\'enquete, la fin du crime parfait'),
+    ('Title  with   spaces', 'Title with spaces'),
 ])
 def test_sanitize_filename(value, expected):
     # Given

--- a/tests/test_naming_specialchars.py
+++ b/tests/test_naming_specialchars.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+"""Tests for episode filename naming with special characters (#12244)."""
+from __future__ import unicode_literals
+
+from datetime import date
+
+from medusa.common import Quality
+
+import pytest
+
+
+@pytest.fixture
+def make_episode(create_tvshow, create_tvepisode, app_config):
+    def _make(show_name, ep_name):
+        app_config('NAMING_STRIP_YEAR', True)
+        app_config('NAMING_MULTI_EP', 1)
+        app_config('NAMING_ANIME', 3)
+        app_config('NAMING_CUSTOM_ANIME', False)
+        app_config('UNKNOWN_RELEASE_GROUP', 'Medusa')
+        show = create_tvshow(
+            indexerid=1, name=show_name, air_by_date=False, sports=False,
+            anime=False, season_folders=1,
+        )
+        ep = create_tvepisode(
+            series=show, season=1, episode=1, name=ep_name,
+            airdate=date(2025, 1, 15), quality=Quality.FULLHDWEBDL,
+            release_group='GROUP', release_name='', is_proper=False,
+            absolute_number=0, scene_season=1, scene_episode=1,
+            scene_absolute_number=0,
+        )
+        ep.related_episodes = []
+        return ep
+    return _make
+
+
+@pytest.mark.parametrize('show_name,ep_name,pattern,expected', [
+    # Apostrophe becomes a separator in dotted tokens (not glued).
+    (
+        "C'est pas sorcier",
+        "L'\xe9mission de janvier",
+        '%S.N.S%0SE%0E.%E.N',
+        'C.est.pas.sorcier.S01E01.L.\xe9mission.de.janvier',
+    ),
+    (
+        'Le journal du hard',
+        "Et si la peur n\u2019existait pas ?",
+        '%S.N.S%0SE%0E.%E.N',
+        'Le.journal.du.hard.S01E01.Et.si.la.peur.n.existait.pas',
+    ),
+    # Plain tokens keep the apostrophe; colon/question use sanitize_filename.
+    (
+        'Alien theory : Les preuves ultimes',
+        'Titre normal',
+        '%SN - S%0SE%0E - %EN',
+        'Alien theory - Les preuves ultimes - S01E01 - Titre normal',
+    ),
+])
+def test_formatted_filename_special_chars(make_episode, show_name, ep_name, pattern, expected):
+    episode = make_episode(show_name, ep_name)
+    assert episode.formatted_filename(pattern=pattern) == expected
+
+
+def test_sanitize_scene_name_unchanged_for_search():
+    """Search/name-cache must keep deleting apostrophes (scene style)."""
+    from medusa.helpers import sanitize_scene_name
+    assert sanitize_scene_name("C'est pas sorcier") == 'Cest.pas.sorcier'
+    assert sanitize_scene_name("L'\xe9mission") == 'L\xe9mission'


### PR DESCRIPTION
## Summary
- Fix `sanitize_filename` to use Sonarr-style colon replacement, treat NBSP as a normal space, and collapse leftover spaces so show folders no longer get double spaces (e.g. `Alien theory : Title` -> `Alien theory - Title`).
- In dotted naming tokens (`%S.N` / `%E.N`), replace apostrophes with a separator before scene sanitization so French elisions stay readable (`L'émission` -> `L.émission`) without changing `sanitize_scene_name` used by search/name cache.
- Extend unit tests for filename sanitization and add naming coverage for special characters.

## Scope
- `medusa/helper/common.py`
- `medusa/tv/episode.py` (`dot()` only)
- `tests/helper/test_common.py`
- `tests/test_naming_specialchars.py`

## Validation
- `pytest tests/helper/test_common.py::test_sanitize_filename tests/test_naming_specialchars.py -q` — 20 passed

## Risk
- Existing on-disk folders that already contain double spaces will not be migrated automatically; rename/move would only happen if the user reorganizes shows.
- Dotted English possessives change from `Bobs.Burgers` to `Bob.s.Burgers` in filenames only (search matching unchanged).

## Rollback
- Revert this PR / commit.

Fixes #12244