### PR TITLE
fix: fall back to guessit title when alias fails to match a known series

### DIFF
--- a/medusa/name_parser/parser.py
+++ b/medusa/name_parser/parser.py
@@ -346,6 +346,12 @@ class NameParser(object):
         result = self.to_parse_result(name, guess)
         search_series = helpers.get_show(result.series_name, self.try_indexers) if not self.naming_pattern else None
 
+        # guessit prefers the alias (e.g. "Lucky 2026") over the bare title ("Lucky") for
+        # single-word titles it treats as ambiguous. The alias won't match a known series
+        # until a matching scene exception exists, so fall back to the bare title.
+        if not search_series and not self.naming_pattern and guess.get('alias') and guess.get('title') != guess.get('alias'):
+            search_series = helpers.get_show(guess.get('title'), self.try_indexers)
+
         # confirm passed in show object indexer id matches result show object indexer id
         series_obj = None if search_series and self.series and search_series.indexerid != self.series.indexerid else search_series
         result.series = series_obj or self.series


### PR DESCRIPTION
## Summary
- When adding a new show whose title is a single, common word (e.g. `Lucky`), guessit sometimes classifies the year as an `alias` rather than folding it into `title` (parsed as `title: Lucky, alias: Lucky 2026`).
- `NameParser._parse_string` builds the lookup key as `guess.get('alias') or guess.get('title')`, so it looks up `helpers.get_show()` using `"Lucky 2026"` only. The internal per-show name cache built for a search only contains the show's actual title (`lucky`) plus any scene exceptions — a brand-new show has none — so the lookup never matches and `assert_supported()` raises `InvalidShowException`.
- The practical effect: every real release for the show fails to parse with `Unable to match ... to a series in your database`, even when releases are correctly named, well-seeded, and available. Both the automatic backlog search that runs when a show is added, and a manual search, silently report zero results with no indication that matches were actually found and discarded.

## Fix
In `NameParser._parse_string`, if the alias-based lookup fails to match a known series, retry the lookup using `guess.get('title')` before giving up. This only engages when the alias lookup already found nothing, so it can't override a previously-successful alias match.

## Test plan
- [x] Reproduced on a live instance: added a show named "Lucky" (TVMaze id 81228), confirmed via debug logs that all 35 results from an otherwise-working provider failed with `Unable to match Lucky.2026.S01E01...` while guessit correctly parsed `title: Lucky, alias: Lucky 2026`.
- [x] Applied the fix, re-ran a manual search: all 35 releases now log `Matched release ... to a series in your database: Lucky using guessit title: Lucky 2026`.
- [x] Re-ran the backlog search that fires automatically on show-add: all 5 aired episodes were correctly snatched and sent to the download client.
