### PR TITLE
Spoof a browser User-Agent for ThePirateBay provider

### DIFF
--- a/medusa/providers/torrent/html/thepiratebay.py
+++ b/medusa/providers/torrent/html/thepiratebay.py
@@ -38,6 +38,14 @@ class ThePirateBayProvider(TorrentProvider):
         self.url = 'https://thepiratebay.org'
         self.custom_url = None
 
+        # ThePirateBay's Cloudflare WAF blocks Medusa's default User-Agent
+        # string outright (403), regardless of IP or content. Spoof a
+        # regular browser UA for this provider to get past that rule.
+        self.session.headers['User-Agent'] = (
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36'
+        )
+
         # Proper Strings
 
         # Miscellaneous Options


### PR DESCRIPTION
## Summary
- ThePirateBay's Cloudflare WAF blocks Medusa's default User-Agent string (`Medusa/{version} (...)`, built in `medusa/common.py`) with a straight `403 Forbidden`, regardless of IP or search content.
- Confirmed via direct curl testing against `thepiratebay.org`: Medusa's real UA -> 403 blocked; a real Chrome UA, or even a blank UA -> 302 (passes through). This is a deliberate anti-scraping deny rule targeting the well-known Medusa/SickBeard-family UA string - not a solvable JS/CAPTCHA challenge, so it's a different issue from the Cloudflare challenge-timeout fix in #12255.
- Set a realistic browser User-Agent on `ThePirateBayProvider`'s own session (scoped to this provider only - each provider already gets its own session instance via `GenericProvider.__init__`, so this doesn't affect any other provider or indexer).

## Test plan
- Before the fix: every search against ThePirateBay logged an explicit `403 Client Error: Forbidden for url: https://thepiratebay.org/...` at DEBUG level.
- After the fix and a live redeploy: ran a manual search that hits ThePirateBay - completes cleanly with no error logged for this provider.
- Direct curl request using the exact User-Agent string this provider now sends returns `302` instead of `403`.
