### PR TITLE
Surface a real error instead of an opaque AttributeError on TMDB failures

### DIFF
--- a/ext/tmdbsimple/base.py
+++ b/ext/tmdbsimple/base.py
@@ -102,6 +102,14 @@ class TMDB(object):
                 headers=self.headers, timeout=self.timeout
             )
 
+        if response is None:
+            # The configured session swallowed the underlying exception and
+            # returned None instead of raising or returning a Response - surface
+            # a real, catchable error instead of an opaque AttributeError below.
+            raise requests.exceptions.RequestException(
+                'No response received for {method} {url}'.format(method=method, url=url)
+            )
+
         response.raise_for_status()
         response.encoding = 'utf-8'
         return response.json()


### PR DESCRIPTION
## Summary
- Filed as #12253. `Tmdb.__init__` (`medusa/indexers/tmdb/api.py`) injects Medusa's own `IndexerSession` into the vendored `tmdbsimple` library. `IndexerSession` subclasses `MedusaSafeSession`, whose `.request()` deliberately swallows exceptions and returns `None` on failure (by design - the real cause is only logged at INFO/DEBUG, not raised).
- `tmdbsimple/base.py::_request()` (vendored at `ext/tmdbsimple/base.py`) assumes the session always returns a real `Response` or raises - it unconditionally calls `response.raise_for_status()`, so a `None` return blows up as `AttributeError: 'NoneType' object has no attribute 'raise_for_status'`.
- `Tmdb.__init__` already catches `AttributeError` and wraps it into a proper `IndexerUnavailable`, so the failure itself is handled correctly - but the `Cause` it reports is this opaque `AttributeError` text rather than anything describing the actual underlying network problem (timeout, connection reset, whatever originally tripped `MedusaSafeSession`'s catch-all).
- Observed live: all 6 TMDB-indexed shows on a production instance hit this identical opaque error during a daily update run, giving no indication of what actually went wrong until debug logging was manually enabled.

## Fix
Add a `None` check right after `tmdbsimple` gets the response back from the session, before calling `raise_for_status()` on it - raising a real `requests.exceptions.RequestException` with a clear message instead of letting `None.raise_for_status()` blow up. `Tmdb.__init__`'s existing exception handling already catches `RequestException`, so this doesn't change what gets caught, only what the resulting error actually says.

## Test plan
- Forced a genuine TMDB connection failure by temporarily routing `api.themoviedb.org` to loopback via `/etc/hosts` (both A and AAAA), then triggered a real show update.
- Before the fix (verified in an earlier diagnosis on the same instance): `Cause: 'NoneType' object has no attribute 'raise_for_status'`.
- After the fix: `Cause: No response received for GET https://api.themoviedb.org/3/configuration` - a real, actionable message.
- Removed the `/etc/hosts` entries and confirmed a normal TMDB show update succeeds cleanly again with no regressions to the success path.
