### PR TITLE
Fix IMDb indexer fabricating a fake air date for unannounced episodes

### DIFF
--- a/medusa/indexers/imdb/api.py
+++ b/medusa/indexers/imdb/api.py
@@ -343,7 +343,11 @@ class Imdb(BaseIndexer):
                         if k == 'id':
                             v = ImdbIdentifier(v).series_id
                         if k == 'firstaired':
-                            v = '{year}-01-01'.format(year=v)
+                            # `year` is only a rough estimate IMDb provides for
+                            # unaired episodes, not a confirmed air date. Skip it
+                            # here; _get_episodes_detailed() sets a precise date
+                            # from `releaseDate` if/when IMDb actually has one.
+                            continue
 
                         self._set_item(series_id, season_no, episode_no, k, v)
 


### PR DESCRIPTION
## Summary
- `Imdb._get_episodes()` mapped IMDb's per-episode `year` field directly to `firstaired` via `'{year}-01-01'.format(year=v)`. IMDb only provides this rough `year` for episodes that aren't scheduled/announced yet - it's an estimate, not a confirmed date - so this fabricates a specific, wrong calendar date (e.g. `2026-01-01`) for episodes that don't actually have one.
- `_get_episodes_detailed()` is meant to overwrite this with a real date once IMDb has one (via `releaseDate.first.date`), but for still-unannounced episodes that field is empty, so the fabricated Jan 1 date is never replaced and sticks as the final value.
- Once that fabricated date is in the past, `Series.should_be_status()` treats the episode as already-aired and flips it to the show's default episode status (typically `WANTED`), pulling a season that isn't even scheduled into backlog searches.
- Observed live: Ahsoka season 2 (IMDb id `tt13622776`) only has a rough `2026` year estimate for its 8 placeholder episodes (generic titles like "Episode #2.1", no real episode data yet - real-world reporting places the season in 2027). All 8 had an identical fabricated `2026-01-01` airdate and were incorrectly sitting in `Wanted`/backlog status.

## Fix
Skip setting `firstaired` when the only source is the rough year estimate, instead of fabricating a date from it. This is safe because downstream code already handles a missing `firstaired` correctly:
- `tv/episode.py` falls back to the standard `date.fromordinal(1)` "no date" sentinel when `firstaired` is absent.
- `Series.should_be_status()` already treats that sentinel exactly like an episode airing in the future, correctly marking it `UNAIRED` rather than `WANTED`.

## Test plan
- Deployed to a running Medusa instance with Ahsoka already in this broken state (8 season 2 episodes, `Wanted`, fabricated `2026-01-01` airdate).
- Forced a show refresh from the IMDb indexer after the fix.
- Confirmed all 8 episodes now have `airdate = 1` (the standard sentinel) and `status = UNAIRED` at the DB level, and the API correctly reports `airDate: null` / `status: "Unaired"`.
- Confirmed the show's computed `prevAirDate`/`nextAirDate` correctly reflect the real last-aired episode (season 1, 2023) instead of the fabricated date, after clearing the ttl-cached property.
- Confirmed season 1 (which has real, confirmed IMDb release dates) is unaffected - dates still populate correctly via `_get_episodes_detailed()`.
