### PR TITLE
Fix: episode_updater flips network-less shows to WANTED before their airdate

### DIFF
--- a/medusa/schedulers/episode_updater.py
+++ b/medusa/schedulers/episode_updater.py
@@ -110,6 +110,12 @@ class EpisodeUpdater(object):
                 # filter out any episodes that haven't finished airing yet
                 if end_time + timedelta(hours=series_obj.airdate_offset) > cur_time:
                     continue
+            else:
+                # Without airs/network info (e.g. IMDb-indexed shows) we can't compute a precise
+                # air time, so fall back to a plain calendar-date check instead of relying solely
+                # on the (intentionally forward-looking) cur_date window used for the DB query.
+                if db_episode['airdate'] > date.today().toordinal():
+                    continue
 
             with cur_ep.lock:
                 cur_ep.status = series_obj.default_ep_status if cur_ep.season else common.SKIPPED


### PR DESCRIPTION
## Summary

Fixes #12270 — shows with no `network` value set (e.g. IMDb-indexed shows)
could have episodes flipped to `WANTED` up to two days before their actual
airdate, because `EpisodeUpdater`'s per-episode "hasn't finished airing yet"
safety check is entirely skipped when `series_obj.airs`/`series_obj.network`
aren't both set — there was no fallback validation at all in that branch.

## Fix

Add a fallback in `medusa/schedulers/episode_updater.py`: when precise
air-time data isn't available, only allow the WANTED flip once the episode's
plain calendar airdate has actually arrived, instead of relying solely on the
scheduler's intentionally forward-looking (1-2 day) DB lookahead window.

## Test plan

- [x] Reproduced live: "Stuart Fails to Save the Universe" S01E04 (airdate
      two days out) was set to `WANTED` by `EpisodeUpdater`, confirmed via
      logs and DB state.
- [x] Applied the fix, restarted the service, confirmed clean startup with no
      errors.
- [x] Confirmed the affected episode's status stays `UNAIRED` after the
      restart with the fix in place.
