### PR TITLE
Fix JPEG image size parsing and dimension unpacking

### DIFF
--- a/medusa/helpers/__init__.py
+++ b/medusa/helpers/__init__.py
@@ -1523,7 +1523,7 @@ def get_image_size(image_path):
                 if len(size_bytes) != 2:
                     return None
                 size = struct.unpack('>H', size_bytes)[0] - 2
-            f.seek(1, 1)  # skip precision byte
+            f.seek(3, 1)  # skip 2-byte length and 1-byte precision
             height, width = struct.unpack('>HH', f.read(4))
             return width, height
         else:

--- a/medusa/image_cache.py
+++ b/medusa/image_cache.py
@@ -141,7 +141,7 @@ def which_type(path):
         log.debug('Skipping image. Unable to get metadata from {0}', path)
         return
 
-    height, width = image_dimension
+    width, height = image_dimension
     if not width or not height:
         log.debug('Skipping image. zero width or height {0}', path)
         return


### PR DESCRIPTION
## Description

Fix two bugs in the image type detection pipeline that cause all local JPEG files to fail aspect ratio checks, making Medusa fall back to the default logo for banners/posters/fanart.

### Bug 1: `get_image_size()` JPEG SOF parser

After finding the SOF marker, `f.seek(1, 1)` skips only 1 byte (precision), but the 2-byte segment length field sits between the marker type byte and the precision byte. This causes the length to be misinterpreted as part of the image dimensions.

For a typical 3-component baseline JPEG, the SOF length is 17 (0x0011), which gets combined with the precision byte (0x08) to produce a bogus dimension of 4360 instead of the actual height/width.

**Fix:** `f.seek(1, 1)` -> `f.seek(3, 1)` to correctly skip the 2-byte length + 1-byte precision.

### Bug 2: `which_type()` dimension unpacking

`get_image_size()` returns `(width, height)` (as documented in its docstring and implemented for PNG/GIF), but `which_type()` unpacks it as `height, width`, swapping the values.

**Fix:** `height, width = image_dimension` -> `width, height = image_dimension`

## Reproducing

1. Add a show with a local `banner.jpg` in the show directory
2. Trigger a show refresh
3. Observe: `WARNING Unable to determine image type for .../banner.jpg` and `WARNING Aspect ratio (31.142857142857142) does not match any known types.`

The bogus aspect ratio 31.14 = 4360 / 140 where 4360 is (0x11 << 8) | 0x08 (SOF length + precision).

## Fix Verification

Tested with a synthetic 758x140 JPEG:
- **Before fix:** `get_image_size()` returns (140, 4360) -> aspect ratio 0.03
- **After fix:** `get_image_size()` returns (758, 140) -> aspect ratio 5.41 (correct for banner)

## Related Issue

Fixes #12111
