### PR TITLE
Exclude season 0 specials from next/prev episode lookup

### DIFF
--- a/medusa/tv/series.py
+++ b/medusa/tv/series.py
@@ -1846,6 +1846,7 @@ class Series(TV):
             '  AND showid = ? '
             '  AND airdate < ? '
             '  AND status <> ? '
+            '  AND season > 0 '
             'ORDER BY'
             '  airdate '
             'DESC LIMIT 1',
@@ -1885,6 +1886,7 @@ class Series(TV):
             '  indexer = ?'
             '  AND showid = ? '
             '  AND airdate >= ? '
+            '  AND season > 0 '
             'ORDER BY airdate ',
             [self.indexer, self.series_id, today - 1])
 


### PR DESCRIPTION
## Summary
- `Series.next_episode()` / `Series.prev_episode()` had no `season > 0` filter, so a season-0 entry (TVDB shorts/specials) with a nearby airdate could be returned as the show's next/previous episode — surfacing on the show list as a misleading "Next Ep" date pointing at an unrelated special.
- Specials are already excluded from normal episode tracking elsewhere (`episode_updater.py`: "specials are not supported") — this applies the same exclusion to these two lookups.

## Repro (before fix)
Show with a season-0 short airing soon but no real next-season episode scheduled — `next_airdate` picks the short instead of returning nothing. Concrete example in the linked issue (The Simpsons: real last episode S37E15 aired 2026-02-15, but "Next Ep" showed 2026-07-26 — the airdate of `S00E80 "Yellow Mirror"`, a promotional short with status Skipped).

## Test plan
- [x] Verified against a live instance: before the fix, `GET /api/v2/series/{slug}` returned `nextAirDate` matching a season-0 special's airdate for a show with no real upcoming episode. After the fix (with a full app restart to pick up the change), `nextAirDate` correctly returns `null`, and `prevAirDate` correctly reflects the last real numbered episode instead of a special.
- Minimal, targeted diff — two `AND season > 0` clauses added to the existing `WHERE` clauses, no other behavior changed.

Fixes #12250