### PR TITLE
Fix timezone boundary in relative provider dates

### DIFF
--- a/medusa/providers/generic_provider.py
+++ b/medusa/providers/generic_provider.py
@@ -568,15 +568,21 @@ class GenericProvider(object):
                 dt = datetime.fromtimestamp(int(pubdate), tz=tz.gettz('UTC'))
             else:
                 day_offset = 0
+                date_default = None
                 if 'yesterday at' in pubdate.lower() or 'today at' in pubdate.lower():
                     # Extract a time
                     time = re.search(r'(?P<time>[0-9:]+)', pubdate)
                     if time:
                         if 'yesterday' in pubdate:
                             day_offset = 1
+                        date_default = datetime.now(tz=tz.gettz('UTC')).replace(
+                            hour=0, minute=0, second=0, microsecond=0
+                        )
                         pubdate = time.group('time').strip()
 
-                dt = parser.parse(pubdate, dayfirst=df, yearfirst=yf, fuzzy=True) - timedelta(days=day_offset)
+                dt = parser.parse(pubdate, dayfirst=df, yearfirst=yf, fuzzy=True, default=date_default) - timedelta(
+                    days=day_offset
+                )
 
             # Always make UTC aware if naive
             if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:

--- a/tests/providers/test_generic_provider.py
+++ b/tests/providers/test_generic_provider.py
@@ -7,6 +7,7 @@ from datetime import date, datetime, timedelta
 
 from dateutil import tz
 
+from medusa.providers import generic_provider
 from medusa.providers.generic_provider import GenericProvider
 
 import pytest
@@ -169,6 +170,33 @@ def test_parse_pubdate(p):
             f"Expected ~{expected}s, got {actual}s (diff {expected - actual}s)"
     else:
         assert expected == actual
+
+
+@pytest.mark.parametrize(('pubdate', 'expected'), [
+    ('today at 19:42:35', datetime(2026, 8, 27, 19, 42, 35, tzinfo=tz.gettz('UTC'))),
+    ('yesterday at 19:42:35', datetime(2026, 8, 26, 19, 42, 35, tzinfo=tz.gettz('UTC'))),
+], ids=['today', 'yesterday'])
+def test_parse_pubdate_relative_day_uses_utc_date(monkeypatch, pubdate, expected):
+    """Deterministically verify UTC default handling for today/yesterday phrases."""
+    local_now = datetime(2026, 8, 28, 5, 53, 0)
+    utc_now = datetime(2026, 8, 27, 19, 53, 0, tzinfo=tz.gettz('UTC'))
+    original_parse = generic_provider.parser.parse
+
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            if tz is None:
+                return local_now
+            return utc_now.astimezone(tz)
+
+    def fake_parse(*args, **kwargs):
+        kwargs.setdefault('default', datetime(2026, 8, 28))
+        return original_parse(*args, **kwargs)
+
+    monkeypatch.setattr(generic_provider, 'datetime', FixedDatetime)
+    monkeypatch.setattr(generic_provider.parser, 'parse', fake_parse)
+
+    assert expected == sut.parse_pubdate(pubdate)
 
 
 @pytest.mark.parametrize('p', [


### PR DESCRIPTION
## Summary

- Parse `today at` and `yesterday at` provider timestamps using the UTC calendar date.
- Prevent one-day shifts when the host's local date differs from UTC.
- Add deterministic clock-boundary coverage.

## Testing

- Provider and full backend suites pass without a `TZ=UTC` override.
- Fork CI: 28/28 checks passed, including Codecov.

Run the focused regression test:

```bash
python -m pytest tests/providers/test_generic_provider.py::test_parse_pubdate_relative_day_uses_utc_date -vv
```
