### PR TITLE
Fall back to per-show updates when indexer batch update list is unavailable

### DIFF
--- a/medusa/schedulers/show_updater.py
+++ b/medusa/schedulers/show_updater.py
@@ -90,9 +90,10 @@ class ShowUpdater(object):
                     show_updates_supported = False
                 except IndexerUnavailable:
                     logger.warning('Problem running show_updater, Indexer {indexer_name} seems to be having '
-                                   'connectivity issues while trying to look for show updates on show: {show}',
+                                   'connectivity issues while trying to look for show updates on show: {show}. '
+                                   'Attempting a regular update for show instead.',
                                    indexer_name=indexer_name, show=show.name)
-                    continue
+                    show_updates_supported = False
                 except IndexerException as error:
                     logger.warning('Problem running show_updater, Indexer {indexer_name} seems to be having '
                                    'issues while trying to get updates for show {show}. Cause: {cause!r}',


### PR DESCRIPTION
## Summary
- Filed as #12252. `ShowUpdater.run()` calls `get_last_updated_series()` once per indexer per run, to get a list of recently-changed shows and avoid a full per-show refresh when not needed.
- On `IndexerShowUpdatesNotSupported`, this is handled correctly: `show_updates_supported` is set to `False` and every show under that indexer falls through to a regular per-show update.
- On `IndexerUnavailable`, however, the code only logs a warning and `continue`s to the next show - dropping that show from the update cycle for the *entire run*. Since `indexer_updated_shows` never gets populated for that indexer when this exception fires, every subsequent show under the same indexer hits the identical `if show.indexer not in indexer_updated_shows` check, re-attempts the same call, and re-fails identically - so one transient failure of the batch endpoint silently skips *every* show on that indexer for the whole run, with no fallback and no retry until the next scheduled run.
- Observed live on a production instance: all 18 TVDB-indexed shows hit this exact warning on every daily run for 5 consecutive days straight, while shows on other indexers updated fine on the same days (ruling out a general scheduler/network problem). Manually forcing a regular per-show update (bypassing the batch "updated series" list entirely, via the legacy `/home/updateShow` route) succeeded instantly for all 18 - proving the indexer was reachable the whole time and the per-show fallback path already works reliably; it just was never reached for this specific exception. 3 of the 18 shows had a genuinely wrong cached `status` as a result of being stuck stale for 5 days.

## Fix
Make `IndexerUnavailable` set `show_updates_supported = False` and fall through to the same per-show update path `IndexerShowUpdatesNotSupported` already uses, instead of unconditionally skipping the show for the whole run.

## Test plan
- Verified the app starts and runs cleanly with this change (no syntax/import errors, confirmed via a full service restart + API health check).
- Couldn't safely force a live `IndexerUnavailable` against a real indexer for this test without risking an actual outage-simulation on a production instance, but the fallback branch this now takes is the exact same one `IndexerShowUpdatesNotSupported` already uses and which was already proven reliable during the manual recovery described above - this change makes `IndexerUnavailable` take that same, already-working path instead of dead-ending.
