### PR TITLE
Fix Episode.to_json related field for WebSocket JSON serialization

### DIFF
--- a/medusa/tv/episode.py
+++ b/medusa/tv/episode.py
@@ -1141,7 +1141,8 @@ class Episode(TV):
             data['statistics']['subtitleSearch']['last'] = self.subtitles_lastsearch
             data['statistics']['subtitleSearch']['count'] = self.subtitles_searchcount
             data['wantedQualities'] = self.wanted_quality
-            data['related'] = self.related_episodes
+            # Serialize related episodes; raw Episode instances break JSON/WebSocket dumps.
+            data['related'] = [ep.to_json(detailed=False) for ep in self.related_episodes]
 
             if self.file_size:
                 # Used by the test-rename vue component.


### PR DESCRIPTION
## Summary
- Fix `Episode.to_json()` so `related` is a list of JSON dicts instead of live `Episode` objects
- Stops WebSocket `QueueItemUpdate` failures/warnings for multi-episode backlog releases
- Fixes #12303

## Scope
- `medusa/tv/episode.py` only

## Validation
- Local smoke: `json.dumps` of episode payload with related episodes succeeds
- Bugbot: no findings
- Copilot on fork PR: approval recommended, no change requests
- Fork CI ([#39](https://github.com/Mika3578/Medusa/pull/39)): Check app version, API tests, Backend tests, Frontend tests all pass; prior Windows Node 22 yarn timeout (`ESOCKETTIMEDOUT`) succeeded on re-run with no product changes

## Risk
Low — changes serialization of `related` from accidental `str(Episode)` fallback to proper episode JSON (`detailed=False`), matching UI expectations (`test-rename.vue`).

## Rollback
Revert the single commit.