### PR TITLE
Pass timeout through to cloudscraper.get_tokens() to prevent indefinite search hangs

### DIFF
--- a/medusa/session/handlers.py
+++ b/medusa/session/handlers.py
@@ -42,7 +42,9 @@ def cloudflare(session, resp, **kwargs):
         original_request = resp.request
 
         # Get the Cloudflare tokens and original user-agent
-        tokens, user_agent = cf.cloudscraper.get_tokens(original_request.url)
+        # Pass the timeout through explicitly - get_tokens() otherwise makes an
+        # unbounded request that can hang the calling thread indefinitely.
+        tokens, user_agent = cf.cloudscraper.get_tokens(original_request.url, timeout=kwargs.get('timeout', 30))
 
         # Add Cloudflare tokens to the session cookies
         session.cookies.update(tokens)


### PR DESCRIPTION
## Summary
- Fixes #12254 — manual/forced/backlog provider searches could hang for minutes with no timeout, because the Cloudflare challenge-bypass path called `cloudscraper.get_tokens()` with no timeout at all.
- `medusa/session/handlers.py::cloudflare()` already receives `timeout` via `**kwargs` (forwarded from `MedusaSession.request()`, and used later in the same function for the retry request) — this just forwards it to the `get_tokens()` call too, so the challenge-solve step is bounded by the same timeout as every other request.

## Root cause
1. Every provider session is created with `cloudflare=True` (`medusa/providers/generic_provider.py`).
2. `MedusaSession.request()` applies `timeout=30` to the initial request, then calls `handlers.cloudflare(self, response, timeout=timeout, ...)` if `self.cloudflare` is set.
3. If the response looks like a Cloudflare IUAM/CAPTCHA challenge, `handlers.cloudflare()` calls `cf.cloudscraper.get_tokens(original_request.url)` with no kwargs, so this request (and the challenge-solve round trip within it) has no timeout ceiling.
4. Observed live: manual searches for a specific episode repeatedly froze for 2-4 minutes right after picking a result, on a different provider each time (consistent with Cloudflare's adaptive bot detection rather than one dead provider), and reproduced identically after a clean process restart (ruling out stuck threads/locks).

## Test plan
- [x] Deployed to a live instance, restarted the process, confirmed the module loads without error
- [ ] Maintainers: confirm `get_tokens()`'s accepted kwargs pass through cleanly to a bounded timeout in all cloudscraper versions currently pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)