### PR TITLE
Fix single-episode PATCH silently not persisting to DB

### DIFF
--- a/medusa/server/api/v2/episodes.py
+++ b/medusa/server/api/v2/episodes.py
@@ -106,6 +106,9 @@ class EpisodeHandler(BaseRequestHandler):
 
         accepted = self._patch_episode(episode, data)
 
+        # Save patched attributes in db.
+        episode.save_to_db()
+
         return self._ok(data=accepted)
 
     def _patch_multi(self, series, request_data):


### PR DESCRIPTION
## Summary
- Filed as #12249. `EpisodeHandler.patch()`'s single-episode path (`PATCH /api/v2/series/{seriesSlug}/episodes/{episodeSlug}`) calls `_patch_episode()`, which updates the episode object in memory, but never calls `episode.save_to_db()` afterward - despite `_patch_episode()`'s own docstring claiming "Patch episode and save the changes to DB". The request returns `200 OK` with the submitted value echoed back in the response, making it look successful, but the change is never persisted and is lost.
- The sibling multi-episode route (`_patch_multi()`, used when no episode slug is in the URL path, body keyed by episode slug) already does this correctly - it calls `_patch_episode()` and then explicitly `episode.save_to_db()` right after.
- Confirmed via grepping Medusa's own Vue frontend (`themes-default/slim/src`) that every UI call site already uses the multi-episode route, so this doesn't affect the stock web UI - only direct API consumers/scripts hitting the single-episode route.

## Fix
Add the same `episode.save_to_db()` call (with the same comment) that the multi-episode route already uses, right after `_patch_episode()` in the single-episode `patch()` method.

## Test plan
- Before the fix: `PATCH /api/v2/series/{slug}/episodes/{episode}` with `{"watched": true}` returned `200` with `{"watched": true}`, but a direct SQLite query against `tv_episodes` still showed the old value.
- After the fix: same request now correctly persists - verified via direct DB query showing the new value - and reverted the test change afterward.
