### PR TITLE
Fix Torrenting provider: adapt to site restructure and handle empty results

### DIFF
--- a/medusa/providers/torrent/html/torrenting.py
+++ b/medusa/providers/torrent/html/torrenting.py
@@ -32,7 +32,7 @@ class TorrentingProvider(TorrentProvider):
         self.url = 'https://www.torrenting.com/'
         self.urls = {
             'login': urljoin(self.url, 'login.php'),
-            'search': urljoin(self.url, 'browse.php'),
+            'search': urljoin(self.url, 't'),
         }
 
         # Proper Strings
@@ -61,11 +61,7 @@ class TorrentingProvider(TorrentProvider):
 
         # Search Params
         search_params = {
-            'c4': 1,  # TV/SD-x264
-            'c5': 1,  # TV/X264 HD
-            'c18': 1,  # TV/Packs
-            'c49': 1,  # x265 (HEVC)
-            'search': '',
+            'q': '',
         }
 
         for mode in search_strings:
@@ -76,7 +72,7 @@ class TorrentingProvider(TorrentProvider):
                 if mode != 'RSS':
                     log.debug('Search string: {search}',
                               {'search': search_string})
-                    search_params['search'] = search_string
+                    search_params['q'] = search_string
 
                 response = self.session.get(self.urls['search'], params=search_params)
                 if not response or not response.text:
@@ -99,7 +95,7 @@ class TorrentingProvider(TorrentProvider):
         items = []
 
         with BS4Parser(data, 'html5lib') as html:
-            torrent_table = html.find('table', {'id': 'torrentsTable'})
+            torrent_table = html.find('table', {'class': 't1'})
             torrent_rows = torrent_table.find_all('tr') if torrent_table else []
 
             # Continue only if at least one release is found
@@ -111,14 +107,18 @@ class TorrentingProvider(TorrentProvider):
             for row in torrent_rows[1:]:
                 try:
                     torrent_items = row.find_all('td')
+                    if len(torrent_items) < 8:
+                        # Row doesn't contain a torrent, e.g. the
+                        # "No Torrents Found!" placeholder row.
+                        continue
                     title = torrent_items[1].find('a').get_text(strip=True)
-                    download_url = torrent_items[2].find('a')['href']
+                    download_url = torrent_items[3].find('a')['href']
                     if not all([title, download_url]):
                         continue
                     download_url = urljoin(self.url, download_url)
 
-                    seeders = try_int(torrent_items[5].get_text(strip=True))
-                    leechers = try_int(torrent_items[6].get_text(strip=True))
+                    seeders = try_int(torrent_items[6].get_text(strip=True))
+                    leechers = try_int(torrent_items[7].get_text(strip=True))
 
                     # Filter unseeded torrent
                     if seeders < self.minseed:
@@ -128,10 +128,12 @@ class TorrentingProvider(TorrentProvider):
                                       title, seeders)
                         continue
 
-                    torrent_size = torrent_items[4].get_text()
+                    torrent_size = torrent_items[5].get_text()
                     size = convert_size(torrent_size) or -1
 
-                    pubdate_raw = torrent_items[1].find('div').get_text()
+                    pubdate_div = torrent_items[1].find('div')
+                    pubdate_text = pubdate_div.get_text() if pubdate_div else ''
+                    pubdate_raw = pubdate_text.split('|')[-1].strip() if '|' in pubdate_text else pubdate_text
                     pubdate = self.parse_pubdate(pubdate_raw, human_time=True)
 
                     item = {


### PR DESCRIPTION
## Summary
- torrenting.com restructured their search page at some point (new `/t` endpoint with a `q` query param, `table.t1` result table, shifted column indices) — the provider's `search()`/`parse()` were still written against the old `browse.php` + `#torrentsTable` layout and had already been patched locally to track the new site; this commit formalizes that update upstream.
- Fixes a separate `IndexError` that fires on **every** zero-result search: torrenting.com's "no results" response still renders a 2-row table (header + a single-cell "No Torrents Found!" placeholder row), so the existing `len(torrent_rows) < 2` guard never catches it. Execution falls through to indexing into the placeholder row's single `<td>`, raising `IndexError: list index out of range`, which is caught by the broad `except` a few lines down but logged as a full ERROR-level "Failed parsing provider" traceback. This happens very frequently in practice (e.g. any backlog/manual/PROPER search that legitimately finds nothing on this provider), and shows up as pure log noise since it's already handled gracefully and doesn't affect search results.

## Test plan
- Verified against the live site: fetched both a real search result page and a deliberately-empty-result search page, confirmed the "No Torrents Found!" row has 1 `<td>` vs. 8 `<td>`s on a real torrent row.
- Deployed to a running Medusa instance and re-ran a manual search for an episode that previously triggered this exact traceback (confirmed via logs) — search now completes cleanly with "Unable to find manual results" and no ERROR-level traceback.
- Confirmed normal (non-empty) searches on this provider still parse and pick results correctly after the change.
