### PR TITLE
fix: reject non-video single-file postprocess resources

### DIFF
--- a/medusa/process_tv.py
+++ b/medusa/process_tv.py
@@ -397,6 +397,19 @@ class ProcessResult(object):
         processed_items = False
         for path in self.paths:
 
+            if os.path.isfile(path) and not (helpers.is_media_file(path) or helpers.is_rar_file(path)):
+                # A single-file resource (e.g. handed to us directly by a torrent client's
+                # AutoRun hook) that isn't a recognized video/rar file. Accepting this as a
+                # completed episode would let a malicious non-video file (padded to look like
+                # a real download) get treated as if the episode were successfully grabbed.
+                self.log_and_output(
+                    'Resource is not a recognized video file, refusing to accept it as a '
+                    'completed download: {path}', level=logging.WARNING, **{'path': path})
+                self.missed_files.append('{0}: Not a valid video file'.format(path))
+                self.succeeded = False
+                self.result = False
+                continue
+
             if not self.should_process(path):
                 continue
 


### PR DESCRIPTION
## Summary
- Torrent-client hooks (e.g. qBittorrent AutoRun) can hand Medusa a single file directly for postprocessing. When that file isn't a recognized video/rar file, `ProcessResult.should_process()` silently rejects it via an `os.walk()` call that degenerates to a no-op on a file path — but the run still logs `Post-processing completed.` because `self.succeeded` is never set to `False`.
- In practice this let a malware dropper padded to look like a real episode (a `.exe` disguised as a TV episode) sit in the library folder indefinitely while Medusa reported success, never triggering the existing failed-download pipeline (no blacklist, no episode revert to Wanted, no retry with a different release).
- This adds an explicit check: a single-file resource that fails `helpers.is_media_file()`/`helpers.is_rar_file()` is now rejected up front, with `self.succeeded`/`self.result` set to `False` so the existing failed-download handling (blacklist + status revert + cleanup) runs correctly.

## Test plan
- [x] Verified live: POSTing a dummy `.exe` named after an untracked show now logs `Resource is not a recognized video file, refusing to accept it as a completed download` and `Problem(s) during processing` instead of a false `Post-processing completed.`
- [x] Verified live end-to-end: POSTing a dummy `.exe` named after a real tracked show/episode triggers `Failed download detected` -> blacklists the release in `failed.db` -> reverts the episode to `Wanted` -> kicks off a retry search automatically.
- [x] `py_compile` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
