### PR TITLE
Fix: clear manually_searched flag when reverting a failed download

### DIFF
--- a/medusa/failed_history.py
+++ b/medusa/failed_history.py
@@ -165,6 +165,10 @@ def revert_episode(ep_obj):
                            u'to revert. Setting it back to WANTED',
                            logger.DEBUG)
                 ep_obj.status = WANTED
+            # The snatch that failed may have been a manual/forced search. Clear the flag so
+            # automatic backlog/daily search (Quality.should_search) doesn't skip this episode
+            # forever after a bad manual pick turns out to be a failed download.
+            ep_obj.manually_searched = False
             ep_obj.save_to_db()
 
     except EpisodeNotFoundException as error:


### PR DESCRIPTION
## Summary

`failed_history.revert_episode()` resets an episode's status back to `WANTED` after a failed download is detected, but never clears `manually_searched`.

`Quality.should_search()` unconditionally skips any episode with `manually_searched=True`, checked before status is even considered:

```python
if manually_searched:
    return False, 'Episode was manually searched. Skipping episode'
```

So once an episode has ever been manually/forced-searched, a later automatic failed-download revert correctly puts it back to `Wanted`, but leaves it permanently invisible to all future automatic backlog/daily search — silently requiring a human to manually search it again, forever, even though nothing about the episode's state suggests that.

This is a real-world trap: a user manually snatches a release that turns out to be bad (fake/corrupt/wrong file). Medusa's own failed-download handling correctly detects the failure and reverts the episode to `Wanted" — but because the original snatch was manual, the episode silently stops being covered by automatic search from that point on. Confirmed this live: a backlog run correctly skipped this exact episode entirely (no queue item created) while snatching other shows normally in the same run, even though the episode was `Wanted" with an existing well-seeded release available.

`mass_update_episode_status()` (`tv/episode.py`) already clears this flag when transitioning an episode to `WANTED" for exactly this reason:

```python
if self.manually_searched:
    log.debug("Resetting 'manually searched' flag of {series} {episode}"
              ' as episode was changed to WANTED', ...)
    self.manually_searched = False
```

`revert_episode()` was simply missing the same treatment.

## Fix

Clear `manually_searched` in `revert_episode()` alongside the status reset, matching the existing precedent in `mass_update_episode_status()`.

## Test plan

- [x] Verified live: an episode with `manually_searched=1` and a failed download correctly had the flag cleared to `0` after `revert_episode()` ran via the postprocess failed-download path.
- [x] Confirmed automatic search picks the episode back up afterward instead of silently skipping it.